### PR TITLE
Example: Sugarscape

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ option(BUILD_EXAMPLE_CIRCLES_SPATIAL3D "Enable building examples/circles_spatial
 option(BUILD_EXAMPLE_GAME_OF_LIFE "Enable building examples/game_of_life" OFF)
 option(BUILD_EXAMPLE_HOST_FUNCTIONS "Enable building examples/host_functions" OFF)
 option(BUILD_EXAMPLE_ENSEMBLE "Enable building examples/ensemble" OFF)
-                       
+option(BUILD_EXAMPLE_SUGARSCAPE "Enable building examples/sugarscape" OFF)
+
 option(BUILD_SWIG_PYTHON "Enable python bindings via SWIG" OFF)
 cmake_dependent_option(BUILD_SWIG_PYTHON_VIRTUALENV "Enable building of SWIG Python Virtual Env for Python Testing" OFF
                        "BUILD_SWIG_PYTHON" OFF)
@@ -108,47 +109,39 @@ if(BUILD_FLAMEGPU2)
 endif()
 
 # Add each example
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_BRUTEFORCE)
     add_subdirectory(examples/boids_bruteforce)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_BRUTEFORCE_DEPENDENCY_GRAPH)
     add_subdirectory(examples/boids_bruteforce_dependency_graph)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_SPATIAL3D)
     add_subdirectory(examples/boids_spatial3D)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_RTC_BRUTEFORCE)
     add_subdirectory(examples/boids_rtc_bruteforce)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_BOIDS_RTC_SPATIAL3D)
     add_subdirectory(examples/boids_rtc_spatial3D)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_CIRCLES_BRUTEFORCE)
     add_subdirectory(examples/circles_bruteforce)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_CIRCLES_SPATIAL3D)
     add_subdirectory(examples/circles_spatial3D)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_GAME_OF_LIFE)
     add_subdirectory(examples/game_of_life)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_HOST_FUNCTIONS)
     add_subdirectory(examples/host_functions)
 endif()
-
 if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_ENSEMBLE)
     add_subdirectory(examples/ensemble)
 endif()
-
+if(BUILD_ALL_EXAMPLES OR BUILD_EXAMPLE_SUGARSCAPE)
+    add_subdirectory(examples/sugarscape)
+endif()
 # Add the tests directory (if required)
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/examples/sugarscape/CMakeLists.txt
+++ b/examples/sugarscape/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Set the minimum cmake version to that which supports cuda natively.
+# 3.10 required for cuda -std=c++14, however 3.12 fixes some device linker errors
+cmake_minimum_required(VERSION VERSION 3.12 FATAL_ERROR)
+
+# Name the project and set languages
+project(sugarscape CUDA CXX)
+
+# Set the location of the ROOT flame gpu project relative to this CMakeList.txt
+get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../.. REALPATH)
+
+# Include common rules.
+include(${FLAMEGPU_ROOT}/cmake/common.cmake)
+
+# Define output location of binary files
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    # If top level project
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+else()
+    # If called via add_subdirectory()
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../bin/${CMAKE_SYSTEM_NAME_LOWER}-x64/${CMAKE_BUILD_TYPE}/)
+endif()
+
+# Prepare list of source files
+# Can't do this automatically, as CMake wouldn't know when to regen (as CMakeLists.txt would be unchanged)
+SET(ALL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu
+)
+
+# Option to enable/disable building the static library
+option(VISUALISATION "Enable visualisation support" OFF)
+
+# Add the executable and set required flags for the target
+add_flamegpu_executable("${PROJECT_NAME}" "${ALL_SRC}" "${FLAMEGPU_ROOT}" "${PROJECT_BINARY_DIR}" TRUE)
+
+# Also set as startup project (if top level project)
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"  PROPERTY VS_STARTUP_PROJECT "${PROJECT_NAME}")
+
+# Set the default (visual studio) debug working directory and args
+set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                                                   VS_DEBUGGER_COMMAND_ARGUMENTS "-s 10")

--- a/examples/sugarscape/src/main.cu
+++ b/examples/sugarscape/src/main.cu
@@ -1,0 +1,498 @@
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+
+
+#include "flamegpu/flame_api.h"
+#include "flamegpu/runtime/flamegpu_api.h"
+#include "flamegpu/io/factory.h"
+#include "flamegpu/util/nvtx.h"
+
+// Grid Size (the product of these is the agent count)
+#define GRID_WIDTH 256
+#define GRID_HEIGHT 256
+
+// Agent state variables
+#define AGENT_STATUS_UNOCCUPIED 0
+#define AGENT_STATUS_OCCUPIED 1
+#define AGENT_STATUS_MOVEMENT_REQUESTED 2
+#define AGENT_STATUS_MOVEMENT_UNRESOLVED 3
+
+// Growback variables
+#define SUGAR_GROWBACK_RATE 1
+#define SUGAR_MAX_CAPACITY 7
+
+// Visualisation mode (0=occupied/move status, 1=occupied/sugar/level)
+#define VIS_MODE 1
+
+
+FLAMEGPU_AGENT_FUNCTION(metabolise_and_growback, MsgNone, MsgNone) {
+    int sugar_level = FLAMEGPU->getVariable<int>("sugar_level");
+    int env_sugar_level = FLAMEGPU->getVariable<int>("env_sugar_level");
+    int env_max_sugar_level = FLAMEGPU->getVariable<int>("env_max_sugar_level");
+    int status = FLAMEGPU->getVariable<int>("status");
+    // metabolise if occupied
+    if (status == AGENT_STATUS_OCCUPIED || status == AGENT_STATUS_MOVEMENT_UNRESOLVED) {
+        // store any sugar present in the cell
+        if (env_sugar_level > 0) {
+            sugar_level += env_sugar_level;
+            // Occupied cells are marked as -1 sugar.
+            env_sugar_level = -1;
+        }
+
+        // metabolise
+        sugar_level -= FLAMEGPU->getVariable<int>("metabolism");
+
+        // check if agent dies
+        if (sugar_level == 0) {
+            status = AGENT_STATUS_UNOCCUPIED;
+            FLAMEGPU->setVariable<int>("agent_id", -1);
+            sugar_level = 0;
+            FLAMEGPU->setVariable<int>("metabolism", 0);
+        }
+    }
+
+    // growback if unoccupied
+    if (status == AGENT_STATUS_UNOCCUPIED) {
+        env_sugar_level += SUGAR_GROWBACK_RATE;
+        if (env_sugar_level > env_max_sugar_level) {
+            env_sugar_level = env_max_sugar_level;
+        }
+    }
+
+    // set all active agents to unresolved as they may now want to move
+    if (status == AGENT_STATUS_OCCUPIED) {
+        status = AGENT_STATUS_MOVEMENT_UNRESOLVED;
+    }
+    FLAMEGPU->setVariable<int>("sugar_level", sugar_level);
+    FLAMEGPU->setVariable<int>("env_sugar_level", env_sugar_level);
+    FLAMEGPU->setVariable<int>("status", status);
+
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(output_cell_status, MsgNone, MsgArray2D) {
+    unsigned int agent_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
+    unsigned int agent_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
+    FLAMEGPU->message_out.setVariable("location_id", FLAMEGPU->getVariable<int>("location_id"));
+    FLAMEGPU->message_out.setVariable("status", FLAMEGPU->getVariable<int>("status"));
+    FLAMEGPU->message_out.setVariable("env_sugar_level", FLAMEGPU->getVariable<int>("env_sugar_level"));
+    FLAMEGPU->message_out.setIndex(agent_x, agent_y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(movement_request, MsgArray2D, MsgArray2D) {
+    int best_sugar_level = -1;
+    float best_sugar_random = -1;
+    int best_location_id = -1;
+
+    // if occupied then look for empty cells {
+    // find the best location to move to (ensure we don't just pick first cell with max value)
+    int status = FLAMEGPU->getVariable<int>("status");
+
+    unsigned int agent_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
+    unsigned int agent_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
+
+    // if occupied then look for empty cells
+    if (status == AGENT_STATUS_MOVEMENT_UNRESOLVED) {
+        for (auto current_message : FLAMEGPU->message_in(agent_x, agent_y)) {
+            // if location is unoccupied then check for empty locations
+            if (current_message.getVariable<int>("status") == AGENT_STATUS_UNOCCUPIED) {
+                // if the sugar level at current location is better than currently stored then update
+                int msg_env_sugar_level = current_message.getVariable<int>("env_sugar_level");
+                float msg_priority = FLAMEGPU->random.uniform<float>();
+                if ((msg_env_sugar_level > best_sugar_level) ||
+                    (msg_env_sugar_level == best_sugar_level && msg_priority > best_sugar_random)) {
+                    best_sugar_level = msg_env_sugar_level;
+                    best_sugar_random = msg_priority;
+                    best_location_id = current_message.getVariable<int>("location_id");
+                }
+            }
+        }
+
+        // if the agent has found a better location to move to then update its state
+        // if there is a better location to move to then state indicates a movement request
+        status = best_location_id >= 0 ? AGENT_STATUS_MOVEMENT_REQUESTED : AGENT_STATUS_OCCUPIED;
+        FLAMEGPU->setVariable<int>("status", status);
+    }
+
+    // add a movement request
+    FLAMEGPU->message_out.setVariable<int>("agent_id", FLAMEGPU->getVariable<int>("agent_id"));
+    FLAMEGPU->message_out.setVariable<int>("location_id", best_location_id);
+    FLAMEGPU->message_out.setVariable<int>("sugar_level", FLAMEGPU->getVariable<int>("sugar_level"));
+    FLAMEGPU->message_out.setVariable<int>("metabolism", FLAMEGPU->getVariable<int>("metabolism"));
+    FLAMEGPU->message_out.setIndex(agent_x, agent_y);
+
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(movement_response, MsgArray2D, MsgArray2D) {
+    int best_request_id = -1;
+    float best_request_priority = -1;
+    int best_request_sugar_level = -1;
+    int best_request_metabolism = -1;
+
+    int status = FLAMEGPU->getVariable<int>("status");
+    int location_id = FLAMEGPU->getVariable<int>("location_id");
+    unsigned int agent_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
+    unsigned int agent_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
+
+    for (auto current_message : FLAMEGPU->message_in(agent_x, agent_y)) {
+        // if the location is unoccupied then check for agents requesting to move here
+        if (status == AGENT_STATUS_UNOCCUPIED) {
+            // check if request is to move to this location
+            if (current_message.getVariable<int>("location_id") == location_id) {
+                // check the priority and maintain the best ranked agent
+                float message_priority = FLAMEGPU->random.uniform<float>();
+                if (message_priority > best_request_priority) {
+                    best_request_id = current_message.getVariable<int>("agent_id");
+                    best_request_priority = message_priority;
+                }
+            }
+        }
+    }
+
+    // if the location is unoccupied and an agent wants to move here then do so and send a response
+    if ((status == AGENT_STATUS_UNOCCUPIED) && (best_request_id >= 0))    {
+        FLAMEGPU->setVariable<int>("status", AGENT_STATUS_OCCUPIED);
+        // move the agent to here and consume the cell's sugar
+        best_request_sugar_level += FLAMEGPU->getVariable<int>("env_sugar_level");
+        FLAMEGPU->setVariable<int>("agent_id", best_request_id);
+        FLAMEGPU->setVariable<int>("sugar_level", best_request_sugar_level);
+        FLAMEGPU->setVariable<int>("metabolism", best_request_metabolism);
+        FLAMEGPU->setVariable<int>("env_sugar_level", -1);
+    }
+
+    // add a movement response
+    FLAMEGPU->message_out.setVariable<int>("location_id", FLAMEGPU->getVariable<int>("location_id"));
+    FLAMEGPU->message_out.setVariable<int>("agent_id", best_request_id);
+    FLAMEGPU->message_out.setIndex(agent_x, agent_y);
+
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(movement_transaction, MsgArray2D, MsgNone) {
+    int status = FLAMEGPU->getVariable<int>("status");
+    int agent_id = FLAMEGPU->getVariable<int>("agent_id");
+    unsigned int agent_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
+    unsigned int agent_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
+
+    for (auto current_message : FLAMEGPU->message_in(agent_x, agent_y)) {
+        // if location contains an agent wanting to move then look for responses allowing relocation
+        if (status == AGENT_STATUS_MOVEMENT_REQUESTED) {  // if the movement response request came from this location
+            if (current_message.getVariable<int>("agent_id") == agent_id) {
+                // remove the agent and reset agent specific variables as it has now moved
+                status = AGENT_STATUS_UNOCCUPIED;
+                FLAMEGPU->setVariable<int>("agent_id", -1);
+                FLAMEGPU->setVariable<int>("sugar_level", 0);
+                FLAMEGPU->setVariable<int>("metabolism", 0);
+                FLAMEGPU->setVariable<int>("env_sugar_level", 0);
+            }
+        }
+    }
+
+    // if request has not been responded to then agent is unresolved
+    if (status == AGENT_STATUS_MOVEMENT_REQUESTED) {
+        status = AGENT_STATUS_MOVEMENT_UNRESOLVED;
+    }
+
+    FLAMEGPU->setVariable<int>("status", status);
+
+    return ALIVE;
+}
+FLAMEGPU_EXIT_CONDITION(MovementExitCondition) {
+    static unsigned int iterations = 0;
+    iterations++;
+
+    // Max iterations 9
+    if (iterations < 9) {
+        // Agent movements still unresolved
+        if (FLAMEGPU->agent("agent").count("status", AGENT_STATUS_MOVEMENT_UNRESOLVED)) {
+            return CONTINUE;
+        }
+    }
+
+    iterations = 0;
+    return EXIT;
+}
+/**
+ * Construct the common components of agent shared between both parent and submodel
+ */
+AgentDescription &makeCoreAgent(ModelDescription &model) {
+    AgentDescription &agent = model.newAgent("agent");
+    agent.newVariable<unsigned int, 2>("pos");
+    agent.newVariable<int>("location_id");
+    agent.newVariable<int>("agent_id");
+    agent.newVariable<int>("status");
+    // agent specific variables
+    agent.newVariable<int>("sugar_level");
+    agent.newVariable<int>("metabolism");
+    // environment specific var
+    agent.newVariable<int>("env_sugar_level");
+    agent.newVariable<int>("env_max_sugar_level");
+#ifdef VISUALISATION
+    // Redundant seperate floating point position vars for vis
+    agent.newVariable<float>("x");
+    agent.newVariable<float>("y");
+#endif
+    return agent;
+}
+int main(int argc, const char ** argv) {
+    NVTX_RANGE("main");
+    NVTX_PUSH("ModelDescription");
+    ModelDescription submodel("Movement_model");
+    {  // Define sub model for conflict resolution
+        /**
+         * Messages
+         */
+        {   // cell_status message
+            MsgArray2D::Description &message = submodel.newMessage<MsgArray2D>("cell_status");
+            message.newVariable<int>("location_id");
+            message.newVariable<int>("status");
+            message.newVariable<int>("env_sugar_level");
+            message.setDimensions(GRID_WIDTH, GRID_HEIGHT);
+        }
+        {   // movement_request message
+            MsgArray2D::Description &message = submodel.newMessage<MsgArray2D>("movement_request");
+            message.newVariable<int>("agent_id");
+            message.newVariable<int>("location_id");
+            message.newVariable<int>("sugar_level");
+            message.newVariable<int>("metabolism");
+            message.setDimensions(GRID_WIDTH, GRID_HEIGHT);
+        }
+        {   // movement_response message
+            MsgArray2D::Description &message = submodel.newMessage<MsgArray2D>("movement_response");
+            message.newVariable<int>("location_id");
+            message.newVariable<int>("agent_id");
+            message.setDimensions(GRID_WIDTH, GRID_HEIGHT);
+        }
+        /**
+         * Agents
+         */
+        {
+            AgentDescription &agent = makeCoreAgent(submodel);
+            auto &fn_output_cell_status = agent.newFunction("output_cell_status", output_cell_status);
+            {
+                fn_output_cell_status.setMessageOutput("cell_status");
+            }
+            auto &fn_movement_request = agent.newFunction("movement_request", movement_request);
+            {
+                fn_movement_request.setMessageInput("cell_status");
+                fn_movement_request.setMessageOutput("movement_request");
+            }
+            auto &fn_movement_response = agent.newFunction("movement_response", movement_response);
+            {
+                fn_movement_response.setMessageInput("movement_request");
+                fn_movement_response.setMessageOutput("movement_response");
+            }
+            auto &fn_movement_transaction = agent.newFunction("movement_transaction", movement_transaction);
+            {
+                fn_movement_transaction.setMessageInput("movement_response");
+            }
+        }
+
+        /**
+         * Globals
+         */
+        {
+            // EnvironmentDescription &env = model.Environment();
+        }
+
+        /**
+         * Control flow
+         */
+        {   // Layer #1
+            LayerDescription &layer = submodel.newLayer();
+            layer.addAgentFunction(output_cell_status);
+        }
+        {   // Layer #2
+            LayerDescription &layer = submodel.newLayer();
+            layer.addAgentFunction(movement_request);
+        }
+        {   // Layer #3
+            LayerDescription &layer = submodel.newLayer();
+            layer.addAgentFunction(movement_response);
+        }
+        {   // Layer #4
+            LayerDescription &layer = submodel.newLayer();
+            layer.addAgentFunction(movement_transaction);
+        }
+        submodel.addExitCondition(MovementExitCondition);
+    }
+
+    ModelDescription model("Sugarscape_example");
+
+    /**
+     * Agents
+     */
+    {   // Per cell agent
+        AgentDescription &agent = makeCoreAgent(model);
+        // Functions
+        agent.newFunction("metabolise_and_growback", metabolise_and_growback);
+    }
+
+    /**
+     * Submodels
+     */
+    SubModelDescription &movement_sub = model.newSubModel("movement_conflict_resolution_model", submodel);
+    {
+        movement_sub.bindAgent("agent", "agent", true, true);
+    }
+
+    /**
+     * Globals
+     */
+    {
+        // EnvironmentDescription &env = model.Environment();
+    }
+
+    /**
+     * Control flow
+     */
+    {   // Layer #1
+        LayerDescription &layer = model.newLayer();
+        layer.addAgentFunction(metabolise_and_growback);
+    }
+    {   // Layer #2
+        LayerDescription &layer = model.newLayer();
+        layer.addSubModel(movement_sub);
+    }
+    NVTX_POP();
+
+    /**
+     * Create Model Runner
+     */
+    NVTX_PUSH("CUDAAgentModel creation");
+    CUDASimulation cuda_model(model);
+    NVTX_POP();
+
+    /**
+     * Create visualisation
+     * @note FGPU2 doesn't currently have proper support for discrete/2d visualisations
+     */
+#ifdef VISUALISATION
+    ModelVis &visualisation = cuda_model.getVisualisation();
+    {
+        visualisation.setSimulationSpeed(2);
+        visualisation.setInitialCameraLocation(GRID_WIDTH / 2.0f, GRID_HEIGHT / 2.0f, 225.0f);
+        visualisation.setInitialCameraTarget(GRID_WIDTH / 2.0f, GRID_HEIGHT /2.0f, 0.0f);
+        visualisation.setCameraSpeed(0.001f * GRID_WIDTH);
+        visualisation.setViewClips(0.1f, 5000);
+        auto &agt = visualisation.addAgent("agent");
+        // Position vars are named x, y, z; so they are used by default
+        agt.setModel(Stock::Models::CUBE);  // 5 unwanted faces!
+        agt.setModelScale(1.0f);
+#if VIS_MODE == 0
+            DiscreteColor<int> cell_colors = DiscreteColor<int>("status", Color{"#666"});
+            cell_colors[AGENT_STATUS_UNOCCUPIED] = Stock::Colors::RED;
+            cell_colors[AGENT_STATUS_OCCUPIED] = Stock::Colors::GREEN;
+            cell_colors[AGENT_STATUS_MOVEMENT_REQUESTED] = Stock::Colors::BLUE;  // Not possible, only occurs inside the submodel
+            cell_colors[AGENT_STATUS_MOVEMENT_UNRESOLVED] = Stock::Colors::WHITE;
+            agt.setColor(cell_colors);
+#else
+            DiscreteColor<int> cell_colors = DiscreteColor<int>("env_sugar_level", Stock::Palettes::Viridis(SUGAR_MAX_CAPACITY + 1), Color{"#f00"});
+            agt.setColor(cell_colors);
+#endif
+    }
+    visualisation.activate();
+#endif
+
+    /**
+     * Initialisation
+     */
+    NVTX_PUSH("CUDAAgentModel initialisation");
+    cuda_model.initialise(argc, argv);
+    if (cuda_model.getSimulationConfig().input_file.empty()) {
+        std::default_random_engine rng;
+        // Pre init, decide the sugar hotspots
+        std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> sugar_hotspots;
+        {
+            std::uniform_int_distribution<unsigned int> width_dist(0, GRID_WIDTH-1);
+            std::uniform_int_distribution<unsigned int> height_dist(0, GRID_HEIGHT-1);
+            // Each sugar hotspot has a radius of 3-15 blocks
+            std::uniform_int_distribution<unsigned int> radius_dist(5, 30);
+            // Hostpot area should cover around 50% of the map
+            float hotspot_area = 0;
+            while (hotspot_area < GRID_WIDTH * GRID_HEIGHT) {
+                unsigned int rad = radius_dist(rng);
+                std::tuple<int, int, unsigned int, unsigned int> hs = {width_dist(rng), height_dist(rng), rad, SUGAR_MAX_CAPACITY };
+                sugar_hotspots.push_back(hs);
+                hotspot_area += 3.141f * rad * rad;
+            }
+        }
+
+
+        // Currently population has not been init, so generate an agent population on the fly
+        const unsigned int CELL_COUNT = GRID_WIDTH * GRID_HEIGHT;
+        std::uniform_real_distribution<float> normal(0, 1);
+        std::uniform_int_distribution<int> agent_sugar_dist(0, SUGAR_MAX_CAPACITY * 2);
+        std::uniform_int_distribution<int> poor_env_sugar_dist(0, SUGAR_MAX_CAPACITY/2);
+        unsigned int location_id = 0;
+        unsigned int agent_id = 0;
+        AgentVector init_pop(model.Agent("agent"), CELL_COUNT);
+        for (unsigned int x = 0; x < GRID_WIDTH; ++x) {
+            for (unsigned int y = 0; y < GRID_HEIGHT; ++y) {
+                AgentVector::Agent instance = init_pop[location_id];
+                instance.setVariable<unsigned int, 2>("pos", { x, y });
+                // TODO: How should these values be init?
+                // Location index assigned linearly
+                instance.setVariable<int>("location_id", location_id++);
+                // agent specific variables
+                // 10% chance of cell holding an agent
+                if (normal(rng) < 0.1) {
+                    instance.setVariable<int>("agent_id", agent_id++);
+                    instance.setVariable<int>("status", AGENT_STATUS_OCCUPIED);
+                    instance.setVariable<int>("sugar_level", agent_sugar_dist(rng)/2);  // Agent sugar dist 0-3, less chance of 0
+                    instance.setVariable<int>("metabolism", 6);
+                } else {
+                    instance.setVariable<int>("agent_id", -1);
+                    instance.setVariable<int>("status", AGENT_STATUS_UNOCCUPIED);
+                    instance.setVariable<int>("sugar_level", 0);
+                    instance.setVariable<int>("metabolism", 0);
+                }
+                // environment specific var
+                unsigned int env_sugar_lvl = 0;
+                const int hotspot_core_size = 5;
+                for (auto &hs : sugar_hotspots) {
+                    // Workout the highest sugar lvl from a nearby hotspot
+                    int hs_x = std::get<0>(hs);
+                    int hs_y = std::get<1>(hs);
+                    unsigned int hs_rad = std::get<2>(hs);
+                    unsigned int hs_level = std::get<3>(hs);
+                    float hs_dist = static_cast<float>(sqrt(pow(hs_x-static_cast<int>(x), 2.0) + pow(hs_y-static_cast<int>(y), 2.0)));
+                    if (hs_dist <= hotspot_core_size) {
+                        unsigned int t = hs_level;
+                        env_sugar_lvl = t > env_sugar_lvl ? t : env_sugar_lvl;
+                    } else if (hs_dist <= hs_rad) {
+                        int non_core_len = hs_rad - hotspot_core_size;
+                        float dist_from_core = hs_dist - hotspot_core_size;
+                        unsigned int t = static_cast<unsigned int>(hs_level * (non_core_len - dist_from_core) / non_core_len);
+                        env_sugar_lvl = t > env_sugar_lvl ? t : env_sugar_lvl;
+                    }
+                }
+                env_sugar_lvl = env_sugar_lvl < SUGAR_MAX_CAPACITY / 2 ? poor_env_sugar_dist(rng) : env_sugar_lvl;
+                instance.setVariable<int>("env_max_sugar_level", env_sugar_lvl);  // All cells begin at their local max sugar
+                instance.setVariable<int>("env_sugar_level", env_sugar_lvl);
+#ifdef VISUALISATION
+                // Redundant separate floating point position vars for vis
+                instance.setVariable<float>("x", static_cast<float>(x));
+                instance.setVariable<float>("y", static_cast<float>(y));
+#endif
+            }
+        }
+        cuda_model.setPopulationData(init_pop);
+    }
+    NVTX_POP();
+
+    /**
+     * Execution
+     */
+    cuda_model.simulate();
+
+    /**
+     * Export Pop
+     */
+    // cuda_model.exportData("end.xml");
+
+#ifdef VISUALISATION
+    visualisation.join();
+#endif
+    return 0;
+}


### PR DESCRIPTION
Porting the Sugarscape example from FLAMEGPU1 to demonstrate SubModels.

As we don't have proper dicrete visualisation support, it visualise tightly packed cubes with colors based on visualisation rules.

Notable changes:
* Global function condition has been replaced with a submodel.
* Agent variable `state` has been renamed `status` (similar named throughout have also been updated for clarity).
* Agent's now explicitly hold their cell coordinates as variables (array var `pos`)
* A random initialisation function is provided. This is based off a combination of the FGPU1 init file and an understanding of how the environment exists as hotspots, rather than fully RNG.
* A bug from the original FLAMEGPU1 version, causing bias inside `movement_request`, has been corrected.
* A commented out random value from the original FLAMEGPU1 version, causing bias inside `movement_response`, has been reverted.
* Cells now have individualised `env_max_sugar_level` values, this allows hotspots to persist through the simulation.
* Various configuration parameters have been tuned to provide a more compelling visualisation.
* Occupied cells have their `env_sugar_level` set to -1, to facilitate visualising occupied cells over sugar level. (Previously they would be 0)

Note:
* The model still lacks birth, so it is not possible for more agents to be born. Due to agents (farmers?) not being represented by FLAMEGPU agents, birth would necessitate agent ids being inherited from the location whenever birth occurs (this includes existing agents changing their id to location on movement).

Closes #67 


*Having two discrete examples, may be time to start considering how we will visualise discrete models. properly*