### PR TITLE
Enable ctest for C++ test executable(s)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ option(BUILD_TESTS "Enable building tests" OFF)
 # Option to enable the development tests target, test_dev. This is independant from build_tests
 option(BUILD_TESTS_DEV "Enable building test_dev" OFF)
 
+# Option to enable GTEST_DISCOVER if tests or tests_dev are enabled. Defaults to off due to runtime increase
+cmake_dependent_option(USE_GTEST_DISCOVER "Enable GTEST_DISCOVER for more detailed ctest output without -VV. This dramitically increases test suite runtime to CUDA context initialisation." OFF "BUILD_TESTS OR BUILD_TESTS_DEV" OFF)
+
 # Option to enable/disable NVTX markers for improved profiling
 option(USE_NVTX "Build with NVTX markers enabled" OFF)
 
@@ -189,6 +192,9 @@ if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_DIFFUSION)
 endif()
 # Add the tests directory (if required)
 if(BUILD_TESTS OR BUILD_TESTS_DEV)
+    # Enable Ctest
+    enable_testing()
+    # Add the tests subdirectory
     add_subdirectory(tests)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ cmake --build . --target all
 | `BUILD_SWIG_PYTHON_VENV` | `ON`/`OFF`        | Use a python `venv` when building the python Swig target. Default `ON`. Python package `venv` required     |
 | `BUILD_TESTS`            | `ON`/`OFF`        | Build the C++/CUDA test suite. Default `OFF`.                                                              |
 | `BUILD_TESTS_DEV`        | `ON`/`OFF`        | Build the reduced-scope development test suite. Default `OFF`                                              |
+| `USE_GTEST_DISCOVER`     | `ON`/`OFF`        | Run individual CUDA C++ tests as independent `ctest` tests. This dramatically increases test suite runtime. Default `OFF`. |
 | `VISUALISATION`          | `ON`/`OFF`        | Enable Visualisation. Default `OFF`.                                                                       |
 | `VISUALISATION_ROOT`     | `path/to/vis`     | Provide a path to a local copy of the visualisation repository.                                            |
 | `USE_NVTX`               | `ON`/`OFF`        | Enable NVTX markers for improved profiling. Default `OFF`                                                  |
@@ -244,7 +245,26 @@ Several environmental variables are used or required by FLAME GPU 2.
 
 ## Running the Test Suite(s)
 
-To run the CUDA/C++ test suite:
+### CUDA C++ Test Suites
+
+The test suite for the CUDA/C++ library can be executed using CTest, or by manually running the test executable(s).
+
+ can be used to orchestrate running multiple test suites for different aspects of FLAME GPU 2.
+
+The test suite can be executed using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html) by running `ctest`, or `ctest -VV` for verbose output of sub-tests, from the the build directory.
+
+More verbose CTest output for the GoogleTest based CUDA C++ test suite(s) can be enabled by configuring CMake with `USE_GTEST_DISCOVER` set to `ON`.
+This however will dramatically increase test suite execution time.
+
+1. Configure CMake to build the desired tests suites as desired, using `BUILD_TESTS=ON`, `BUILD_TESTS_DEV=ON` and optionally `USE_GTEST_DISCOVER=ON`.
+2. Build the `tests`, `tests_dev` targets as required
+3. Run the test suites via ctest, using `-vv` for more-verbose output. Multiple tests can be ran concurrently using `-j <jobs>`. Use `-R <regex>` to only run matching tests.
+
+    ```bash
+    ctest -vv -j 8
+    ```
+
+To run the CUDA/C++ test suite(s) manually, which allows use of `--gtest_filter`:
 
 1. Configure CMake with `BUILD_TESTS=ON`
 2. Build the `tests` target
@@ -253,6 +273,8 @@ To run the CUDA/C++ test suite:
     ```bash
     ./bin/Release/tests
     ```
+
+### Python Testing via pytest
 
 To run the python test suite:
 
@@ -263,7 +285,7 @@ To run the python test suite:
     If using Bash (linux, bash for windows)
 
     ```bash
-    source lib/Release/lib/Release/python/venv/bin/activate
+    source lib/Release/python/venv/bin/activate
     ```
 
     If using `cmd`:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,7 +103,13 @@ get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
 # Include googletest as a dependency.
 include(${FLAMEGPU_ROOT}/cmake/dependencies/googletest.cmake)
 
+# If CTest's GoogleTest integreation is required, include GoogleTest.
+if((BUILD_TESTS OR BUILD_TESTS_DEV) AND USE_GTEST_DISCOVER)
+    include(GoogleTest)
+endif()
+
 if(BUILD_TESTS)
+    enable_testing()
     # Name the project and set languages
     project(tests CUDA CXX)
     # Include common rules.
@@ -134,10 +140,28 @@ if(BUILD_TESTS)
     # Set the default (visual studio) debugger configure_file
     set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     VS_DEBUGGER_COMMAND_ARGUMENTS "$<$<CONFIG:Debug>:--gtest_catch_exceptions=0> --gtest_filter=*")
+
+    # Add the tests target as to ctest, optionally using the gtest_discover integration.
+    if(USE_GTEST_DISCOVER)
+        # If GTEST_DISCOVER is enabled, add the unit test executable using it. This results in very long test exeuction times due to CUDA context initialisation per test
+        gtest_discover_tests(
+            "${PROJECT_NAME}"
+            WORKING_DIRECTORY
+            ${PROJECT_DIR}
+        )
+    else()
+        # Otherwise add the whole test suite as a single test. Use ctest -VV to view per-test results in this case.
+        add_test(
+            NAME ${PROJECT_NAME} 
+            COMMAND "${PROJECT_NAME}"
+            WORKING_DIRECTORY ${PROJECT_DIR}
+        )
+    endif()
 endif()
 
 # If the tests_dev target is requirest, create it.
 if(BUILD_TESTS_DEV)
+    enable_testing()
     # DEVELOPMENT TESTING THING (Compact repeated version of above)
     project(tests_dev CUDA CXX)
     # Include common rules.
@@ -166,4 +190,21 @@ if(BUILD_TESTS_DEV)
     # Set the default (visual studio) debugger configure_file
     set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     VS_DEBUGGER_COMMAND_ARGUMENTS "$<$<CONFIG:Debug>:--gtest_catch_exceptions=0> --gtest_filter=*")
+    
+    # Add the tests target as to ctest, optionally using the gtest_discover integration.
+    if(USE_GTEST_DISCOVER)
+        # If GTEST_DISCOVER is enabled, add the unit test executable using it. This results in very long test exeuction times due to CUDA context initialisation per test
+        gtest_discover_tests(
+            "${PROJECT_NAME}"
+            WORKING_DIRECTORY
+            ${PROJECT_DIR}
+        )
+    else()
+        # Otherwise add the whole test suite as a single test. Use ctest -VV to view per-test results in this case.
+        add_test(
+            NAME ${PROJECT_NAME} 
+            COMMAND "${PROJECT_NAME}"
+            WORKING_DIRECTORY ${PROJECT_DIR}
+        )
+    endif()
 endif()


### PR DESCRIPTION
+ [x] `enable_testing()`
+ [x] Tweaks readme
+ [x] `-DUSE_GTEST_DISCOVER` to switch between `add_test` and `gtest_discover`
+ [x] Adds the `tests` and `tests_dev` executables if enabled

Part of #267

## Usage


### Without `-DUSE_GTEST_DISCOVER`

```bash
mkdir build && cd build
cmake .. -DSMS=61 -DBUILD_TESTS=ON -DTEST_DEV_MODE=ON
make -j 4 tests tests_dev
```

```bash
ctest
Test project /home/ptheywood/code/flamegpu/flamegpu2_dev/build
    Start 1: tests
1/2 Test #1: tests ............................   Passed   46.61 sec
    Start 2: tests_dev
2/2 Test #2: tests_dev ........................   Passed    0.19 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  46.80 sec

```


```bash
ctest -VV

1: ---------------------------------------------------
1: --- JIT compile log for odd_only_program ---
1: ---------------------------------------------------
1: flamegpu/gpu/CUDAScanCompaction.h(77): warning: extern declaration of the entity flamegpu_internal::CUDAScanCompaction::hd_configs is treated as a static definition
1: 
1: flamegpu/runtime/utility/DeviceEnvironment.cuh(16): warning: extern declaration of the entity flamegpu_internal::c_deviceEnvErrorPattern is treated as a static definition
1: 
1: 
1: 
1: ---------------------------------------------------
1: [       OK ] DeviceRTCAPITest.AgentFunction_cond_rtc (3794 ms)
1: [----------] 12 tests from DeviceRTCAPITest (46137 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 494 tests from 37 test suites ran. (46763 ms total)
1: [  PASSED  ] 494 tests.
1/2 Test #1: tests ............................   Passed   47.07 sec
test 2
    Start 2: tests_dev

2: Test command: /home/ptheywood/code/flamegpu/flamegpu2_dev/build/bin/linux-x64/Release/tests_dev
2: Test timeout computed to be: 10000000
2: Running main() from /home/ptheywood/code/flamegpu/flamegpu2_dev/tests/helpers/main.cu
2: [==========] Running 0 tests from 0 test suites.
2: [==========] 0 tests from 0 test suites ran. (0 ms total)
2: [  PASSED  ] 0 tests.
2/2 Test #2: tests_dev ........................   Passed    0.18 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  47.26 sec

...


```

### With `-DUSE_GTEST_DISCOVER=ON`

Each test takes 0.25 seconds minimum, due to context cration. * 500 tests = ~ 100 seconds of context creation on its own.

```bash
mkdir build && cd build
cmake .. -DSMS=61 -DBUILD_TESTS=ON -DTEST_DEV_MODE=ON -DUSE_GTEST_DISCOVER=ON
make -j 4 tests tests_dev
```

```bash
ctest

%] Linking CXX executable ../bin/linux-x64/Release/tests_dev
[100%] Built target tests_dev
[17:45:25 rainby] ~/code/flamegpu/flamegpu2_dev/build ctest ▲ → 
ctest
Test project /home/ptheywood/code/flamegpu/flamegpu2_dev/build
        Start   1: TestCUDAAgentModel.ApplyConfigDerivedContextCreation
  1/494 Test   #1: TestCUDAAgentModel.ApplyConfigDerivedContextCreation ...........................................   Passed    0.26 sec
        Start   2: TestCUDAAgentModel.AllDeviceIdValues
  2/494 Test   #2: TestCUDAAgentModel.AllDeviceIdValues ...........................................................   Passed    0.28 sec
        Start   3: TestCUDAAgentModel.ArgParse_device_long
  3/494 Test   #3: TestCUDAAgentModel.ArgParse_device_long ........................................................   Passed    0.25 sec
  
...

493/494 Test #493: DeviceRTCAPITest.AgentFunction_cond_non_rtc ....................................................   Passed    4.46 sec
        Start 494: DeviceRTCAPITest.AgentFunction_cond_rtc
494/494 Test #494: DeviceRTCAPITest.AgentFunction_cond_rtc ........................................................   Passed    8.16 sec

100% tests passed, 0 tests failed out of 494

Total Test time (real) = 188.72 sec

```


## Filters:

### Without -DUSE_GTEST_DISCOVER


Can't currently (easily) pass arguments thought. 


```bash

./bin/linux-x64/Release/tests --gtest_filter="TestCUDAAgentModel.All*"


```

Possible workaround

https://stackoverflow.com/questions/28812533/how-to-pass-command-line-arguments-in-ctest-at-runtime

Can just run `tests` itself, ignoring `test_dev`

```bash
ctest -VV -R "tests"
```

### With -DUSE_GTEST_DISCOVER

```bash
ctest -R "TestCUDAAgentModel.All"
Test project /home/ptheywood/code/flamegpu/flamegpu2_dev/build
    Start 2: TestCUDAAgentModel.AllDeviceIdValues
1/1 Test #2: TestCUDAAgentModel.AllDeviceIdValues ...   Passed    0.17 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.18 sec

```

--- 

This no longer referes to the python test suite, which is deffered to future work (venv issues). 
