### PR TITLE
Hostfn Agent Access

### DIFF
--- a/examples/ensemble/src/main.cu
+++ b/examples/ensemble/src/main.cu
@@ -9,9 +9,9 @@ FLAMEGPU_INIT_FUNCTION(Init) {
     const unsigned int POPULATION_TO_GENERATE = FLAMEGPU->environment.getProperty<unsigned int>("POPULATION_TO_GENERATE");
     const int init = FLAMEGPU->environment.getProperty<int>("init");
     const int init_offset = FLAMEGPU->environment.getProperty<int>("init_offset");
+    auto agent = FLAMEGPU->agent("Agent");
     for (unsigned int i = 0; i < POPULATION_TO_GENERATE; ++i) {
-        auto agent = FLAMEGPU->newAgent("Agent");
-        agent.setVariable<int>("x", init + i * init_offset);
+        agent.newAgent().setVariable<int>("x", init + i * init_offset);
     }
 }
 std::atomic<unsigned int> atomic_init = {0};

--- a/examples/host_functions/src/main.cu
+++ b/examples/host_functions/src/main.cu
@@ -14,11 +14,12 @@ FLAMEGPU_AGENT_FUNCTION(device_function, MsgNone, MsgNone) {
     return ALIVE;
 }
 FLAMEGPU_INIT_FUNCTION(init_function) {
-    float min_x = FLAMEGPU->agent("agent").min<float>("x");
-    float max_x = FLAMEGPU->agent("agent").max<float>("x");
+    HostAgentAPI agent = FLAMEGPU->agent("agent");
+    float min_x = agent.min<float>("x");
+    float max_x = agent.max<float>("x");
     printf("Init Function! (AgentCount: %u, Min: %g, Max: %g)\n", FLAMEGPU->agent("agent").count(), min_x, max_x);
     for (unsigned int i = AGENT_COUNT / 2; i < AGENT_COUNT; i++) {
-        HostNewAgentAPI instance = FLAMEGPU->newAgent("agent");
+        HostNewAgentAPI instance = agent.newAgent();
         instance.setVariable<float>("x", static_cast<float>(i));
         instance.setVariable<int>("a", i % 2 == 0 ? 1 : 0);
     }

--- a/examples/host_functions/src/main.cu
+++ b/examples/host_functions/src/main.cu
@@ -18,7 +18,7 @@ FLAMEGPU_INIT_FUNCTION(init_function) {
     float max_x = FLAMEGPU->agent("agent").max<float>("x");
     printf("Init Function! (AgentCount: %u, Min: %g, Max: %g)\n", FLAMEGPU->agent("agent").count(), min_x, max_x);
     for (unsigned int i = AGENT_COUNT / 2; i < AGENT_COUNT; i++) {
-        FLAMEGPU_HOST_NEW_AGENT_API instance = FLAMEGPU->newAgent("agent");
+        HostNewAgentAPI instance = FLAMEGPU->newAgent("agent");
         instance.setVariable<float>("x", static_cast<float>(i));
         instance.setVariable<int>("a", i % 2 == 0 ? 1 : 0);
     }

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -156,7 +156,7 @@ class CUDAAgent : public AgentInterface {
      * @param state_name The state agents are scattered into
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream in which the corresponding agent function has executed
-     * @see HostAgentInstance::sort(const std::string &, HostAgentInstance::Order, int, int)
+     * @see HostAgentAPI::sort(const std::string &, HostAgentAPI::Order, int, int)
      */
     void scatterSort(const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -51,6 +51,7 @@ class CUDAAgentStateList {
         const SubAgentData::Mapping &mapping);
     /**
      * Resize all variable buffers within the parent CUDAFatAgentStateList
+     * Only initialises unmapped agent data
      * @param minimumSize The minimum number of agents that must be representable
      * @param retainData If true existing buffer data is retained
      * @see CUDAFatAgentStateList::resize(const unsigned int &, const bool &)
@@ -117,10 +118,29 @@ class CUDAAgentStateList {
      */
     void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
     /**
+     * Initialises any agent variables within the CUDAFatAgentStateList which are not present in this CUDAAgentStateList
+     * @param count Number of variables to init
+     * @param offset Offset into the buffer of agents to init
+     * @param scatter Scatter instance and scan arrays to be used
+     * @param streamId This is required for scan compaction arrays and async
+     */
+    void initExcludedVars(const unsigned int& count, const unsigned int& offset, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream);
+    /**
      * Returns the statelist to an empty state
      * This resets the size to 0.
      */
     void clear();
+    /**
+     * Updates the number of alive agents, does not affect disabled agents or change agent data
+     * @param newSize Number of active agents
+     * @throw InvalidMemoryCapacity If the new number of disabled + active agents would exceed currently allocated buffer capacity
+     */
+    void setAgentCount(const unsigned int& newSize);
+    /**
+     * Returns a list of variable buffers attached to bound agents, not available in this agent
+     * @note This access is only intended for DeviceAgentVector's correctly handling of subagents
+     */
+    std::list<std::shared_ptr<VariableBuffer>> getUnboundVariableBuffers();
 
  private:
     /**

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -241,6 +241,13 @@ class CUDAFatAgentStateList {
      * This is used when performing a state transition to an empty statelist
      */
     void swap(CUDAFatAgentStateList*other);
+    /**
+     * Returns a list of variable buffers managed by the CUDAFatAgentStateList, which do not occur in exclusionSet
+     * @param exclusionSet A set of buffers to compare against
+     * @note Comparison checks for identical shared_ptr, not equality of VariableBuffer
+     * @note This access is only intended for DeviceAgentVector's correctly handling of subagents
+     */
+    std::list<std::shared_ptr<VariableBuffer>> getBuffers(std::set<std::shared_ptr<VariableBuffer>>& exclusionSet);
 
  private:
     /**

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -13,7 +13,7 @@
 #include "flamegpu/gpu/CUDAScatter.h"
 #include "flamegpu/gpu/CUDAEnsemble.h"
 #include "flamegpu/runtime/utility/RandomManager.cuh"
-#include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
+#include "flamegpu/runtime/HostNewAgentAPI.h"
 #include "flamegpu/visualiser/ModelVis.h"
 
 #ifdef _MSC_VER
@@ -40,7 +40,7 @@ class CUDASimulation : public Simulation {
     /**
      * Requires internal access to scan/scatter singletons
      */
-    friend class HostAgentInstance;
+    friend class HostAgentAPI;
     friend class SimRunner;
     /**
      * Map of a number of CUDA agents by name.

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -474,7 +474,7 @@ class CUDASimulation : public Simulation {
     /**
      * One instance of host api is used for entire model
      */
-    std::unique_ptr<FLAMEGPU_HOST_API> host_api;
+    std::unique_ptr<HostAPI> host_api;
     /**
      * Adds any agents stored in agentData to the device
      * Clears agent storage in agentData

--- a/include/flamegpu/model/LayerData.h
+++ b/include/flamegpu/model/LayerData.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#include "flamegpu/runtime/flamegpu_host_api_macros.h"  // Todo replace with std/cub style fns (see AgentFunction.h)
+#include "flamegpu/runtime/HostAPI_macros.h"  // Todo replace with std/cub style fns (see AgentFunction.h)
 #include "flamegpu/model/ModelData.h"
 struct AgentFunctionData;
 class LayerDescription;

--- a/include/flamegpu/model/ModelData.h
+++ b/include/flamegpu/model/ModelData.h
@@ -9,7 +9,7 @@
 #include <string>
 
 #include "flamegpu/model/EnvironmentDescription.h"
-#include "flamegpu/runtime/flamegpu_host_api_macros.h"
+#include "flamegpu/runtime/HostAPI_macros.h"
 #include "flamegpu/runtime/messaging/BruteForce.h"
 
 

--- a/include/flamegpu/pop/AgentVector_Agent.h
+++ b/include/flamegpu/pop/AgentVector_Agent.h
@@ -46,7 +46,7 @@ class AgentVector_CAgent {
     /**
      * Constructor, only ever called by AgentVector
      */
-    AgentVector_CAgent(const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, AgentVector::size_type pos);
+    AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, AgentVector::size_type pos);
     /**
      * Index within _data
      */
@@ -59,6 +59,12 @@ class AgentVector_CAgent {
      * Copy of agent definition
      */
     std::shared_ptr<const AgentData> _agent;
+    /**
+     * Raw pointer to the parent AgentVector
+     * This should not be accessed unless _data can be locked!!
+     * It only exists here so that change tracking methods can be called
+     */
+    AgentVector * const _parent;
 };
 
 /**
@@ -113,7 +119,7 @@ class AgentVector_Agent : public AgentVector_CAgent {
     /**
      * Constructor, only ever called by AgentVector
      */
-    AgentVector_Agent(const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, AgentVector::size_type pos);
+    AgentVector_Agent(AgentVector* parent, const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, AgentVector::size_type pos);
 };
 
 template <typename T>
@@ -141,8 +147,11 @@ void AgentVector_Agent::setVariable(const std::string &variable_name, const T &v
             "in AgentVector_Agent::setVariable().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     // do the replace
     static_cast<T*>(v_buff->getDataPtr())[index] = value;
+    // Notify (_data was locked above)
+    _parent->_changed(variable_name, index);
 }
 template <typename T, unsigned int N>
 void AgentVector_Agent::setVariable(const std::string &variable_name, const std::array<T, N> &value) {
@@ -169,7 +178,10 @@ void AgentVector_Agent::setVariable(const std::string &variable_name, const std:
             "in AgentVector_Agent::setVariable().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     memcpy(static_cast<T*>(v_buff->getDataPtr()) + (index * N), value.data(), sizeof(T) * N);
+    // Notify (_data was locked above)
+    _parent->_changed(variable_name, index);
 }
 template <typename T>
 void AgentVector_Agent::setVariable(const std::string &variable_name, const unsigned int &array_index, const T &value) {
@@ -196,6 +208,7 @@ void AgentVector_Agent::setVariable(const std::string &variable_name, const unsi
             "in AgentVector_Agent::setVariable().",
             array_index, v_buff->getElements(), variable_name.c_str());
     }
+    _parent->_require(variable_name);
     static_cast<T*>(v_buff->getDataPtr())[(index * v_buff->getElements()) + array_index] = value;
 }
 #ifdef SWIG
@@ -224,7 +237,10 @@ void AgentVector_Agent::setVariableArray(const std::string &variable_name, const
             "in AgentVector_Agent::setVariableArray().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     memcpy(static_cast<T*>(v_buff->getDataPtr()) + (index * v_buff->getElements()), value.data(), sizeof(T) * v_buff->getElements());
+    // Notify (_data was locked above)
+    _parent->_changed(variable_name, index);
 }
 #endif
 
@@ -253,6 +269,7 @@ T AgentVector_CAgent::getVariable(const std::string &variable_name) const {
             "in AgentVector_Agent::getVariable().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     return static_cast<const T*>(v_buff->getReadOnlyDataPtr())[index];
 }
 template <typename T, unsigned int N>
@@ -280,6 +297,7 @@ std::array<T, N> AgentVector_CAgent::getVariable(const std::string &variable_nam
             "in AgentVector_Agent::getVariable().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     std::array<T, N> rtn;
     memcpy(rtn.data(), static_cast<const T*>(v_buff->getReadOnlyDataPtr()) + (index * N), sizeof(T) * N);
     return rtn;
@@ -309,6 +327,7 @@ T AgentVector_CAgent::getVariable(const std::string &variable_name, const unsign
             "in AgentVector_Agent::getVariable().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     return static_cast<const T*>(v_buff->getReadOnlyDataPtr())[(index * v_buff->getElements()) + array_index];
 }
 #ifdef SWIG
@@ -332,6 +351,7 @@ std::vector<T> AgentVector_CAgent::getVariableArray(const std::string& variable_
             "in AgentVector_Agent::getVariableArray().",
             variable_name.c_str(), v_buff->getType().name(), typeid(T).name());
     }
+    _parent->_require(variable_name);
     std::vector<T> rtn(static_cast<size_t>(v_buff->getElements()));
     memcpy(rtn.data(), static_cast<T*>(v_buff->getDataPtr()) + (index * v_buff->getElements()), sizeof(T) * v_buff->getElements());
     return rtn;

--- a/include/flamegpu/pop/DeviceAgentVector.h
+++ b/include/flamegpu/pop/DeviceAgentVector.h
@@ -1,0 +1,15 @@
+#ifndef INCLUDE_FLAMEGPU_POP_DEVICEAGENTVECTOR_H_
+#define INCLUDE_FLAMEGPU_POP_DEVICEAGENTVECTOR_H_
+
+#include "flamegpu/pop/AgentVector.h"
+#include "flamegpu/pop/DeviceAgentVector_impl.h"
+
+/**
+ * This acts as a reference to DeviceAgentVector_impl
+ * That class cannot be copied or assigned so it is accessed via a reference wrapper
+ *
+ * @see DeviceAgentVector_impl
+ */
+typedef DeviceAgentVector_impl& DeviceAgentVector;
+
+#endif  // INCLUDE_FLAMEGPU_POP_DEVICEAGENTVECTOR_H_

--- a/include/flamegpu/pop/DeviceAgentVector_impl.h
+++ b/include/flamegpu/pop/DeviceAgentVector_impl.h
@@ -1,0 +1,356 @@
+#ifndef INCLUDE_FLAMEGPU_POP_DEVICEAGENTVECTOR_IMPL_H_
+#define INCLUDE_FLAMEGPU_POP_DEVICEAGENTVECTOR_IMPL_H_
+
+#include <string>
+#include <utility>
+#include <memory>
+#include <list>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "flamegpu/pop/AgentVector.h"
+#include "flamegpu/gpu/CUDAFatAgentStateList.h"  // VariableBuffer
+
+class CUDAScatter;
+class CUDAAgent;
+
+struct VarOffsetStruct;
+struct NewAgentStorage;
+
+/**
+ * This class provides an AgentVector interface to agent data currently stored on the device during execution of a CUDASimulation
+ *
+ * It attempts to prevent unnecessary memory transfers, as copying all agent variable buffers to only use 1
+ * Would result in a large number of redundant but costly memcpys between host and device
+ *
+ * @note This class cannot be created directly, you should use one created by HostAgentAPI
+ * @see HostAgentAPI::getPopulationData()
+ */
+class DeviceAgentVector_impl : protected AgentVector {
+ public:
+    /**
+      * Construct a DeviceAgentVector interface to the on-device data of cuda_agent
+      * @param cuda_agent CUDAAgent instance holding pointers to the desired agent data
+      * @param cuda_agent_state Name of the state within cuda_agent to represent.
+      */
+    DeviceAgentVector_impl(CUDAAgent& cuda_agent, const std::string& cuda_agent_state,
+        const VarOffsetStruct& _agentOffsets, std::vector<NewAgentStorage>& _newAgentData,
+        CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream);
+    /**
+     * Copy operations are disabled
+     */
+     // DeviceAgentVector_t(const DeviceAgentVector_t& other) = delete;
+     // DeviceAgentVector_t& operator=(const DeviceAgentVector_t& other) = delete;
+     /**
+      * Copies changed agent data back to device
+      */
+    void syncChanges();
+    /**
+     * Clears the local cache, so data is re-downloaded from the device when next required
+     */
+    void purgeCache();
+
+    /**
+     * Access specified element with bounds checking
+     * @param pos position of the element to return
+     * @return Reference to the requested element.
+     * @throws std::out_of_range if `!(pos < size())`
+     */
+    using AgentVector::at;
+    /**
+     * Returns a reference to the element at specified location pos.
+     * @param pos position of the element to return
+     * @return Reference to the requested element.
+     * @throws std::out_of_range if `!(pos < size())`
+     */
+    using AgentVector::operator[];
+    /**
+     * Returns a reference to the first element in the container.
+     * @return Reference to the first element
+     * @throws std::out_of_range if `empty()`
+     */
+    using AgentVector::front;
+    /**
+     * Returns a reference to the last element in the container.
+     * @return Reference to the last element
+     * @throws std::out_of_range if `empty()`
+     */
+    using AgentVector::back;
+    // using AgentVector::data; // Would need to assume whole vector changed
+    /**
+     * Forward iterator access to the start of the vector
+     */
+    using AgentVector::begin;
+    /**
+     * Forward iterator to position after the last element
+     */
+    using AgentVector::end;
+    /**
+     * Forward iterator const access to the start of the vector
+     */
+    using AgentVector::cbegin;
+    /**
+     * Forward iterator to position after the last element
+     * (Const version of end())
+     */
+    using AgentVector::cend;
+    /**
+     * Reverse iterator access to the last element of the vector
+     */
+    using AgentVector::rbegin;
+    /**
+     * Reverse iterator to position before the first element
+     */
+    using AgentVector::rend;
+    /**
+     * Reverse iterator const access to the last element of the vector
+     */
+    using AgentVector::crbegin;
+    /**
+     * Reverse iterator to position before the first element
+     * (Const version of rend())
+     */
+    using AgentVector::crend;
+    /**
+     * Checks if the container has no elements, i.e. whether begin() == end()
+     * @return `true` if the container is empty, `false` otherwise
+     */
+    using AgentVector::empty;
+    /**
+     * Returns the number of elements in the container, i.e. std::distance(begin(), end())
+     * @return The number of elements in the container.
+     */
+    using AgentVector::size;
+    /**
+     * Returns the max theoretical size of this host vector
+     * This does not reflect the device allocated buffer
+     */
+    using AgentVector::max_size;
+    /**
+     * Pre-allocates buffer space for this host vector
+     * This does not affect the device allocated buffer, that is updated if necessary when agents are returned to device.
+     */
+    using AgentVector::reserve;
+    /**
+     * Returns the current capacity of the host vector
+     * This does not reflect the capacity of the device allocated buffer
+     */
+    using AgentVector::capacity;
+    /**
+     * Reduces the current capacity to fit the size of the host vector
+     * This does not affect the capacity of the device allocated buffer, that is updated if necessary when agents are returned to device.
+     */
+    using AgentVector::shrink_to_fit;
+    /**
+     * Erases all elements from the container. After this call, size() returns zero.
+     *
+     * Invalidates any references, pointers, or iterators referring to contained elements. Any past-the-end iterators are also invalidated.
+     *
+     * Leaves the capacity() of the vector unchanged
+     */
+    using AgentVector::clear;
+    /**
+     * Inserts elements at the specified location in the container
+     * a) Inserts value before pos
+     * b) Inserts count copies of the value before pos
+     * c) Inserts elements from range [first, last) before pos.
+     *    The behavior is undefined if first and last are iterators into *this
+     *
+     * Causes reallocation if the new size() is greater than the old capacity().
+     * If the new size() is greater than capacity(), all iterators and references are invalidated.
+     * Otherwise, only the iterators and references before the insertion point remain valid.
+     * The past-the-end iterator is also invalidated.
+     *
+     * @throw InvalidAgent If agent type of value does not match
+     */
+    using AgentVector::insert;
+#ifdef SWIG
+    /**
+     * Python insert behaviour
+     */
+    using AgentVector::py_insert;
+#endif
+    /**
+     * Erases the specified elements from the container.
+     * a) Removes the element at pos.
+     * b) Removes the elements in the range [first, last).
+     *
+     * Invalidates iterators and references at or after the point of the erase,  including the end() iterator.
+     *
+     * The iterator pos must be valid and dereferenceable.
+     * Thus the end() iterator (which is valid, but is not dereferenceable) cannot be used as a value for pos.
+     *
+     * @param pos iterator to the element to remove
+     *
+     * @return Iterator following the last removed element
+     * @return If pos refers to the last element, then the end() iterator is returned
+     * @throw OutOfBoundsException pos >= size()
+     */
+    using AgentVector::erase;
+#ifdef SWIG
+    /**
+     * Python erase behaviour
+     */
+    using AgentVector::py_erase;
+#endif
+    /**
+     * Appends a default initialised agent to the end of the container
+     */
+    using AgentVector::push_back;
+    /**
+     * Removes the last agent of the container.
+     * Calling pop_back on an empty container results in undefined behavior.
+     * Iterators and references to the last element, as well as the end() iterator, are invalidated.
+     */
+    using AgentVector::pop_back;
+    using AgentVector::resize;
+    // using AgentVector::swap; // This would essentially require replacing the entire on-device agent vector
+
+ protected:
+    /**
+     * Triggered when insert() has been called
+     */
+    void _insert(size_type pos, size_type count) override;
+    /**
+     * Triggered when erase() has been called
+     */
+    void _erase(size_type pos, size_type count) override;
+    /**
+     * Useful for notifying changes due when a single agent variable has been updated (AgentVector::Agent::setVariable())
+     * @param variable_name Name of the variable that has been changed
+     * @param pos The index of the agent that's variable has been changed
+     */
+    void _changed(const std::string& variable_name, size_type pos) override;
+    /**
+     * Useful for notifying changes due to inserting/removing items, which essentially move all trailing items
+     * @param variable_name Name of the variable that has been changed
+     * @param pos The first index that has been changed
+     */
+    void _changedAfter(const std::string& variable_name, size_type pos) override;
+    /**
+     * Notify this that a variable is about to be accessed, to allow it's data to be synced
+     * Should be called by operations which update variables (e.g. AgentVector::Agent::getVariable())
+     * @param variable_name Name of the variable that has been changed
+     */
+    void _require(const std::string& variable_name) const override;
+    /**
+     * Notify this that all variables are about to be accessed
+     * Should be called by operations which move agents (e.g. insert/erase)
+     * @note This is not called in conjunction with _insert() or _erase()
+     */
+    void _requireAll() const override;
+    /**
+     * Notify that the size is about to be accessed
+     * This reflects both whether size is accessed directly or indirectly
+     * This will poll HostNewAgent for creations and apply them to the data structure
+     */
+    void _requireLength() const override;
+    /**
+     * Store information regarding which variables have been changed
+     * This map is built as changes come in, it is empty if no changes have been made
+     */
+    std::map<std::string, std::pair<size_type, size_type>> change_detail;
+    /**
+     * Variables included here require data to be updated from the device
+     * @note Mutable, because it must be updated by _requires(), _requiresAll() which are const
+     *       as they can be called by const user methods
+     */
+    mutable std::set<std::string> invalid_variables;
+    /**
+     * Store information regarding which variables have been changed
+     * This map is built as changes come in, it is empty if no changes have been made
+     */
+    bool unbound_buffers_has_changed;
+
+ private:
+    /**
+     * Pair of a host-backed device buffer
+     * This allows transactions which impact master-agent unbound variables to work correctly
+     * @note Can't move this definition to .cu, gcc requires it for std::list
+     */
+     struct VariableBufferPair {
+         /**
+          * Never allocate
+         */
+         explicit VariableBufferPair(const std::shared_ptr<VariableBuffer>& _device)
+             : device(_device) { }
+         VariableBufferPair(VariableBufferPair&& other) {
+             *this = std::move(other);
+         }
+         VariableBufferPair& operator=(VariableBufferPair&& other) {
+             std::swap(this->host, other.host);
+             std::swap(this->device, other.device);
+             return *this;
+         }
+         /**
+         * Copy operations are disabled
+         */
+         // @todo Solve this
+         // VariableBufferPair(const VariableBufferPair& other) = delete;
+         // VariableBufferPair& operator=(const VariableBufferPair& other) = delete;
+
+         /**
+          * Free host if
+          */
+         ~VariableBufferPair() {
+             if (host) free(host);
+         }
+         /**
+         * nullptr until required to be allocated
+         */
+         char* host = nullptr;
+         /**/
+         std::shared_ptr<VariableBuffer> device;
+     };
+    /**
+     * Any operations which move agents just be applied to this buffers too
+     */
+    std::list<VariableBufferPair> unbound_buffers;
+    /**
+     * The currently known size of the device buffer
+     * This is used to track size before the unbound_buffers are init
+     * Can't use _size in place of this, as calls to insert/erase/etc update that before we are notified
+     */
+    unsigned int known_device_buffer_size = 0;
+    /**
+     * Number of agents currently allocated inside the host_buffers
+     * Useful if the device buffers are resized via the CUDAAgent
+     */
+    unsigned int unbound_host_buffer_size = 0;
+    unsigned int unbound_host_buffer_capacity = 0;
+    /**
+     * This is set true by clearCache()
+     * If data has been re-ordered on the device, the host buffers will be out of sync
+     * At next insert/erase, this tells host buffers to download new
+     * It also tells a future call to sync, to ignore the unbound host buffers
+     */
+    bool unbound_host_buffer_invalid = false;
+    /**
+     * Initialises the host copies of the unbound buffers
+     * Allocates the host copy, and copies device data to them
+     */
+    void initUnboundBuffers();
+    /**
+     * Re-downloads updates the host unbound buffers from the device
+     */
+    void reinitUnboundBuffers();
+    /**
+     * Resizes the host copy of the unbound buffers, retaining data
+     * @param new_capacity New buffer capacity
+     * @param init If true, new memory is init
+     */
+    void resizeUnboundBuffers(const unsigned int& new_capacity, bool init);
+    CUDAAgent& cuda_agent;
+    std::string cuda_agent_state;
+
+
+    const VarOffsetStruct& agentOffsets;
+    std::vector<NewAgentStorage>& newAgentData;
+
+    CUDAScatter& scatter;
+    const unsigned int& streamId;
+    const cudaStream_t& stream;
+};
+
+#endif  // INCLUDE_FLAMEGPU_POP_DEVICEAGENTVECTOR_IMPL_H_

--- a/include/flamegpu/runtime/AgentFunction.h
+++ b/include/flamegpu/runtime/AgentFunction.h
@@ -75,11 +75,11 @@ __global__ void agent_function_wrapper(
         buff[0] = error_buffer;
     }
 #endif
-    // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
-    if (FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID() >= popNo)
+    // Must be terminated here, else AgentRandom has bounds issues inside DeviceAPI constructor
+    if (DeviceAPI<MsgIn, MsgOut>::TID() >= popNo)
         return;
     // create a new device FLAME_GPU instance
-    FLAMEGPU_DEVICE_API<MsgIn, MsgOut> api = FLAMEGPU_DEVICE_API<MsgIn, MsgOut>(
+    DeviceAPI<MsgIn, MsgOut> api = DeviceAPI<MsgIn, MsgOut>(
         instance_id_hash,
         agent_func_name_hash,
         agent_output_hash,
@@ -92,7 +92,7 @@ __global__ void agent_function_wrapper(
     FLAME_GPU_AGENT_STATUS flag = AgentFunction()(&api);
     if (scanFlag_agentDeath) {
         // (scan flags will not be processed unless agent death has been requested in model definition)
-        scanFlag_agentDeath[FLAMEGPU_DEVICE_API<MsgIn, MsgOut>::TID()] = flag;
+        scanFlag_agentDeath[DeviceAPI<MsgIn, MsgOut>::TID()] = flag;
 #if !defined(SEATBELTS) || SEATBELTS
     } else if (flag == DEAD) {
         DTHROW("Agent death must be enabled per agent function when defining the model.\n");

--- a/include/flamegpu/runtime/AgentFunctionCondition.h
+++ b/include/flamegpu/runtime/AgentFunctionCondition.h
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
-#include "flamegpu/runtime/flamegpu_device_api.h"
+#include "flamegpu/runtime/DeviceAPI.h"
 #include "flamegpu/runtime/AgentFunctionCondition_shim.h"
 #include "flamegpu/gpu/CUDAScanCompaction.h"
 
@@ -47,11 +47,11 @@ __global__ void agent_function_condition_wrapper(
         shared_mem[0] = error_buffer;
     }
 #endif
-    // Must be terminated here, else AgentRandom has bounds issues inside FLAMEGPU_DEVICE_API constructor
-    if (FLAMEGPU_READ_ONLY_DEVICE_API::TID() >= popNo)
+    // Must be terminated here, else AgentRandom has bounds issues inside DeviceAPI constructor
+    if (ReadOnlyDeviceAPI::TID() >= popNo)
         return;
     // create a new device FLAME_GPU instance
-    FLAMEGPU_READ_ONLY_DEVICE_API api = FLAMEGPU_READ_ONLY_DEVICE_API(
+    ReadOnlyDeviceAPI api = ReadOnlyDeviceAPI(
         instance_id_hash,
         agent_func_name_hash,
         d_rng);
@@ -61,7 +61,7 @@ __global__ void agent_function_condition_wrapper(
         // Negate the return value, we want false at the start of the scattered array
         bool conditionResult = !(AgentFunctionCondition()(&api));
         // (scan flags will be processed to filter agents
-        scanFlag_conditionResult[FLAMEGPU_READ_ONLY_DEVICE_API::TID()] = conditionResult;
+        scanFlag_conditionResult[ReadOnlyDeviceAPI::TID()] = conditionResult;
     }
 }
 

--- a/include/flamegpu/runtime/AgentFunctionCondition_shim.h
+++ b/include/flamegpu/runtime/AgentFunctionCondition_shim.h
@@ -2,14 +2,14 @@
 #define INCLUDE_FLAMEGPU_RUNTIME_AGENTFUNCTIONCONDITION_SHIM_H_
 
 
-class FLAMEGPU_READ_ONLY_DEVICE_API;
+class ReadOnlyDeviceAPI;
 
 /**
  * Macro for defining agent transition functions conditions with the correct input. Must always be a device function to be called by CUDA.
  *
  * struct SomeAgentFunctionCondition {
  *    // User Implemented agent function condition behaviour
- *     __device__ __forceinline__ bool operator()(FLAMEGPU_READ_ONLY_DEVICE_API *FLAMEGPU) const {
+ *     __device__ __forceinline__ bool operator()(ReadOnlyDeviceAPI *FLAMEGPU) const {
  *         // do something
  *         return something ? true : false;
  *     }
@@ -22,11 +22,11 @@ class FLAMEGPU_READ_ONLY_DEVICE_API;
 
 #define FLAMEGPU_AGENT_FUNCTION_CONDITION(funcName)\
 struct funcName ## _cdn_impl {\
-    __device__ __forceinline__ bool operator()(FLAMEGPU_READ_ONLY_DEVICE_API *FLAMEGPU) const;\
+    __device__ __forceinline__ bool operator()(ReadOnlyDeviceAPI *FLAMEGPU) const;\
     static constexpr AgentFunctionConditionWrapper *fnPtr() { return &agent_function_condition_wrapper<funcName ## _cdn_impl>; }\
 };\
 funcName ## _cdn_impl funcName;\
-__device__ __forceinline__ bool funcName ## _cdn_impl::operator()(FLAMEGPU_READ_ONLY_DEVICE_API *FLAMEGPU) const
+__device__ __forceinline__ bool funcName ## _cdn_impl::operator()(ReadOnlyDeviceAPI *FLAMEGPU) const
 
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_AGENTFUNCTIONCONDITION_SHIM_H_

--- a/include/flamegpu/runtime/AgentFunction_shim.h
+++ b/include/flamegpu/runtime/AgentFunction_shim.h
@@ -6,14 +6,14 @@
 
 
 template<typename MsgIn, typename MsgOut>
-class FLAMEGPU_DEVICE_API;
+class DeviceAPI;
 
 /**
  * Macro for defining agent transition functions with the correct input. Must always be a device function to be called by CUDA.
  *
  * struct SomeAgentFunction {
  *    // User Implemented agent function behaviour
- *     __device__ __forceinline__ FLAME_GPU_AGENT_STATUS operator()(FLAMEGPU_DEVICE_API<msg_in, msg_out> *FLAMEGPU) const {
+ *     __device__ __forceinline__ FLAME_GPU_AGENT_STATUS operator()(DeviceAPI<msg_in, msg_out> *FLAMEGPU) const {
  *         // do something
  *         return 0;
  *     }
@@ -29,21 +29,21 @@ class FLAMEGPU_DEVICE_API;
 #ifndef __CUDACC_RTC__
 #define FLAMEGPU_AGENT_FUNCTION(funcName, msg_in, msg_out)\
 struct funcName ## _impl {\
-    __device__ __forceinline__ FLAME_GPU_AGENT_STATUS operator()(FLAMEGPU_DEVICE_API<msg_in, msg_out> *FLAMEGPU) const;\
+    __device__ __forceinline__ FLAME_GPU_AGENT_STATUS operator()(DeviceAPI<msg_in, msg_out> *FLAMEGPU) const;\
     static constexpr AgentFunctionWrapper *fnPtr() { return &agent_function_wrapper<funcName ## _impl, msg_in, msg_out>; }\
     static std::type_index inType() { return std::type_index(typeid(msg_in)); }\
     static std::type_index outType() { return std::type_index(typeid(msg_out)); }\
 };\
 funcName ## _impl funcName;\
-__device__ __forceinline__ FLAME_GPU_AGENT_STATUS funcName ## _impl::operator()(FLAMEGPU_DEVICE_API<msg_in, msg_out> *FLAMEGPU) const
+__device__ __forceinline__ FLAME_GPU_AGENT_STATUS funcName ## _impl::operator()(DeviceAPI<msg_in, msg_out> *FLAMEGPU) const
 #else
 #define FLAMEGPU_AGENT_FUNCTION(funcName, msg_in, msg_out)\
 struct funcName ## _impl {\
-    __device__ __forceinline__ FLAME_GPU_AGENT_STATUS operator()(FLAMEGPU_DEVICE_API<msg_in, msg_out> *FLAMEGPU) const;\
+    __device__ __forceinline__ FLAME_GPU_AGENT_STATUS operator()(DeviceAPI<msg_in, msg_out> *FLAMEGPU) const;\
     static constexpr AgentFunctionWrapper *fnPtr() { return &agent_function_wrapper<funcName ## _impl, msg_in, msg_out>; }\
 }; \
 funcName ## _impl funcName; \
-__device__ __forceinline__ FLAME_GPU_AGENT_STATUS funcName ## _impl::operator()(FLAMEGPU_DEVICE_API<msg_in, msg_out> *FLAMEGPU) const
+__device__ __forceinline__ FLAME_GPU_AGENT_STATUS funcName ## _impl::operator()(DeviceAPI<msg_in, msg_out> *FLAMEGPU) const
 #endif
 
 /**

--- a/include/flamegpu/runtime/HostAPI.h
+++ b/include/flamegpu/runtime/HostAPI.h
@@ -14,6 +14,7 @@
 #include "flamegpu/runtime/HostAPI_macros.h"
 #include "flamegpu/runtime/HostNewAgentAPI.h"
 
+class CUDAScatter;
 class CUDASimulation;
 class HostAgentAPI;
 
@@ -40,9 +41,12 @@ class HostAPI {
      * Stores reference of CUDASimulation
      */
      explicit HostAPI(CUDASimulation&_agentModel,
-        RandomManager &rng,
-         const AgentOffsetMap &agentOffsets,
-         AgentDataMap &agentData);
+          RandomManager &rng,
+          CUDAScatter &scatter,
+          const AgentOffsetMap &agentOffsets,
+          AgentDataMap &agentData,
+          const unsigned int &streamId,
+         cudaStream_t stream);
     /**
      * Frees held device memory
      */
@@ -51,22 +55,6 @@ class HostAPI {
      * Returns methods that work on all agents of a certain type currently in a given state
      */
     HostAgentAPI agent(const std::string &agent_name, const std::string &stateName = ModelData::DEFAULT_STATE);
-    /**
-     * Creates a new agent of the named type and returns an object for configuring it's member variables
-     * The agent is created in their initial state as defined in model description hierarchy
-     * @param agent_name Name of the agent type to be created
-     * @throws InvalidAgentName If an agent with the provided name does not exist withint he model description hierarchy
-     */
-    HostNewAgentAPI newAgent(const std::string &agent_name);
-    /**
-     * Creates a new agent of the named type and returns an object for configuring it's member variables
-     * The agent is created in their initial state as defined in model description hierarchy
-     * @param agent_name Name of the agent type to be created
-     * @param state Name of the state the agent should be created in
-     * @throws InvalidAgentName If an agent with the provided name does not exist withint he model description hierarchy
-     * @throws InvalidStateName If state name does not apply to named agent
-     */
-    HostNewAgentAPI newAgent(const std::string &agent_name, const std::string &state);
     /**
      * Host API access to seeded random number generation
      */
@@ -127,6 +115,18 @@ class HostAPI {
      * when new agents are copied to device.
      */
     AgentDataMap &agentData;
+    /**
+     * Cuda scatter singleton
+     */
+    CUDAScatter &scatter;
+    /**
+     * Stream index for stream-specific resources
+     */
+    const unsigned int streamId;
+    /**
+     * CUDA stream object for CUDA operations
+     */
+    cudaStream_t stream;
 };
 
 template<typename T>

--- a/include/flamegpu/runtime/HostAPI.h
+++ b/include/flamegpu/runtime/HostAPI.h
@@ -1,5 +1,5 @@
-#ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_H_
-#define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_H_
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_HOSTAPI_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_HOSTAPI_H_
 
 #include <cuda_runtime_api.h>
 #include <string>
@@ -11,7 +11,7 @@
 #include "flamegpu/gpu/CUDAErrorChecking.h"
 #include "flamegpu/runtime/utility/HostRandom.cuh"
 #include "flamegpu/runtime/utility/HostEnvironment.cuh"
-#include "flamegpu/runtime/flamegpu_host_api_macros.h"
+#include "flamegpu/runtime/HostAPI_macros.h"
 #include "flamegpu/runtime/HostNewAgentAPI.h"
 
 class CUDASimulation;
@@ -21,7 +21,7 @@ class HostAgentAPI;
  * @brief    A flame gpu api class for use by host functions only
  * This class should only be used by init/step/exit/exitcondition functions.
  */
-class FLAMEGPU_HOST_API {
+class HostAPI {
     /**
      * Requires internal access for resizeTempStorage()
      * @todo Could move this behaviour to a seperate singleton class 
@@ -39,14 +39,14 @@ class FLAMEGPU_HOST_API {
      * Initailises pointers to 0
      * Stores reference of CUDASimulation
      */
-     explicit FLAMEGPU_HOST_API(CUDASimulation&_agentModel,
+     explicit HostAPI(CUDASimulation&_agentModel,
         RandomManager &rng,
          const AgentOffsetMap &agentOffsets,
          AgentDataMap &agentData);
     /**
      * Frees held device memory
      */
-     ~FLAMEGPU_HOST_API();
+     ~HostAPI();
     /**
      * Returns methods that work on all agents of a certain type currently in a given state
      */
@@ -130,7 +130,7 @@ class FLAMEGPU_HOST_API {
 };
 
 template<typename T>
-void FLAMEGPU_HOST_API::resizeOutputSpace(const unsigned int &items) {
+void HostAPI::resizeOutputSpace(const unsigned int &items) {
     if (sizeof(T) * items > d_output_space_size) {
         if (d_output_space_size) {
             gpuErrchk(cudaFree(d_output_space));
@@ -140,4 +140,4 @@ void FLAMEGPU_HOST_API::resizeOutputSpace(const unsigned int &items) {
     }
 }
 
-#endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_H_
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_HOSTAPI_H_

--- a/include/flamegpu/runtime/HostAPI_macros.h
+++ b/include/flamegpu/runtime/HostAPI_macros.h
@@ -1,13 +1,13 @@
-#ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_MACROS_H_
-#define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_MACROS_H_
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_HOSTAPI_MACROS_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_HOSTAPI_MACROS_H_
 
-class FLAMEGPU_HOST_API;
+class HostAPI;
 
 /**
  * @brief FLAMEGPU host function pointer definition
  *  this runs on the host as an init/step/exit or host layer function
  */
-typedef void (*FLAMEGPU_HOST_FUNCTION_POINTER)(FLAMEGPU_HOST_API *api);
+typedef void (*FLAMEGPU_HOST_FUNCTION_POINTER)(HostAPI *api);
 
 /**
  * They all share the same definition
@@ -23,9 +23,9 @@ typedef FLAMEGPU_HOST_FUNCTION_POINTER FLAMEGPU_EXIT_FUNCTION_POINTER;
  * Ugly, but has same usage as device functions
  */
 #define FLAMEGPU_HOST_FUNCTION(funcName) \
-void funcName ## _impl(FLAMEGPU_HOST_API* FLAMEGPU); \
+void funcName ## _impl(HostAPI* FLAMEGPU); \
 FLAMEGPU_HOST_FUNCTION_POINTER funcName = funcName ## _impl;\
-void funcName ## _impl(FLAMEGPU_HOST_API* FLAMEGPU)
+void funcName ## _impl(HostAPI* FLAMEGPU)
 
 /**
  * Return type for FLAMEGPU conditions
@@ -35,7 +35,7 @@ enum FLAME_GPU_CONDITION_RESULT { CONTINUE, EXIT };
  * @brief FLAMEGPU host function pointer definition
  *  this runs on the host as an init/step/exit or host layer function
  */
-typedef FLAME_GPU_CONDITION_RESULT (*FLAMEGPU_HOST_CONDITION_POINTER)(FLAMEGPU_HOST_API *api);
+typedef FLAME_GPU_CONDITION_RESULT (*FLAMEGPU_HOST_CONDITION_POINTER)(HostAPI *api);
 
 /**
  * Only use of condition at current is exit fn
@@ -49,8 +49,8 @@ typedef FLAMEGPU_HOST_CONDITION_POINTER FLAMEGPU_EXIT_CONDITION_POINTER;
  * Ugly, but has same usage as device functions
  */
 #define FLAMEGPU_HOST_CONDITION(funcName) \
-FLAME_GPU_CONDITION_RESULT funcName ## _impl(FLAMEGPU_HOST_API* FLAMEGPU); \
+FLAME_GPU_CONDITION_RESULT funcName ## _impl(HostAPI* FLAMEGPU); \
 FLAMEGPU_HOST_CONDITION_POINTER funcName = funcName ## _impl;\
-FLAME_GPU_CONDITION_RESULT funcName ## _impl(FLAMEGPU_HOST_API* FLAMEGPU)
+FLAME_GPU_CONDITION_RESULT funcName ## _impl(HostAPI* FLAMEGPU)
 
-#endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_API_MACROS_H_
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_HOSTAPI_MACROS_H_

--- a/include/flamegpu/runtime/HostAgentAPI.h
+++ b/include/flamegpu/runtime/HostAgentAPI.h
@@ -25,7 +25,7 @@
 
 #include "flamegpu/sim/AgentInterface.h"
 #include "flamegpu/model/AgentDescription.h"
-#include "flamegpu/runtime/flamegpu_host_api.h"
+#include "flamegpu/runtime/HostAPI.h"
 #include "flamegpu/gpu/CUDASimulation.h"
 #include "flamegpu/gpu/CUDAAgent.h"
 
@@ -55,7 +55,7 @@ __device__ __forceinline__ OutT funcName ## _impl::unary_function<InT, OutT>::op
 
 class HostAgentAPI {
  public:
-    HostAgentAPI(FLAMEGPU_HOST_API &_api, AgentInterface &_agent, const std::string &_stateName = "default")
+    HostAgentAPI(HostAPI &_api, AgentInterface &_agent, const std::string &_stateName = "default")
         : api(_api),
         agent(_agent),
         hasState(true),
@@ -205,7 +205,7 @@ class HostAgentAPI {
      * @param length Length of the buffer (how many items it can it hold)
      */
     static void sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &length, const cudaStream_t &stream);
-    FLAMEGPU_HOST_API &api;
+    HostAPI &api;
     AgentInterface &agent;
     bool hasState;
     const std::string stateName;
@@ -240,7 +240,7 @@ OutT HostAgentAPI::sum(const std::string &variable) const {
     void *var_ptr = agent.getStateVariablePtr(stateName, variable);
     const auto agentCount = agent.getStateSize(stateName);
     // Check if we need to resize cub storage
-    FLAMEGPU_HOST_API::CUB_Config cc = { FLAMEGPU_HOST_API::SUM, typeid(OutT).hash_code() };
+    HostAPI::CUB_Config cc = { HostAPI::SUM, typeid(OutT).hash_code() };
     if (api.tempStorageRequiresResize(cc, agentCount)) {
         // Resize cub storage
         size_t tempByte = 0;
@@ -270,7 +270,7 @@ InT HostAgentAPI::min(const std::string &variable) const {
     void *var_ptr = agent.getStateVariablePtr(stateName, variable);
     const auto agentCount = agent.getStateSize(stateName);
     // Check if we need to resize cub storage
-    FLAMEGPU_HOST_API::CUB_Config cc = { FLAMEGPU_HOST_API::MIN, typeid(InT).hash_code() };
+    HostAPI::CUB_Config cc = { HostAPI::MIN, typeid(InT).hash_code() };
     if (api.tempStorageRequiresResize(cc, agentCount)) {
         // Resize cub storage
         size_t tempByte = 0;
@@ -301,7 +301,7 @@ InT HostAgentAPI::max(const std::string &variable) const {
     void *var_ptr = agent.getStateVariablePtr(stateName, variable);
     const auto agentCount = agent.getStateSize(stateName);
     // Check if we need to resize cub storage
-    FLAMEGPU_HOST_API::CUB_Config cc = { FLAMEGPU_HOST_API::MAX, typeid(InT).hash_code() };
+    HostAPI::CUB_Config cc = { HostAPI::MAX, typeid(InT).hash_code() };
     if (api.tempStorageRequiresResize(cc, agentCount)) {
         // Resize cub storage
         size_t tempByte = 0;
@@ -359,7 +359,7 @@ std::vector<OutT> HostAgentAPI::histogramEven(const std::string &variable, const
     void *var_ptr = agent.getStateVariablePtr(stateName, variable);
     const auto agentCount = agent.getStateSize(stateName);
     // Check if we need to resize cub storage
-    FLAMEGPU_HOST_API::CUB_Config cc = { FLAMEGPU_HOST_API::HISTOGRAM_EVEN, histogramBins * sizeof(OutT) };
+    HostAPI::CUB_Config cc = { HostAPI::HISTOGRAM_EVEN, histogramBins * sizeof(OutT) };
     if (api.tempStorageRequiresResize(cc, agentCount)) {
         // Resize cub storage
         size_t tempByte = 0;
@@ -392,7 +392,7 @@ InT HostAgentAPI::reduce(const std::string &variable, reductionOperatorT /*reduc
     void *var_ptr = agent.getStateVariablePtr(stateName, variable);
     const auto agentCount = agent.getStateSize(stateName);
     // Check if we need to resize cub storage
-    FLAMEGPU_HOST_API::CUB_Config cc = { FLAMEGPU_HOST_API::CUSTOM_REDUCE, typeid(InT).hash_code() };
+    HostAPI::CUB_Config cc = { HostAPI::CUSTOM_REDUCE, typeid(InT).hash_code() };
     if (api.tempStorageRequiresResize(cc, agentCount)) {
         // Resize cub storage
         size_t tempByte = 0;
@@ -466,7 +466,7 @@ void HostAgentAPI::sort(const std::string &variable, Order order, int beginBit, 
     // Create array of agent values (use scanflag_death.scan_flag)
     gpuErrchk(cudaMemcpy(keys_in, var_ptr, total_variable_buffer_size, cudaMemcpyDeviceToDevice));
     // Check if we need to resize cub storage
-    const FLAMEGPU_HOST_API::CUB_Config cc = { FLAMEGPU_HOST_API::SORT, typeid(VarT).hash_code() };
+    const HostAPI::CUB_Config cc = { HostAPI::SORT, typeid(VarT).hash_code() };
     if (api.tempStorageRequiresResize(cc, agentCount)) {
         // Resize cub storage
         size_t tempByte = 0;

--- a/include/flamegpu/runtime/HostAgentAPI.h
+++ b/include/flamegpu/runtime/HostAgentAPI.h
@@ -1,5 +1,5 @@
-#ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_AGENT_API_H_
-#define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_AGENT_API_H_
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_HOSTAGENTAPI_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_HOSTAGENTAPI_H_
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
@@ -53,20 +53,13 @@ funcName ## _impl funcName;\
 template<typename InT, typename OutT>\
 __device__ __forceinline__ OutT funcName ## _impl::unary_function<InT, OutT>::operator()(const InT &a) const
 
-class HostAgentInstance {
+class HostAgentAPI {
  public:
-    HostAgentInstance(FLAMEGPU_HOST_API &_api, AgentInterface &_agent, const std::string &_stateName = "default")
+    HostAgentAPI(FLAMEGPU_HOST_API &_api, AgentInterface &_agent, const std::string &_stateName = "default")
         : api(_api),
         agent(_agent),
         hasState(true),
-        stateName(_stateName) {
-    }
-    /*HostAgentInstance(const CUDAAgent &_agent)
-        :agent(_agent),
-        hasState(false),
-        stateName("") {
-
-    }*/
+        stateName(_stateName) { }
     /*
      * Returns the number of agents in this state
      */
@@ -218,7 +211,7 @@ class HostAgentInstance {
     const std::string stateName;
 };
 
-inline unsigned HostAgentInstance::count() {
+inline unsigned HostAgentAPI::count() {
     return agent.getStateSize(stateName);
 }
 
@@ -227,20 +220,20 @@ inline unsigned HostAgentInstance::count() {
 //
 
 template<typename InT>
-InT HostAgentInstance::sum(const std::string &variable) const {
+InT HostAgentAPI::sum(const std::string &variable) const {
     return sum<InT, InT>(variable);
 }
 template<typename InT, typename OutT>
-OutT HostAgentInstance::sum(const std::string &variable) const {
+OutT HostAgentAPI::sum(const std::string &variable) const {
     static_assert(sizeof(InT) <= sizeof(OutT), "Template arg OutT should not be of a smaller size than InT");
     const auto &agentDesc = agent.getAgentDescription();
 
     std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::sum() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::sum() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::sum(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::sum(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -263,14 +256,14 @@ OutT HostAgentInstance::sum(const std::string &variable) const {
     return rtn;
 }
 template<typename InT>
-InT HostAgentInstance::min(const std::string &variable) const {
+InT HostAgentAPI::min(const std::string &variable) const {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::lowerBound() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::lowerBound() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::lowerBound(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::lowerBound(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -294,14 +287,14 @@ InT HostAgentInstance::min(const std::string &variable) const {
     return rtn;
 }
 template<typename InT>
-InT HostAgentInstance::max(const std::string &variable) const {
+InT HostAgentAPI::max(const std::string &variable) const {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::upperBound() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::upperBound() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to FLAMEGPU_HOST_AGENT_API::upperBound(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::upperBound(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -325,14 +318,14 @@ InT HostAgentInstance::max(const std::string &variable) const {
     return rtn;
 }
 template<typename InT>
-unsigned int HostAgentInstance::count(const std::string &variable, const InT &value) {
+unsigned int HostAgentAPI::count(const std::string &variable, const InT &value) {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::count() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::count() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to FLAMEGPU_HOST_AGENT_API::count(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::count(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -344,22 +337,22 @@ unsigned int HostAgentInstance::count(const std::string &variable, const InT &va
     return rtn;
 }
 template<typename InT>
-std::vector<unsigned int> HostAgentInstance::histogramEven(const std::string &variable, const unsigned int &histogramBins, const InT &lowerBound, const InT &upperBound) const {
+std::vector<unsigned int> HostAgentAPI::histogramEven(const std::string &variable, const unsigned int &histogramBins, const InT &lowerBound, const InT &upperBound) const {
     return histogramEven<InT, unsigned int>(variable, histogramBins, lowerBound, upperBound);
 }
 template<typename InT, typename OutT>
-std::vector<OutT> HostAgentInstance::histogramEven(const std::string &variable, const unsigned int &histogramBins, const InT &lowerBound, const InT &upperBound) const {
+std::vector<OutT> HostAgentAPI::histogramEven(const std::string &variable, const unsigned int &histogramBins, const InT &lowerBound, const InT &upperBound) const {
     if (lowerBound >= upperBound) {
-        THROW InvalidArgument("lowerBound (%s) must be lower than < upperBound (%s) in HostAgentInstance::histogramEven().",
+        THROW InvalidArgument("lowerBound (%s) must be lower than < upperBound (%s) in HostAgentAPI::histogramEven().",
             std::to_string(lowerBound).c_str(), std::to_string(upperBound).c_str());
     }
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::histogramEven() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::histogramEven() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::histogramEven(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::histogramEven(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -385,14 +378,14 @@ std::vector<OutT> HostAgentInstance::histogramEven(const std::string &variable, 
     return rtn;
 }
 template<typename InT, typename reductionOperatorT>
-InT HostAgentInstance::reduce(const std::string &variable, reductionOperatorT /*reductionOperator*/, const InT &init) const {
+InT HostAgentAPI::reduce(const std::string &variable, reductionOperatorT /*reductionOperator*/, const InT &init) const {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::reduce() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::reduce() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::reduce(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::reduce(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -418,14 +411,14 @@ InT HostAgentInstance::reduce(const std::string &variable, reductionOperatorT /*
     return rtn;
 }
 template<typename InT, typename OutT, typename transformOperatorT, typename reductionOperatorT>
-OutT HostAgentInstance::transformReduce(const std::string &variable, transformOperatorT /*transformOperator*/, reductionOperatorT /*reductionOperator*/, const OutT &init) const {
+OutT HostAgentAPI::transformReduce(const std::string &variable, transformOperatorT /*transformOperator*/, reductionOperatorT /*reductionOperator*/, const OutT &init) const {
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::transformReduce() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::transformReduce() does not support agent array variables.");
     }
     if (std::type_index(typeid(InT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::transformReduce(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::transformReduce(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(InT).name());
     }
@@ -442,7 +435,7 @@ OutT HostAgentInstance::transformReduce(const std::string &variable, transformOp
 
 
 template<typename VarT>
-void HostAgentInstance::sort(const std::string &variable, Order order, int beginBit, int endBit) {
+void HostAgentAPI::sort(const std::string &variable, Order order, int beginBit, int endBit) {
     const unsigned int streamId = 0;
     auto &scatter = api.agentModel.singletons->scatter;
     auto &scan = scatter.Scan();
@@ -450,10 +443,10 @@ void HostAgentInstance::sort(const std::string &variable, Order order, int begin
     const auto &agentDesc = agent.getAgentDescription();
     const std::type_index typ = agentDesc.description->getVariableType(variable);  // This will throw name exception
     if (agentDesc.variables.at(variable).elements != 1) {
-        THROW UnsupportedVarType("HostAgentInstance::sort() does not support agent array variables.");
+        THROW UnsupportedVarType("HostAgentAPI::sort() does not support agent array variables.");
     }
     if (std::type_index(typeid(VarT)) != typ) {
-        THROW InvalidVarType("Wrong variable type passed to HostAgentInstance::sort(). "
+        THROW InvalidVarType("Wrong variable type passed to HostAgentAPI::sort(). "
             "This call expects '%s', but '%s' was requested.",
             agentDesc.variables.at(variable).type.name(), typeid(VarT).name());
     }
@@ -496,7 +489,7 @@ void HostAgentInstance::sort(const std::string &variable, Order order, int begin
 
 
 template<typename Var1T, typename Var2T>
-void HostAgentInstance::sort(const std::string &variable1, Order order1, const std::string &variable2, Order order2) {
+void HostAgentAPI::sort(const std::string &variable1, Order order1, const std::string &variable2, Order order2) {
     const unsigned int streamId = 0;
     auto &scatter = api.agentModel.singletons->scatter;
     auto &scan = scatter.Scan();
@@ -504,10 +497,10 @@ void HostAgentInstance::sort(const std::string &variable1, Order order1, const s
     {  // Check variable 1 is valid
         const std::type_index typ = agentDesc.description->getVariableType(variable1);  // This will throw name exception
         if (agentDesc.variables.at(variable1).elements != 1) {
-            THROW UnsupportedVarType("HostAgentInstance::sort() does not support agent array variables.");
+            THROW UnsupportedVarType("HostAgentAPI::sort() does not support agent array variables.");
         }
         if (std::type_index(typeid(Var1T)) != typ) {
-            THROW InvalidVarType("Wrong type for variable '%s' passed to HostAgentInstance::sort(). "
+            THROW InvalidVarType("Wrong type for variable '%s' passed to HostAgentAPI::sort(). "
                 "This call expects '%s', but '%s' was requested.",
                 variable1.c_str(), agentDesc.variables.at(variable1).type.name(), typeid(Var1T).name());
         }
@@ -515,10 +508,10 @@ void HostAgentInstance::sort(const std::string &variable1, Order order1, const s
     {  // Check variable 2 is valid
         const std::type_index typ = agentDesc.description->getVariableType(variable2);  // This will throw name exception
         if (agentDesc.variables.at(variable2).elements != 1) {
-            THROW UnsupportedVarType("HostAgentInstance::sort() does not support agent array variables.");
+            THROW UnsupportedVarType("HostAgentAPI::sort() does not support agent array variables.");
         }
         if (std::type_index(typeid(Var2T)) != typ) {
-            THROW InvalidVarType("Wrong type for variable '%s' passed to HostAgentInstance::sort(). "
+            THROW InvalidVarType("Wrong type for variable '%s' passed to HostAgentAPI::sort(). "
                 "This call expects '%s', but '%s' was requested.",
                 variable2.c_str(), agentDesc.variables.at(variable2).type.name(), typeid(Var2T).name());
         }
@@ -582,4 +575,4 @@ void HostAgentInstance::sort(const std::string &variable1, Order order1, const s
     // Scatter all agent variables
     api.agentModel.agent_map.at(agentDesc.name)->scatterSort(stateName, scatter, streamId, 0);  // @todo - use simulation specific stream.
 }
-#endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_AGENT_API_H_
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_HOSTAGENTAPI_H_

--- a/include/flamegpu/runtime/HostFunctionCallback.h
+++ b/include/flamegpu/runtime/HostFunctionCallback.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_HOSTFUNCTIONCALLBACK_H_
 #define INCLUDE_FLAMEGPU_RUNTIME_HOSTFUNCTIONCALLBACK_H_
 
-// class FLAMEGPU_HOST_API;
+// class HostAPI;
 
 class HostFunctionCallback {
   /**
@@ -9,7 +9,7 @@ class HostFunctionCallback {
    * This is mostly required to allow swig wrapping of host functions in a target language
    */
  public:
-    virtual void run(FLAMEGPU_HOST_API*) = 0;
+    virtual void run(HostAPI*) = 0;
     virtual ~HostFunctionCallback() {}
 };
 
@@ -20,7 +20,7 @@ class HostFunctionConditionCallback {
    * This is mostly required to allow swig wrapping of host functions in a target language
    */
  public:
-    virtual FLAME_GPU_CONDITION_RESULT run(FLAMEGPU_HOST_API*) = 0;
+    virtual FLAME_GPU_CONDITION_RESULT run(HostAPI*) = 0;
     virtual ~HostFunctionConditionCallback() {}
 };
 

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -55,7 +55,7 @@ struct VarOffsetStruct {
     }
 };
 /**
-* This struct provides a compact smemory store for storing generic variables in a single struct
+* This struct provides a compact memory store for storing generic variables in a single struct
 */
 struct NewAgentStorage {
     explicit NewAgentStorage(const VarOffsetStruct &v)
@@ -69,7 +69,8 @@ struct NewAgentStorage {
         memcpy(data, other.data, offsets.totalSize);
     }
     ~NewAgentStorage() {
-        free(data);
+        if (data)
+            free(data);
     }
     template<typename T>
     void setVariable(const std::string &var_name, const T &val) {
@@ -274,6 +275,10 @@ struct NewAgentStorage {
      * Used by CUDASimulation::processHostAgentCreation() which needs raw access to the data buffer
      */
     friend class CUDASimulation;
+    /**
+     * Used by DeviceAgentVector which needs raw access to the data buffer if a dependency requires it
+     */
+    friend class DeviceAgentVector_impl;
  private:
     char *const data;
     const VarOffsetStruct &offsets;

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -1,5 +1,5 @@
-#ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_NEW_AGENT_API_H_
-#define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_NEW_AGENT_API_H_
+#ifndef INCLUDE_FLAMEGPU_RUNTIME_HOSTNEWAGENTAPI_H_
+#define INCLUDE_FLAMEGPU_RUNTIME_HOSTNEWAGENTAPI_H_
 
 #include <unordered_map>
 #include <string>
@@ -282,24 +282,24 @@ struct NewAgentStorage {
 /**
  * This is the main API class used by a user for creating new agents on the host
  */
-class FLAMEGPU_HOST_NEW_AGENT_API {
+class HostNewAgentAPI {
  public:
     /**
      * Assigns a new agent it's storage
      */
-    explicit FLAMEGPU_HOST_NEW_AGENT_API(NewAgentStorage &_s)
+    explicit HostNewAgentAPI(NewAgentStorage &_s)
         : s(&_s) { }
     /**
      * Copy Constructor
      * This does not duplicate the agent, they both point to the same data, it updates the pointed to agent data
      */
-    FLAMEGPU_HOST_NEW_AGENT_API(const FLAMEGPU_HOST_NEW_AGENT_API &hna)
+    HostNewAgentAPI(const HostNewAgentAPI &hna)
         : s(hna.s) { }
     /**
      * Assignment Operator
      * This does not duplicate the agent, it updates the pointed to agent data
      */
-    FLAMEGPU_HOST_NEW_AGENT_API& operator=(const FLAMEGPU_HOST_NEW_AGENT_API &hna) {
+    HostNewAgentAPI& operator=(const HostNewAgentAPI &hna) {
         s = hna.s;
         return *this;
     }
@@ -311,7 +311,7 @@ class FLAMEGPU_HOST_NEW_AGENT_API {
     void setVariable(const std::string &var_name, const T &val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
-                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+                "in HostNewAgentAPI::setVariable().");
         }
         s->setVariable<T>(var_name, val);
     }
@@ -319,7 +319,7 @@ class FLAMEGPU_HOST_NEW_AGENT_API {
     void setVariable(const std::string &var_name, const std::array<T, N> &val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
-                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+                "in HostNewAgentAPI::setVariable().");
         }
         s->setVariable<T, N>(var_name, val);
     }
@@ -327,7 +327,7 @@ class FLAMEGPU_HOST_NEW_AGENT_API {
     void setVariable(const std::string &var_name, const unsigned int &index, const T &val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
-                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+                "in HostNewAgentAPI::setVariable().");
         }
         s->setVariable<T>(var_name, index, val);
     }
@@ -336,7 +336,7 @@ class FLAMEGPU_HOST_NEW_AGENT_API {
     void setVariableArray(const std::string &var_name, const std::vector<T> &val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
-                "in FLAMEGPU_HOST_NEW_AGENT_API::setVariable().");
+                "in HostNewAgentAPI::setVariable().");
         }
         s->setVariableArray<T>(var_name, val);
     }
@@ -368,4 +368,4 @@ class FLAMEGPU_HOST_NEW_AGENT_API {
     NewAgentStorage *s;
 };
 
-#endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_HOST_NEW_AGENT_API_H_
+#endif  // INCLUDE_FLAMEGPU_RUNTIME_HOSTNEWAGENTAPI_H_

--- a/include/flamegpu/runtime/flamegpu_api.h
+++ b/include/flamegpu/runtime/flamegpu_api.h
@@ -2,7 +2,7 @@
 #define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_
 
 #include "flamegpu/runtime/flamegpu_host_api.h"
-#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/runtime/HostAgentAPI.h"
 #include "flamegpu/runtime/flamegpu_device_api.h"
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_

--- a/include/flamegpu/runtime/flamegpu_api.h
+++ b/include/flamegpu/runtime/flamegpu_api.h
@@ -1,8 +1,8 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_
 #define INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_
 
-#include "flamegpu/runtime/flamegpu_host_api.h"
+#include "flamegpu/runtime/HostAPI.h"
 #include "flamegpu/runtime/HostAgentAPI.h"
-#include "flamegpu/runtime/flamegpu_device_api.h"
+#include "flamegpu/runtime/DeviceAPI.h"
 
 #endif  // INCLUDE_FLAMEGPU_RUNTIME_FLAMEGPU_API_H_

--- a/include/flamegpu/runtime/flamegpu_host_api.h
+++ b/include/flamegpu/runtime/flamegpu_host_api.h
@@ -12,10 +12,10 @@
 #include "flamegpu/runtime/utility/HostRandom.cuh"
 #include "flamegpu/runtime/utility/HostEnvironment.cuh"
 #include "flamegpu/runtime/flamegpu_host_api_macros.h"
-#include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
+#include "flamegpu/runtime/HostNewAgentAPI.h"
 
 class CUDASimulation;
-class HostAgentInstance;
+class HostAgentAPI;
 
 /**
  * @brief    A flame gpu api class for use by host functions only
@@ -26,7 +26,7 @@ class FLAMEGPU_HOST_API {
      * Requires internal access for resizeTempStorage()
      * @todo Could move this behaviour to a seperate singleton class 
      */
-    friend class HostAgentInstance;
+    friend class HostAgentAPI;
 
  public:
     // Typedefs repeated from CUDASimulation
@@ -50,14 +50,14 @@ class FLAMEGPU_HOST_API {
     /**
      * Returns methods that work on all agents of a certain type currently in a given state
      */
-    HostAgentInstance agent(const std::string &agent_name, const std::string &stateName = ModelData::DEFAULT_STATE);
+    HostAgentAPI agent(const std::string &agent_name, const std::string &stateName = ModelData::DEFAULT_STATE);
     /**
      * Creates a new agent of the named type and returns an object for configuring it's member variables
      * The agent is created in their initial state as defined in model description hierarchy
      * @param agent_name Name of the agent type to be created
      * @throws InvalidAgentName If an agent with the provided name does not exist withint he model description hierarchy
      */
-    FLAMEGPU_HOST_NEW_AGENT_API newAgent(const std::string &agent_name);
+    HostNewAgentAPI newAgent(const std::string &agent_name);
     /**
      * Creates a new agent of the named type and returns an object for configuring it's member variables
      * The agent is created in their initial state as defined in model description hierarchy
@@ -66,7 +66,7 @@ class FLAMEGPU_HOST_API {
      * @throws InvalidAgentName If an agent with the provided name does not exist withint he model description hierarchy
      * @throws InvalidStateName If state name does not apply to named agent
      */
-    FLAMEGPU_HOST_NEW_AGENT_API newAgent(const std::string &agent_name, const std::string &state);
+    HostNewAgentAPI newAgent(const std::string &agent_name, const std::string &state);
     /**
      * Host API access to seeded random number generation
      */

--- a/include/flamegpu/runtime/messaging.h
+++ b/include/flamegpu/runtime/messaging.h
@@ -27,13 +27,13 @@
  * Nested Classes:
  *  
  *  In:
- *  This is available to the user via the FLAMEGPU_DEVICE_API object passed into agent functions.
+ *  This is available to the user via the DeviceAPI object passed into agent functions.
  *  This class should provide users access to messages in the message list.
  *  
  *  It's only required methods are the format of the construtor, see None.h for example.
  *  
  *  Out:
- *  This is available to the user via the FLAMEGPU_DEVICE_API object passed into agent functions.
+ *  This is available to the user via the DeviceAPI object passed into agent functions.
  *  This class should provide users access to messages ouput functionality
  *  
  *  It's only required methods are the format of the construtor, see None.h for example.

--- a/include/flamegpu/runtime/messaging/Array/ArrayDevice.h
+++ b/include/flamegpu/runtime/messaging/Array/ArrayDevice.h
@@ -293,7 +293,7 @@ class MsgArray::In {
     const size_type length;
 };
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgArray is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgArray is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting array messages
  */
 class MsgArray::Out {

--- a/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.h
@@ -8,7 +8,7 @@
 
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgArray2D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_in if MsgArray2D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for reading array messages
  */
 class MsgArray2D::In {
@@ -322,7 +322,7 @@ class MsgArray2D::In {
 };
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgArray2D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgArray2D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting array messages
  */
 class MsgArray2D::Out {

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -7,7 +7,7 @@
 
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgArray3D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_in if MsgArray3D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for reading array messages
  */
 class MsgArray3D::In {
@@ -343,7 +343,7 @@ class MsgArray3D::In {
 };
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgArray3D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgArray3D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting array messages
  */
 class MsgArray3D::Out {

--- a/include/flamegpu/runtime/messaging/BruteForce/BruteForceDevice.h
+++ b/include/flamegpu/runtime/messaging/BruteForce/BruteForceDevice.h
@@ -7,7 +7,7 @@
 struct ModelData;
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgBruteForce is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_in if MsgBruteForce is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for reading brute force messages
  */
 class MsgBruteForce::In {
@@ -161,7 +161,7 @@ class MsgBruteForce::In {
 
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgBruteForce is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgBruteForce is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting brute force messages
  */
 class MsgBruteForce::Out {

--- a/include/flamegpu/runtime/messaging/Bucket/BucketDevice.h
+++ b/include/flamegpu/runtime/messaging/Bucket/BucketDevice.h
@@ -5,7 +5,7 @@
 #include "flamegpu/runtime/messaging/BruteForce/BruteForceDevice.h"
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgBucket is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_in if MsgBucket is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for reading bucket
  */
 class MsgBucket::In {
@@ -240,7 +240,7 @@ class MsgBucket::In {
 };
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgBucket is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgBucket is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting bucketed messages
  */
 class MsgBucket::Out : public MsgBruteForce::Out {

--- a/include/flamegpu/runtime/messaging/None/NoneDevice.h
+++ b/include/flamegpu/runtime/messaging/None/NoneDevice.h
@@ -10,7 +10,7 @@
 
 /**
  * Provides message input functionality during agent functions
- * Constructed and owned by FLAMEGPU_DEVICE_API
+ * Constructed and owned by DeviceAPI
  */
 class MsgNone::In {
  public:
@@ -24,7 +24,7 @@ class MsgNone::In {
 };
 /**
  * Provides message output functionality during agent functions
- * Constructed and owned by FLAMEGPU_DEVICE_API
+ * Constructed and owned by DeviceAPI
  */
 class MsgNone::Out {
  public:

--- a/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DDevice.h
@@ -6,7 +6,7 @@
 
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_in if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for reading spatially partitioned messages
  */
 class MsgSpatial2D::In {
@@ -249,7 +249,7 @@ class MsgSpatial2D::In {
 };
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting spatially partitioned messages
  */
 class MsgSpatial2D::Out : public MsgBruteForce::Out {

--- a/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
@@ -6,7 +6,7 @@
 #include "flamegpu/runtime/messaging/BruteForce/BruteForceDevice.h"
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_in if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_in if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for reading spatially partitioned messages
  */
 class MsgSpatial3D::In {
@@ -260,7 +260,7 @@ class MsgSpatial3D::In {
 };
 
 /**
- * This class is accessible via FLAMEGPU_DEVICE_API.message_out if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
+ * This class is accessible via DeviceAPI.message_out if MsgSpatial3D is specified in FLAMEGPU_AGENT_FUNCTION
  * It gives access to functionality for outputting spatially partitioned messages
  */
 class MsgSpatial3D::Out : public MsgBruteForce::Out {

--- a/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
@@ -24,7 +24,7 @@ class DeviceEnvironment {
     /**
      * Constructs the object
      */
-    friend class FLAMEGPU_READ_ONLY_DEVICE_API;
+    friend class ReadOnlyDeviceAPI;
     /**
      * Performs runtime validation that CURVE_NAMESPACE_HASH matches host value
      */

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -17,18 +17,18 @@
  * This class provides host function access to Environment Properties
  * It acts as a wrapper to EnvironmentManager, proxying calls, converting variable name and model_name into a combined hash
  * Pairs with EnvironmentManager, AgentEnvironment and EnvironmentDescription
- * This class is only to be constructed by FLAMEGPU_HOST_API
+ * This class is only to be constructed by HostAPI
  * @note Not thread-safe
  */
 class HostEnvironment {
     /**
-     * This class can only be constructed by FLAMEGPU_HOST_API
+     * This class can only be constructed by HostAPI
      */
-    friend class FLAMEGPU_HOST_API;
+    friend class HostAPI;
 
  protected:
     /**
-     * Constructor, to be called by FLAMEGPU_HOST_API
+     * Constructor, to be called by HostAPI
      */
     explicit HostEnvironment(const unsigned int &instance_id);
     /**

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -9,10 +9,10 @@
 /**
 * Utility for accessing random generation within host functions
 * This is prefered over using std random, as it uses a common seed with the device random
-* This should only be instantiated by FLAMEGPU_HOST_API
+* This should only be instantiated by HostAPI
 */
 class HostRandom {
-    friend class FLAMEGPU_HOST_API;
+    friend class HostAPI;
  public:
     /**
     * Returns a float uniformly distributed between 0.0 and 1.0.

--- a/include/flamegpu/sim/AgentLoggingConfig.h
+++ b/include/flamegpu/sim/AgentLoggingConfig.h
@@ -9,7 +9,7 @@
 
 #include "flamegpu/sim/LoggingConfig.h"
 #include "flamegpu/sim/AgentLoggingConfig_Reductions.cuh"
-#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/runtime/HostAgentAPI.h"
 
 struct ModelData;
 
@@ -121,24 +121,24 @@ template <typename T> struct sum_input_t { typedef T result_t; };
  *  this runs on the host as an init/step/exit or host layer function
  */
 template<typename T>
-Any getAgentVariableMeanFunc(HostAgentInstance &ai, const std::string &variable_name) {
+Any getAgentVariableMeanFunc(HostAgentAPI &ai, const std::string &variable_name) {
     return Any(ai.sum<T, typename sum_input_t<T>::result_t>(variable_name) / static_cast<double>(ai.count()));
 }
 template<typename T>
-Any getAgentVariableSumFunc(HostAgentInstance &ai, const std::string &variable_name) {
+Any getAgentVariableSumFunc(HostAgentAPI &ai, const std::string &variable_name) {
     return Any(ai.sum<T, typename sum_input_t<T>::result_t>(variable_name));
 }
 template<typename T>
-Any getAgentVariableMinFunc(HostAgentInstance &ai, const std::string &variable_name) {
+Any getAgentVariableMinFunc(HostAgentAPI &ai, const std::string &variable_name) {
     return Any(ai.min<T>(variable_name));
 }
 template<typename T>
-Any getAgentVariableMaxFunc(HostAgentInstance &ai, const std::string &variable_name) {
+Any getAgentVariableMaxFunc(HostAgentAPI &ai, const std::string &variable_name) {
     return Any(ai.max<T>(variable_name));
 }
 
 template<typename T>
-Any getAgentVariableStandardDevFunc(HostAgentInstance &ai, const std::string &variable_name) {
+Any getAgentVariableStandardDevFunc(HostAgentAPI &ai, const std::string &variable_name) {
     // Todo, workout how to make this more multi-thread/deviceable.
     // Todo, streams for the memcpy?
     // Work out the Mean

--- a/include/flamegpu/sim/LoggingConfig.h
+++ b/include/flamegpu/sim/LoggingConfig.h
@@ -7,7 +7,7 @@
 #include <utility>
 #include <memory>
 
-#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/runtime/HostAgentAPI.h"
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/gpu/CUDAEnsemble.h"
 
@@ -49,7 +49,7 @@ class LoggingConfig {
         }
     }
     typedef std::pair<std::string, std::string> NameStatePair;
-    typedef Any (ReductionFn)(HostAgentInstance &ai, const std::string &variable_name);
+    typedef Any (ReductionFn)(HostAgentAPI &ai, const std::string &variable_name);
     struct NameReductionFn {
         std::string name;
         Reduction reduction;

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -10,7 +10,7 @@
 #include "flamegpu/sim/AgentInterface.h"
 
 class AgentVector;
-class FLAMEGPU_HOST_API;
+class HostAPI;
 class ModelDescription;
 struct ModelData;
 struct RunLog;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,8 +134,8 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_device_api.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_host_api.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_host_api_macros.h
-    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_host_agent_api.h
-    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_host_new_agent_api.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostAgentAPI.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostNewAgentAPI.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/cuRVE/curve.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/cuRVE/curve_rtc.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/messaging.h
@@ -225,7 +225,7 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_api.cu
-    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_agent_api.cu 
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/HostAgentAPI.cu 
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/BruteForce.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial2D.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial3D.cu

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,9 +131,9 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/AgentFunctionCondition_shim.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostFunctionCallback.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_api.h
-    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_device_api.h
-    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_host_api.h
-    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/flamegpu_host_api_macros.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/DeviceAPI.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostAPI.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostAPI_macros.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostAgentAPI.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/HostNewAgentAPI.h
     ${FLAMEGPU_ROOT}/include/flamegpu/runtime/cuRVE/curve.h
@@ -224,7 +224,7 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/sim/Simulation.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/cuRVE/curve_rtc.cpp
-    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/flamegpu_host_api.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/runtime/HostAPI.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/HostAgentAPI.cu 
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/BruteForce.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/Spatial2D.cu

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,8 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/pop/AgentVector.h
     ${FLAMEGPU_ROOT}/include/flamegpu/pop/AgentVector_Agent.h
     ${FLAMEGPU_ROOT}/include/flamegpu/pop/AgentInstance.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/pop/DeviceAgentVector.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/pop/DeviceAgentVector_impl.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAScanCompaction.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAErrorChecking.h
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAMessageList.h
@@ -204,6 +206,7 @@ SET(SRC_FLAMEGPU2
     ${FLAMEGPU_ROOT}/src/flamegpu/pop/AgentVector.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/pop/AgentVector_Agent.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/pop/AgentInstance.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/pop/DeviceAgentVector_impl.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAScanCompaction.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAMessageList.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/gpu/CUDAAgent.cu

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -119,7 +119,7 @@ void CUDAAgentStateList::getAgentData(AgentVector& population) const {
     }
     const unsigned int data_count = getSize();
     if (data_count) {
-        population.resize(data_count, false);
+        population.internal_resize(data_count, false);
         // Copy across the required data device->host
         for (auto& _var : variables) {
             // get the variable size from agent description
@@ -245,6 +245,21 @@ void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned i
         }
     }
 }
+void CUDAAgentStateList::initExcludedVars(const unsigned int& count, const unsigned int& offset, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream) {
+    std::set<std::shared_ptr<VariableBuffer>> exclusionSet;
+    for (auto& a : variables)
+        exclusionSet.insert(a.second);
+    parent_list->initVariables(exclusionSet, count, offset, scatter, streamId, stream);
+}
 void CUDAAgentStateList::clear() {
     parent_list->setAgentCount(0, true);
+}
+void CUDAAgentStateList::setAgentCount(const unsigned int& newSize) {
+    parent_list->setAgentCount(newSize, false);
+}
+std::list<std::shared_ptr<VariableBuffer>> CUDAAgentStateList::getUnboundVariableBuffers() {
+    std::set<std::shared_ptr<VariableBuffer>> exclusionSet;
+    for (auto& a : variables)
+        exclusionSet.insert(a.second);
+    return parent_list->getBuffers(exclusionSet);
 }

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -8,7 +8,7 @@
 #include "flamegpu/pop/AgentVector.h"
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/gpu/CUDAScatter.h"
-#include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
+#include "flamegpu/runtime/HostNewAgentAPI.h"
 #include "flamegpu/exception/FGPUException.h"
 
 #ifdef _MSC_VER

--- a/src/flamegpu/gpu/CUDAFatAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAFatAgentStateList.cu
@@ -73,7 +73,6 @@ void CUDAFatAgentStateList::resize(const unsigned int &minSize, const bool &reta
     unsigned int newSize = bufferLen > 1024 ? bufferLen : 1024;
     while (newSize < minSize)
         newSize = static_cast<unsigned int>(newSize * 1.25f);
-
     // Resize all buffers in fat state list
     for (auto &buff : variables_unique) {
         const size_t var_size = buff->type_size * buff->elements;
@@ -246,4 +245,13 @@ void CUDAFatAgentStateList::swap(CUDAFatAgentStateList*other) {
     for (auto a = variables_unique.begin(), b=other->variables_unique.begin(); a != variables_unique.end() && b != other->variables_unique.end(); ++a, ++b) {
         (*a)->swap(b->get());
     }
+}
+std::list<std::shared_ptr<VariableBuffer>> CUDAFatAgentStateList::getBuffers(std::set<std::shared_ptr<VariableBuffer>>& exclusionSet) {
+    std::list<std::shared_ptr<VariableBuffer>> returnVars;
+    for (const auto& v : variables_unique) {
+        if (exclusionSet.find(v) == exclusionSet.end()) {
+            returnVars.push_back(v);
+        }
+    }
+    return returnVars;
 }

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -10,7 +10,7 @@
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/model/SubModelData.h"
 #include "flamegpu/model/SubAgentData.h"
-#include "flamegpu/runtime/flamegpu_host_api.h"
+#include "flamegpu/runtime/HostAPI.h"
 #include "flamegpu/gpu/CUDAScanCompaction.h"
 #include "flamegpu/util/nvtx.h"
 #include "flamegpu/util/compute_capability.cuh"
@@ -1260,7 +1260,7 @@ void CUDASimulation::initialiseSingletons() {
         singletons->rng.reseed(getSimulationConfig().random_seed);
 
         // Pass created RandomManager to host api
-        host_api = std::make_unique<FLAMEGPU_HOST_API>(*this, singletons->rng, agentOffsets, agentData);
+        host_api = std::make_unique<HostAPI>(*this, singletons->rng, agentOffsets, agentData);
 
         for (auto &cm : message_map) {
             cm.second->init(singletons->scatter, 0);

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1260,7 +1260,7 @@ void CUDASimulation::initialiseSingletons() {
         singletons->rng.reseed(getSimulationConfig().random_seed);
 
         // Pass created RandomManager to host api
-        host_api = std::make_unique<HostAPI>(*this, singletons->rng, agentOffsets, agentData);
+        host_api = std::make_unique<HostAPI>(*this, singletons->rng, singletons->scatter, agentOffsets, agentData, 0, getStream(0));  // Host fns are currently all serial
 
         for (auto &cm : message_map) {
             cm.second->init(singletons->scatter, 0);
@@ -1629,7 +1629,7 @@ void CUDASimulation::createStreams(const unsigned int nStreams) {
 
 cudaStream_t CUDASimulation::getStream(const unsigned int n) {
     // Return the appropriate stream, unless concurrency is disabled in which case always stream 0.
-    if (this->streams.size() < n) {
+    if (this->streams.size() <= n) {
         unsigned int nStreams = getMaximumLayerWidth();
         this->createStreams(nStreams);
     }

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1562,7 +1562,7 @@ void CUDASimulation::processStepLog() {
         // Create the named sub map
         const std::string &agent_name = name_state.first.first;
         const std::string &agent_state = name_state.first.second;
-        HostAgentInstance host_agent = host_api->agent(agent_name, agent_state);
+        HostAgentAPI host_agent = host_api->agent(agent_name, agent_state);
         auto &agent_state_log = agents_log.emplace(name_state.first, std::make_pair(std::map<LoggingConfig::NameReductionFn, Any>(), UINT_MAX)).first->second;
         // Log individual variable reductions
         for (const auto &name_reduction : *name_state.second.first) {
@@ -1595,7 +1595,7 @@ void CUDASimulation::processExitLog() {
         // Create the named sub map
         const std::string &agent_name = name_state.first.first;
         const std::string &agent_state = name_state.first.second;
-        HostAgentInstance host_agent = host_api->agent(agent_name, agent_state);
+        HostAgentAPI host_agent = host_api->agent(agent_name, agent_state);
         auto &agent_state_log = agents_log.emplace(name_state.first, std::make_pair(std::map<LoggingConfig::NameReductionFn, Any>(), UINT_MAX)).first->second;
         // Log individual variable reductions
         for (const auto &name_reduction : *name_state.second.first) {

--- a/src/flamegpu/model/AgentFunctionDescription.cpp
+++ b/src/flamegpu/model/AgentFunctionDescription.cpp
@@ -371,7 +371,7 @@ void AgentFunctionDescription::setRTCFunctionCondition(std::string func_cond_src
     }
 
     // append jitify program string and include
-    std::string func_cond_src_str = std::string(func_cond_name + "_program\n").append("#include \"flamegpu/runtime/flamegpu_device_api.h\"\n").append(func_cond_src);
+    std::string func_cond_src_str = std::string(func_cond_name + "_program\n").append("#include \"flamegpu/runtime/DeviceAPI.h\"\n").append(func_cond_src);
 
     // update the agent function data
     function->rtc_func_condition_name = func_cond_name;
@@ -466,7 +466,7 @@ bool AgentFunctionDescription::isRTC() const {
 AgentFunctionDescription& AgentDescription::newRTCFunction(const std::string& function_name, const char* func_src) {
     if (agent->functions.find(function_name) == agent->functions.end()) {
         // append jitify program string and include
-        std::string func_src_str = std::string(function_name + "_program\n").append("#include \"flamegpu/runtime/flamegpu_device_api.h\"\n").append(func_src);
+        std::string func_src_str = std::string(function_name + "_program\n").append("#include \"flamegpu/runtime/DeviceAPI.h\"\n").append(func_src);
         // Use Regex to get agent function name, and input/output message type
         std::regex rgx(R"###(.*FLAMEGPU_AGENT_FUNCTION\([ \t]*(\w+),[ \t]*(\w+),[ \t]*(\w+)[ \t]*\))###");
         std::smatch match;

--- a/src/flamegpu/pop/AgentVector_Agent.cpp
+++ b/src/flamegpu/pop/AgentVector_Agent.cpp
@@ -1,10 +1,11 @@
 #include "flamegpu/pop/AgentVector_Agent.h"
 
-AgentVector_CAgent::AgentVector_CAgent(const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, AgentVector::size_type pos)
+AgentVector_CAgent::AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, AgentVector::size_type pos)
     : index(pos)
     , _data(data)
-    , _agent(agent) { }
+    , _agent(agent)
+, _parent(parent) { }
 AgentVector_CAgent::~AgentVector_CAgent() {
 }
-AgentVector_Agent::AgentVector_Agent(const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, AgentVector::size_type pos)
-    : AgentVector_CAgent(agent, data, pos) { }
+AgentVector_Agent::AgentVector_Agent(AgentVector *parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, AgentVector::size_type pos)
+    : AgentVector_CAgent(parent, agent, data, pos) { }

--- a/src/flamegpu/pop/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/pop/DeviceAgentVector_impl.cu
@@ -1,0 +1,398 @@
+#include "flamegpu/pop/DeviceAgentVector_impl.h"
+#include "flamegpu/gpu/CUDAAgent.h"
+
+/**
+ * Pair of a host-backed device buffer
+ * This allows transactions which impact master-agent unbound variables to work correctly
+ */
+
+DeviceAgentVector_impl::DeviceAgentVector_impl(CUDAAgent& _cuda_agent, const std::string &_cuda_agent_state,
+    const VarOffsetStruct& _agentOffsets, std::vector<NewAgentStorage>& _newAgentData,
+    CUDAScatter& _scatter, const unsigned int& _streamId, const cudaStream_t& _stream)
+    : AgentVector(_cuda_agent.getAgentDescription(), 0)
+    , unbound_buffers_has_changed(false)
+    , known_device_buffer_size(_cuda_agent.getStateSize(_cuda_agent_state))
+    , cuda_agent(_cuda_agent)
+    , cuda_agent_state(_cuda_agent_state)
+    , agentOffsets(_agentOffsets)
+    , newAgentData(_newAgentData)
+    , scatter(_scatter)
+    , streamId(_streamId)
+    , stream(_stream) {
+    // Create an empty AgentVector and initialise it manually
+    // For each variable create an uninitialised array of variable data
+    _size = known_device_buffer_size;
+    internal_resize(_size, false);
+    // Mark all variables as Invalid
+    for (const auto& v : agent->variables)
+        invalid_variables.insert(v.first);
+    // Grab the unbound variable buffers from the CUDAFatAgentStateList
+    // Leave their host counterparts de-allocated until required
+    {
+        const auto buffs = cuda_agent.getUnboundVariableBuffers(cuda_agent_state);
+        for (auto &d_buff : buffs)
+            unbound_buffers.emplace_back(d_buff);
+        unbound_host_buffer_invalid = true;
+    }
+}
+
+void DeviceAgentVector_impl::syncChanges() {
+    // Resize device buffers if necessary
+    const unsigned int old_allocated_size = cuda_agent.getStateAllocatedSize(cuda_agent_state);
+    if (_size > old_allocated_size) {
+        const unsigned int old_size = cuda_agent.getStateSize(cuda_agent_state);
+        // Resize the underlying variable buffers for this agent state and retain variable data
+        cuda_agent.resizeState(cuda_agent_state, _size, true);  // @todo Don't retain data for mapped buffers?
+        // Init agent data for any variables of newly created agents which are only present in a parent model
+        const unsigned int new_allocated_size = cuda_agent.getStateAllocatedSize(cuda_agent_state);
+        // This call does not use streams properly internally
+        cuda_agent.initExcludedVars(cuda_agent_state, new_allocated_size - old_size, old_size, scatter, streamId, stream);
+    }
+    _requireLength();
+    // Copy all changes back to device
+    for (const auto &ch : change_detail) {
+        auto &v = agent->variables.at(ch.first);
+        // Copy back variable data into each array
+        const char* host_src = static_cast<const char*>(_data->at(ch.first)->getDataPtr());
+        char* device_dest = static_cast<char*>(cuda_agent.getStateVariablePtr(cuda_agent_state, ch.first));
+        const size_t copy_offset = ch.second.first * v.type_size * v.elements;
+        const size_t copy_len = (ch.second.second - ch.second.first) * v.type_size * v.elements;
+        gpuErrchk(cudaMemcpyAsync(device_dest + copy_offset, host_src + copy_offset, copy_len, cudaMemcpyHostToDevice, stream));
+    }
+    change_detail.clear();
+    // Copy all unbound buffes
+    if (unbound_buffers_has_changed) {
+        if (unbound_host_buffer_size != _size) {
+            THROW InvalidOperation("Unbound buffers have gone out of sync, in DeviceAgentVector::syncChanges().\n");
+        }
+        for (auto &buff : unbound_buffers) {
+            const size_t variable_size = buff.device->type_size * buff.device->elements;
+            gpuErrchk(cudaMemcpyAsync(buff.device->data, buff.host, unbound_host_buffer_size * variable_size, cudaMemcpyHostToDevice, stream));
+        }
+        unbound_buffers_has_changed = false;
+    }
+    gpuErrchk(cudaStreamSynchronize(stream));
+    // Update CUDAAgent statelist size
+    cuda_agent.setStateAgentCount(cuda_agent_state, _size);
+}
+void DeviceAgentVector_impl::purgeCache() {
+    _size = cuda_agent.getStateSize(cuda_agent_state);
+    // All variables are now invalid
+    for (const auto& v : agent->variables)
+        invalid_variables.insert(v.first);
+    // Mark all unbound host buffers as requiring update
+    unbound_host_buffer_invalid = false;
+    unbound_host_buffer_size = 0;
+    known_device_buffer_size = cuda_agent.getStateSize(cuda_agent_state);
+    unbound_buffers_has_changed = false;
+}
+
+void DeviceAgentVector_impl::initUnboundBuffers() {
+    if (!_capacity)
+      return;
+    const unsigned int device_len = cuda_agent.getStateSize(cuda_agent_state);
+    const unsigned int copy_len = _size < device_len ? _size : device_len;
+    // Resize to match _capacity
+    for (auto &buff : unbound_buffers) {
+        if (buff.host) {
+            THROW InvalidOperation("Host buffer is already allocated, in DeviceAgentVector::initUnboundBuffers().\n");
+        }
+        // Alloc
+        const size_t var_size = buff.device->type_size * buff.device->elements;
+        buff.host = static_cast<char*>(malloc(_capacity * var_size));
+        // DtH memcpy
+        gpuErrchk(cudaMemcpyAsync(buff.host, buff.device->data, copy_len * var_size, cudaMemcpyDeviceToHost, stream));
+        // Not sure this will ever happen, but better safe
+        for (unsigned int i = device_len; i < _size; ++i) {
+            // We have unknown agents, default init them
+            memcpy(buff.host + i * var_size, buff.device->default_value, var_size);
+        }
+    }
+    gpuErrchk(cudaStreamSynchronize(stream));
+    unbound_host_buffer_capacity = _capacity;
+    unbound_host_buffer_size = copy_len;
+    unbound_buffers_has_changed = true;  // Probably not required, but if they are being init, high chance they're going to be changed
+    unbound_host_buffer_invalid = false;
+}
+void DeviceAgentVector_impl::reinitUnboundBuffers() {
+    const unsigned int device_len = cuda_agent.getStateSize(cuda_agent_state);
+    const unsigned int copy_len = _size;
+    if (device_len > _size) {
+        THROW InvalidOperation("Unexpected state, in DeviceAgentVector::reinitUnboundBuffers()\n");
+    }
+    // Resize to match _capacity
+    for (auto& buff : unbound_buffers) {
+        if (!buff.host) {
+            THROW InvalidOperation("Host buffer is not already allocated, in DeviceAgentVector::reinitUnboundBuffers().\n");
+        }
+        const size_t var_size = buff.device->type_size * buff.device->elements;
+        if (unbound_host_buffer_capacity < _capacity) {
+            free(buff.host);
+            // Alloc
+            buff.host = static_cast<char*>(malloc(_capacity * var_size));
+        }
+        // DtH memcpy
+        gpuErrchk(cudaMemcpyAsync(buff.host, buff.device->data, copy_len * var_size, cudaMemcpyDeviceToHost, stream));
+        // Not sure this will ever happen, but better safe
+        for (unsigned int i = device_len; i < _size; ++i) {
+            // We have unknown agents, default init them
+            memcpy(buff.host + i * var_size, buff.device->default_value, var_size);
+        }
+    }
+    gpuErrchk(cudaStreamSynchronize(stream));
+    unbound_host_buffer_capacity = unbound_host_buffer_capacity < _capacity ?_capacity : unbound_host_buffer_capacity;
+    unbound_host_buffer_size = copy_len;
+    unbound_buffers_has_changed = true;  // Probably not required, but if they are being init, high chance they're going to be changed
+    unbound_host_buffer_invalid = false;
+}
+void DeviceAgentVector_impl::resizeUnboundBuffers(const unsigned int& new_capacity, bool init) {
+    // Resize to match agent_count
+    for (auto& buff : unbound_buffers) {
+        if (!buff.host) {
+            THROW InvalidOperation("Not setup to resize before init");
+        }
+        // Alloc new buff
+        const size_t var_size = buff.device->type_size * buff.device->elements;
+        char *t = static_cast<char*>(malloc(new_capacity * var_size));
+        // Copy data across
+        const unsigned int copy_len = _size < unbound_host_buffer_capacity ? _size : unbound_host_buffer_capacity;
+        memcpy(t, buff.host, copy_len * var_size);
+        // Free old
+        free(buff.host);
+        // Replace old ptr
+        buff.host = t;
+        if (init) {
+            for (unsigned int i = unbound_host_buffer_capacity; i < new_capacity; ++i) {
+                // We have unknown agents, default init them
+                memcpy(buff.host + i * var_size, buff.device->default_value, var_size);
+            }
+        }
+    }
+    unbound_host_buffer_capacity = new_capacity;
+    // unbound_host_buffer_size = agent_count;  // This would only make sense for init, but consisent behaviour is better
+    unbound_buffers_has_changed = true;  // Probably not required, but if they are resized, high chance theyre going to change
+}
+
+void DeviceAgentVector_impl::_insert(size_type pos, size_type count) {
+    // No unbound buffers, return
+    if (unbound_buffers.empty() || !count)
+        return;
+    // Unbound buffers first use, init
+    // This updates unbound_host_buffer_size to match known_device_buffer_size
+    if (!unbound_host_buffer_capacity)
+        initUnboundBuffers();
+    // Resizes unbound buffers if necessary
+    const size_type new_size = known_device_buffer_size + count;
+    if (new_size > unbound_host_buffer_capacity) {
+        resizeUnboundBuffers(_capacity, false);
+        // Init new agents that won't be init by the replacement below
+        for (auto& buff : unbound_buffers) {
+            const size_t variable_size = buff.device->type_size * buff.device->elements;
+            for (unsigned int i = new_size; i < _capacity; ++i) {
+                memcpy(buff.host + i * variable_size, buff.device->default_value, variable_size);
+            }
+        }
+    }
+    if (unbound_host_buffer_invalid) {
+        // Redownload unbound buffers from device
+        reinitUnboundBuffers();
+    }
+    //  Move all items behind pos, then init all the newly inserted
+    for (auto& buff : unbound_buffers) {
+        const size_t variable_size = buff.device->type_size * buff.device->elements;
+        // Move all items after this index backwards count places
+        for (unsigned int i = known_device_buffer_size - 1; i >= pos; --i) {
+            // Copy items individually, incase the src and destination overlap
+            memcpy(buff.host + (i + count) * variable_size, buff.host + i * variable_size, variable_size);
+        }
+        // Default init the inserted variables
+        for (unsigned int i = pos; i < pos + count; ++i) {
+            memcpy(buff.host + i * variable_size, buff.device->default_value, variable_size);
+        }
+    }
+    // Update size
+    unbound_buffers_has_changed = true;
+    unbound_host_buffer_size = new_size;
+    known_device_buffer_size = _size;
+    if (unbound_host_buffer_size != _size) {
+        THROW InvalidOperation("Unbound buffers have gone out of sync, in DeviceAgentVector::_insert().\n");
+    }
+    // Update change detail for all variables
+    for (const auto& v : agent->variables) {
+        // Does it exist in change map
+        auto change = change_detail.find(v.first);
+        if (change == change_detail.end()) {
+            change_detail.emplace(v.first, std::pair<size_type, size_type>{pos, _size});
+        } else {
+            // Inclusive min bound
+            change->second.first = change->second.first > pos ? pos : change->second.first;
+            // Exclusive max bound
+            change->second.second = _size;
+        }
+    }
+}
+void DeviceAgentVector_impl::_erase(size_type pos, size_type count) {
+    // No unbound buffers, return
+    if (unbound_buffers.empty() || !count)
+        return;
+    // Unbound buffers first use, init
+    if (!unbound_host_buffer_capacity)
+        initUnboundBuffers();
+    if (unbound_host_buffer_invalid) {
+        // Redownload unbound buffers from device
+        reinitUnboundBuffers();
+    }
+    const size_type new_size = known_device_buffer_size - count;
+    const size_type copy_start = pos + count;
+    for (auto& buff : unbound_buffers) {
+        const size_t variable_size = buff.device->type_size * buff.device->elements;
+        // Move all items after this index forwards count places
+        for (unsigned int i = copy_start; i < unbound_host_buffer_size; ++i) {
+            // Copy items individually, incase the src and destination overlap
+            memcpy(buff.host + (i - count) * variable_size, buff.host + i * variable_size, variable_size);
+        }
+        // Default init the empty variables at the end
+        for (unsigned int i = new_size; i < known_device_buffer_size; ++i) {
+            memcpy(buff.host + i * variable_size, buff.device->default_value, variable_size);
+        }
+    }
+    // Update size
+    unbound_buffers_has_changed = true;
+    unbound_host_buffer_size = new_size;
+    known_device_buffer_size = _size;
+    if (unbound_host_buffer_size != _size) {
+        THROW InvalidOperation("Unbound buffers have gone out of sync, in DeviceAgentVector::_erase().\n");
+    }
+    // Update change detail for all variables
+    for (const auto &v : agent->variables) {
+        // Does it exist in change map
+        auto change = change_detail.find(v.first);
+        if (change == change_detail.end()) {
+            change_detail.emplace(v.first, std::pair<size_type, size_type>{pos, _size});
+        } else {
+            // Inclusive min bound
+            change->second.first = change->second.first > pos ? pos : change->second.first;
+            // Exclusive max bound
+            change->second.second = _size;
+        }
+    }
+}
+
+
+void DeviceAgentVector_impl::_changed(const std::string& variable_name, size_type pos) {
+    // Check the variable exists
+    auto var = agent->variables.find(variable_name);
+    if (var == agent->variables.end()) {
+        THROW InvalidAgentVar("Variable %s was not found, "
+            "in DeviceAgentVector::_changed()\n",
+            variable_name.c_str());
+    }
+    // Does it exist in change map
+    auto change = change_detail.find(variable_name);
+    if (change == change_detail.end()) {
+        change_detail.emplace(variable_name, std::pair<size_type, size_type>{pos, pos + 1});
+    } else {
+        // Inclusive min bound
+        change->second.first = change->second.first > pos ? pos : change->second.first;
+        // Exclusive max bound
+        change->second.second = change->second.second <= pos ? pos + 1 : change->second.second;
+    }
+}
+void DeviceAgentVector_impl::_changedAfter(const std::string& variable_name, size_type pos) {
+    // Check the variable exists
+    auto var = agent->variables.find(variable_name);
+    if (var == agent->variables.end()) {
+        THROW InvalidAgentVar("Variable %s was not found, "
+            "in DeviceAgentVector::_changed()\n",
+            variable_name.c_str());
+    }
+    // Does it exist in change map
+    auto change = change_detail.find(variable_name);
+    if (change == change_detail.end()) {
+        change_detail.emplace(variable_name, std::pair<size_type, size_type>{pos, _size});
+    } else {
+        // Inclusive min bound
+        change->second.first = change->second.first > pos ? pos : change->second.first;
+        // Exclusive max bound
+        change->second.second = _size;
+    }
+}
+void DeviceAgentVector_impl::_require(const std::string& variable_name) const {
+    if (invalid_variables.find(variable_name) !=invalid_variables.end()) {
+        const auto& v = agent->variables.at(variable_name);
+        // Copy back variable data into array
+        void* host_dest = _data->at(variable_name)->getDataPtr();
+        const void* device_src = cuda_agent.getStateVariablePtr(cuda_agent_state, variable_name);
+        gpuErrchk(cudaMemcpyAsync(host_dest, device_src, _size * v.type_size * v.elements, cudaMemcpyDeviceToHost, stream));
+        if (_capacity > _size) {
+            // Default-init remaining buffer space
+            const auto it = _data->find(variable_name);
+            const size_t variable_size = v.type_size * v.elements;
+            char* t_data = static_cast<char*>(it->second->getDataPtr());
+            for (unsigned int i = _size; i < _capacity; ++i) {
+                memcpy(t_data + i * variable_size, v.default_value, variable_size);
+            }
+        }
+        // The invalid variable is now current
+        invalid_variables.erase(variable_name);
+        gpuErrchk(cudaStreamSynchronize(stream));
+    }
+}
+void DeviceAgentVector_impl::_requireAll() const {
+    for (const auto& vn : invalid_variables) {
+        const auto &v = agent->variables.at(vn);
+        // Copy back variable data into array
+        void* host_dest = _data->at(vn)->getDataPtr();
+        const void* device_src = cuda_agent.getStateVariablePtr(cuda_agent_state, vn);
+        gpuErrchk(cudaMemcpyAsync(host_dest, device_src, _size * v.type_size * v.elements, cudaMemcpyDeviceToHost, stream));
+    }
+    // Perform the cuda ops in a separate loop to host inits, gives a slight bit of time to eat latency
+    for (const auto& vn : invalid_variables) {
+        if (_capacity > _size) {
+            const auto& v = agent->variables.at(vn);
+            // Default-init remaining buffer space
+            const auto it = _data->find(vn);
+            const size_t variable_size = v.type_size * v.elements;
+            char* t_data = static_cast<char*>(it->second->getDataPtr());
+            for (unsigned int i = _size; i < _capacity; ++i) {
+                memcpy(t_data + i * variable_size, v.default_value, variable_size);
+            }
+        }
+    }
+    // All invalid variables are now current
+    invalid_variables.clear();
+    gpuErrchk(cudaStreamSynchronize(stream));
+}
+void DeviceAgentVector_impl::_requireLength() const {
+    /**
+     * This method is a nightmare, as it needs to be const, so can't call non-const untility methods
+     * Copy the implementations was bad, so I just decided to abuse const cast instead
+     */
+    if (newAgentData.empty())
+        return;
+    if (_size + newAgentData.size() > _capacity) {
+        // BEGIN: Re implementation of AgentVector::resize(size_type, bool)
+        // Can't call it here, as would have huge knock-on effects to which methods can/can't be const
+        const_cast<DeviceAgentVector_impl*>(this)->internal_resize(_size + static_cast<size_type>(newAgentData.size()), false);
+        // END: Re implementation of AgentVector::resize(size_type, bool)
+    }
+    _requireAll();
+    // Check if host new agent has any agents
+    for (auto &newAgent : newAgentData) {
+        // Manually insert them to device agent vector
+        for (auto &v : agentOffsets.vars) {
+            char* dst = static_cast<char*>(_data->at(v.first)->getDataPtr()) + _size * v.second.len;
+            const char * src = newAgent.data + v.second.offset;
+            memcpy(dst, src, v.second.len);
+        }
+        // Increase size
+        ++_size;
+    }
+    // This updates unbound buffers
+    // BEGIN: Re implementation of DeviceAgentVector_t::_insert(size_type, size_type)
+    // Can't call it here, as would have huge knock-on effects to which methods can/can't be const
+    const_cast<DeviceAgentVector_impl*>(this)->_insert(_size - static_cast<size_type>(newAgentData.size()), static_cast<size_type>(newAgentData.size()));
+    // END: Re implementation of DeviceAgentVector_t::_insert(size_type, size_type)
+    newAgentData.clear();
+}
+

--- a/src/flamegpu/runtime/HostAPI.cu
+++ b/src/flamegpu/runtime/HostAPI.cu
@@ -6,9 +6,12 @@
 #include "flamegpu/gpu/CUDASimulation.h"
 
 HostAPI::HostAPI(CUDASimulation &_agentModel,
-    RandomManager &rng,
+    RandomManager& rng,
+    CUDAScatter &_scatter,
     const AgentOffsetMap &_agentOffsets,
-    AgentDataMap &_agentData)
+    AgentDataMap &_agentData,
+    const unsigned int& _streamId,
+    cudaStream_t _stream)
     : random(rng)
     , environment(_agentModel.getInstanceID())
     , agentModel(_agentModel)
@@ -17,7 +20,10 @@ HostAPI::HostAPI(CUDASimulation &_agentModel,
     , d_output_space(nullptr)
     , d_output_space_size(0)
     , agentOffsets(_agentOffsets)
-    , agentData(_agentData) { }
+    , agentData(_agentData)
+    , scatter(_scatter)
+    , streamId(_streamId)
+    , stream(_stream) { }
 
 HostAPI::~HostAPI() {
     // @todo - cuda is not allowed in destructor
@@ -31,41 +37,16 @@ HostAPI::~HostAPI() {
     }
 }
 
-HostAgentAPI HostAPI::agent(const std::string &agent_name, const std::string &stateName) {
-    return HostAgentAPI(*this, agentModel.getAgent(agent_name), stateName);
-}
-
-HostNewAgentAPI HostAPI::newAgent(const std::string &agent_name) {
-    // Validation
-    auto &model = agentModel.getModelDescription();
-    auto agent = model.agents.find(agent_name);
-    if (agent == model.agents.end()) {
-        THROW InvalidAgentName("Agent '%s' was not found within the model hierarchy, "
-            "in HostAPI::newAgent()\n",
-            agent_name.c_str());
+HostAgentAPI HostAPI::agent(const std::string &agent_name, const std::string &state_name) {
+    auto agt = agentData.find(agent_name);
+    if (agt == agentData.end()) {
+        THROW InvalidAgent("Agent '%s' was not found in model description hierarchy.\n", agent_name.c_str());
     }
-    return newAgent(agent_name, agent->second->initial_state);
-}
-HostNewAgentAPI HostAPI::newAgent(const std::string &agent_name, const std::string &state) {
-    // Validation
-    auto &model = agentModel.getModelDescription();
-    auto agent = model.agents.find(agent_name);
-    if (agent == model.agents.end()) {
-        THROW InvalidAgentName("Agent '%s' was not found within the model hierarchy, "
-            "in HostAPI::newAgent()\n",
-            agent_name.c_str());
+    auto state = agt->second.find(state_name);
+    if (state == agt->second.end()) {
+        THROW InvalidAgentState("Agent '%s' in model description hierarchy does not contain state '%s'.\n", agent_name.c_str(), state_name.c_str());
     }
-    if (agent->second->states.find(state) == agent->second->states.end()) {
-        THROW InvalidStateName("Agent '%s' does not contain state '%s', "
-            "in HostAPI::newAgent()\n",
-            agent_name.c_str(), state.c_str());
-    }
-    // Create the agent in our backing data structure
-    NewAgentStorage t_agentData(agentOffsets.at(agent_name));
-    auto &s = agentData.at(agent_name).at(state);
-    s.push_back(t_agentData);
-    // Point the returned object to the created agent
-    return HostNewAgentAPI(s.back());
+    return HostAgentAPI(*this, agentModel.getAgent(agent_name), state_name, agentOffsets.at(agent_name), state->second);
 }
 
 bool HostAPI::tempStorageRequiresResize(const CUB_Config &cc, const unsigned int &items) {

--- a/src/flamegpu/runtime/HostAgentAPI.cu
+++ b/src/flamegpu/runtime/HostAgentAPI.cu
@@ -1,4 +1,28 @@
 #include "flamegpu/runtime/HostAgentAPI.h"
+#include "flamegpu/pop/DeviceAgentVector_impl.h"
+
+HostAgentAPI::~HostAgentAPI() {
+    if (population) {
+        population->syncChanges();
+        population.reset();
+    }
+}
+
+HostNewAgentAPI HostAgentAPI::newAgent() {
+    // Create the agent in our backing data structure
+    NewAgentStorage t_agentData(agentOffsets);
+    newAgentData.emplace_back(NewAgentStorage(agentOffsets));
+    // Point the returned object to the created agent
+    return HostNewAgentAPI(newAgentData.back());
+}
+
+unsigned HostAgentAPI::count() {
+    if (population) {
+        // If the user has a DeviceAgentVector out, use that instead
+        return population->size();
+    }
+    return agent.getStateSize(stateName);
+}
 
 __global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount) {
     const unsigned int TID = blockIdx.x * blockDim.x + threadIdx.x;
@@ -22,4 +46,12 @@ __global__ void sortBuffer_kernel(char *dest, char*src, unsigned int *position, 
 void HostAgentAPI::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount, const cudaStream_t &stream) {
     sortBuffer_kernel<<<(threadCount/512)+1, 512, 0, stream >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
     gpuErrchkLaunch();
+}
+
+DeviceAgentVector HostAgentAPI::getPopulationData() {
+    // Create and return a new AgentVector
+    if (!population) {
+        population = std::make_shared<DeviceAgentVector_impl>(static_cast<CUDAAgent&>(agent), stateName, agentOffsets, newAgentData, api.scatter, api.streamId, api.stream);
+    }
+    return *population;
 }

--- a/src/flamegpu/runtime/HostAgentAPI.cu
+++ b/src/flamegpu/runtime/HostAgentAPI.cu
@@ -1,4 +1,4 @@
-#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/runtime/HostAgentAPI.h"
 
 __global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount) {
     const unsigned int TID = blockIdx.x * blockDim.x + threadIdx.x;
@@ -7,7 +7,7 @@ __global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount
     }
 }
 
-void HostAgentInstance::fillTIDArray(unsigned int *buffer, const unsigned int &threadCount, const cudaStream_t &stream) {
+void HostAgentAPI::fillTIDArray(unsigned int *buffer, const unsigned int &threadCount, const cudaStream_t &stream) {
     initToThreadIndex<<<(threadCount/512)+1, 512, 0, stream>>>(buffer, threadCount);
     gpuErrchkLaunch();
 }
@@ -19,7 +19,7 @@ __global__ void sortBuffer_kernel(char *dest, char*src, unsigned int *position, 
     }
 }
 
-void HostAgentInstance::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount, const cudaStream_t &stream) {
+void HostAgentAPI::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount, const cudaStream_t &stream) {
     sortBuffer_kernel<<<(threadCount/512)+1, 512, 0, stream >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
     gpuErrchkLaunch();
 }

--- a/src/flamegpu/runtime/flamegpu_host_api.cu
+++ b/src/flamegpu/runtime/flamegpu_host_api.cu
@@ -1,5 +1,5 @@
 #include "flamegpu/runtime/flamegpu_host_api.h"
-#include "flamegpu/runtime/flamegpu_host_agent_api.h"
+#include "flamegpu/runtime/HostAgentAPI.h"
 #include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/sim/Simulation.h"
 #include "flamegpu/util/nvtx.h"
@@ -31,11 +31,11 @@ FLAMEGPU_HOST_API::~FLAMEGPU_HOST_API() {
     }
 }
 
-HostAgentInstance FLAMEGPU_HOST_API::agent(const std::string &agent_name, const std::string &stateName) {
-    return HostAgentInstance(*this, agentModel.getAgent(agent_name), stateName);
+HostAgentAPI FLAMEGPU_HOST_API::agent(const std::string &agent_name, const std::string &stateName) {
+    return HostAgentAPI(*this, agentModel.getAgent(agent_name), stateName);
 }
 
-FLAMEGPU_HOST_NEW_AGENT_API FLAMEGPU_HOST_API::newAgent(const std::string &agent_name) {
+HostNewAgentAPI FLAMEGPU_HOST_API::newAgent(const std::string &agent_name) {
     // Validation
     auto &model = agentModel.getModelDescription();
     auto agent = model.agents.find(agent_name);
@@ -46,7 +46,7 @@ FLAMEGPU_HOST_NEW_AGENT_API FLAMEGPU_HOST_API::newAgent(const std::string &agent
     }
     return newAgent(agent_name, agent->second->initial_state);
 }
-FLAMEGPU_HOST_NEW_AGENT_API FLAMEGPU_HOST_API::newAgent(const std::string &agent_name, const std::string &state) {
+HostNewAgentAPI FLAMEGPU_HOST_API::newAgent(const std::string &agent_name, const std::string &state) {
     // Validation
     auto &model = agentModel.getModelDescription();
     auto agent = model.agents.find(agent_name);
@@ -65,7 +65,7 @@ FLAMEGPU_HOST_NEW_AGENT_API FLAMEGPU_HOST_API::newAgent(const std::string &agent
     auto &s = agentData.at(agent_name).at(state);
     s.push_back(t_agentData);
     // Point the returned object to the created agent
-    return FLAMEGPU_HOST_NEW_AGENT_API(s.back());
+    return HostNewAgentAPI(s.back());
 }
 
 bool FLAMEGPU_HOST_API::tempStorageRequiresResize(const CUB_Config &cc, const unsigned int &items) {

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -355,8 +355,51 @@ namespace EnvironmentManager{
 
 //%include "flamegpu/runtime/DeviceAPI.h"
 %ignore VarOffsetStruct; // not required but defined in HostNewAgentAPI
+%feature("valuewrapper") DeviceAgentVector;
 %include "flamegpu/runtime/HostAPI.h"
 %include "flamegpu/runtime/HostNewAgentAPI.h"
+%ignore DeviceAgentVector_t; // Not required, internal
+%ignore DeviceAgentVector_t::VariableBufferPair; // Not required, internal
+// Disable functions which use C++ iterators/type_index
+%ignore DeviceAgentVector::const_iterator;
+%ignore DeviceAgentVector::const_reverse_iterator;
+%ignore DeviceAgentVector::iterator;
+%ignore DeviceAgentVector::const_iterator;
+%ignore DeviceAgentVector::reverse_iterator;
+%ignore DeviceAgentVector::const_reverse_iterator;
+%ignore DeviceAgentVector::begin;
+%ignore DeviceAgentVector::cbegin;
+%ignore DeviceAgentVector::end;
+%ignore DeviceAgentVector::cend;
+%ignore DeviceAgentVector::rbegin;
+%ignore DeviceAgentVector::crbegin;
+%ignore DeviceAgentVector::rend;
+%ignore DeviceAgentVector::crend;
+%ignore DeviceAgentVector::insert;
+%ignore DeviceAgentVector::erase;
+%ignore DeviceAgentVector::getVariableType;
+%ignore DeviceAgentVector::getVariableMetaData;
+%ignore DeviceAgentVector::data;
+%rename(insert) DeviceAgentVector::py_insert; 
+%rename(erase) DeviceAgentVector::py_erase; 
+// Extend DeviceAgentVector so that it is python iterable
+%extend DeviceAgentVector {
+%pythoncode {
+    def __iter__(self):
+        return FLAMEGPUIterator(self)
+    def __len__(self):
+        return self.size()
+}
+    DeviceAgentVector::Agent DeviceAgentVector::__getitem__(const int &index) {
+        if (index >= 0)
+            return $self->operator[](index);
+        return $self->operator[]($self->size() + index);
+    }
+    void DeviceAgentVector::__setitem__(const size_type &index, const Agent &value) {
+        $self->operator[](index).setData(value);
+    }
+}
+%include "flamegpu/pop/DeviceAgentVector.h"
 
 %include "flamegpu/runtime/HostAgentAPI.h"
 /* Extend HostAgentAPI to add a templated version of the sum function (with differing return type) with a different name so this can be instantiated */

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -354,14 +354,14 @@ namespace EnvironmentManager{
 %feature("flatnested", ""); // flat nested off
 
 //%include "flamegpu/runtime/flamegpu_device_api.h"
-%ignore VarOffsetStruct; // not required but defined in flamegpu_host_new_agent_api
+%ignore VarOffsetStruct; // not required but defined in HostNewAgentAPI
 %include "flamegpu/runtime/flamegpu_host_api.h"
-%include "flamegpu/runtime/flamegpu_host_new_agent_api.h"
+%include "flamegpu/runtime/HostNewAgentAPI.h"
 
-%include "flamegpu/runtime/flamegpu_host_agent_api.h"
-/* Extend HostAgentInstance to add a templated version of the sum function (with differing return type) with a different name so this can be instantiated */
-%extend HostAgentInstance{
-    template<typename InT, typename OutT> OutT HostAgentInstance::sumOutT(const std::string& variable) const {
+%include "flamegpu/runtime/HostAgentAPI.h"
+/* Extend HostAgentAPI to add a templated version of the sum function (with differing return type) with a different name so this can be instantiated */
+%extend HostAgentAPI{
+    template<typename InT, typename OutT> OutT HostAgentAPI::sumOutT(const std::string& variable) const {
         return $self->sum<InT,OutT>(variable);
     }
 }
@@ -483,11 +483,11 @@ TEMPLATE_VARIABLE_INSTANTIATE(getVariableArray, AgentInstance::getVariableArray)
 
 // Instantiate template versions of host agent instance functions from the API
 // Not currently supported: custom reductions, transformations or histograms
-TEMPLATE_VARIABLE_INSTANTIATE(sort, HostAgentInstance::sort)
-TEMPLATE_VARIABLE_INSTANTIATE(count, HostAgentInstance::count)
-TEMPLATE_VARIABLE_INSTANTIATE(min, HostAgentInstance::min)
-TEMPLATE_VARIABLE_INSTANTIATE(max, HostAgentInstance::max)
-TEMPLATE_SUM_INSTANTIATE(HostAgentInstance)
+TEMPLATE_VARIABLE_INSTANTIATE(sort, HostAgentAPI::sort)
+TEMPLATE_VARIABLE_INSTANTIATE(count, HostAgentAPI::count)
+TEMPLATE_VARIABLE_INSTANTIATE(min, HostAgentAPI::min)
+TEMPLATE_VARIABLE_INSTANTIATE(max, HostAgentAPI::max)
+TEMPLATE_SUM_INSTANTIATE(HostAgentAPI)
 
 // Instantiate template versions of host environment functions from the API
 TEMPLATE_VARIABLE_INSTANTIATE(getProperty, HostEnvironment::getProperty)
@@ -496,10 +496,10 @@ TEMPLATE_VARIABLE_INSTANTIATE(setProperty, HostEnvironment::setProperty)
 TEMPLATE_VARIABLE_INSTANTIATE(setPropertyArray, HostEnvironment::setPropertyArray)
 
 // Instantiate template versions of host agent functions from the API
-TEMPLATE_VARIABLE_INSTANTIATE(getVariable, FLAMEGPU_HOST_NEW_AGENT_API::getVariable)
-TEMPLATE_VARIABLE_INSTANTIATE(getVariableArray, FLAMEGPU_HOST_NEW_AGENT_API::getVariableArray)
-TEMPLATE_VARIABLE_INSTANTIATE(setVariable, FLAMEGPU_HOST_NEW_AGENT_API::setVariable)
-TEMPLATE_VARIABLE_INSTANTIATE(setVariableArray, FLAMEGPU_HOST_NEW_AGENT_API::setVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE(getVariable, HostNewAgentAPI::getVariable)
+TEMPLATE_VARIABLE_INSTANTIATE(getVariableArray, HostNewAgentAPI::getVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE(setVariable, HostNewAgentAPI::setVariable)
+TEMPLATE_VARIABLE_INSTANTIATE(setVariableArray, HostNewAgentAPI::setVariableArray)
 
 // Instantiate template versions of environment description functions from the API
 TEMPLATE_VARIABLE_INSTANTIATE(newProperty, EnvironmentDescription::newProperty)

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -353,9 +353,9 @@ namespace EnvironmentManager{
 %include "flamegpu/gpu/CUDASimulation.h"
 %feature("flatnested", ""); // flat nested off
 
-//%include "flamegpu/runtime/flamegpu_device_api.h"
+//%include "flamegpu/runtime/DeviceAPI.h"
 %ignore VarOffsetStruct; // not required but defined in HostNewAgentAPI
-%include "flamegpu/runtime/flamegpu_host_api.h"
+%include "flamegpu/runtime/HostAPI.h"
 %include "flamegpu/runtime/HostNewAgentAPI.h"
 
 %include "flamegpu/runtime/HostAgentAPI.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/model/test_subenvironment.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/pop/test_agent_vector.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/pop/test_agent_instance.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/pop/test_device_agent_vector.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_host_functions.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_agent_environment.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_agent_function_conditions.cu    

--- a/tests/swig/python/io/test_logging.py
+++ b/tests/swig/python/io/test_logging.py
@@ -27,7 +27,7 @@ class logging_ensemble_init(pyflamegpu.HostFunctionCallback):
     def run(self, FLAMEGPU):
         instance_id  = FLAMEGPU.environment.getPropertyInt("instance_id");
         for i in range(instance_id, instance_id + 101):
-            instance = FLAMEGPU.newAgent(AGENT_NAME1);
+            instance = FLAMEGPU.agent(AGENT_NAME1).newAgent();
             instance.setVariableFloat("float_var", i);
             instance.setVariableInt("int_var", i+1);
             instance.setVariableUInt("uint_var", i+2);

--- a/tests/swig/python/runtime/test_host_agent_creation.py
+++ b/tests/swig/python/runtime/test_host_agent_creation.py
@@ -12,7 +12,7 @@ class BasicOutput(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT):
-            FLAMEGPU.newAgent("agent").setVariableFloat("x", 1.0)
+            FLAMEGPU.agent("agent").newAgent().setVariableFloat("x", 1.0)
      
 class BasicOutputCdn(pyflamegpu.HostFunctionConditionCallback):
     def __init__(self):
@@ -20,7 +20,7 @@ class BasicOutputCdn(pyflamegpu.HostFunctionConditionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT):
-            FLAMEGPU.newAgent("agent").setVariableFloat("x", 1.0)
+            FLAMEGPU.agent("agent").newAgent().setVariableFloat("x", 1.0)
         return pyflamegpu.CONTINUE  # New agents wont be created if EXIT is passed
     
 class OutputState(pyflamegpu.HostFunctionCallback):
@@ -29,7 +29,7 @@ class OutputState(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT):
-            FLAMEGPU.newAgent("agent", "b").setVariableFloat("x", 1.0)
+            FLAMEGPU.agent("agent", "b").newAgent().setVariableFloat("x", 1.0)
 
 class OutputMultiAgent(pyflamegpu.HostFunctionCallback):
     def __init__(self):
@@ -37,22 +37,22 @@ class OutputMultiAgent(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT): 
-            FLAMEGPU.newAgent("agent", "b").setVariableFloat("x", 1.0)
-            FLAMEGPU.newAgent("agent2").setVariableFloat("y", 2.0)
+            FLAMEGPU.agent("agent", "b").newAgent().setVariableFloat("x", 1.0)
+            FLAMEGPU.agent("agent2").newAgent().setVariableFloat("y", 2.0)
         
 class BadVarName(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent").setVariableFloat("nope", 1.0)
+        FLAMEGPU.agent("agent").newAgent().setVariableFloat("nope", 1.0)
 
 class BadVarType(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent").setVariableInt64("x", 1.0)
+        FLAMEGPU.agent("agent").newAgent().setVariableInt64("x", 1.0)
         
 class Getter(pyflamegpu.HostFunctionCallback):
     def __init__(self):
@@ -60,7 +60,7 @@ class Getter(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT): 
-            newAgt = FLAMEGPU.newAgent("agent")
+            newAgt = FLAMEGPU.agent("agent").newAgent()
             newAgt.setVariableFloat("x", newAgt.getVariableFloat("default"))
         
 class GetBadVarName(pyflamegpu.HostFunctionCallback):
@@ -69,8 +69,8 @@ class GetBadVarName(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT): 
-            newAgt = FLAMEGPU.newAgent("agent")
-            FLAMEGPU.newAgent("agent").getVariableFloat("nope")
+            newAgt = FLAMEGPU.agent("agent").newAgent()
+            FLAMEGPU.agent("agent").newAgent().getVariableFloat("nope")
                 
 class GetBadVarType(pyflamegpu.HostFunctionCallback):
     def __init__(self):
@@ -78,8 +78,8 @@ class GetBadVarType(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(NEW_AGENT_COUNT): 
-            newAgt = FLAMEGPU.newAgent("agent")
-            FLAMEGPU.newAgent("agent").getVariableInt64("x")
+            newAgt = FLAMEGPU.agent("agent").newAgent()
+            FLAMEGPU.agent("agent").newAgent().getVariableInt64("x")
         
 class ArrayVarHostBirth(pyflamegpu.HostFunctionCallback):
     def __init__(self):
@@ -87,7 +87,7 @@ class ArrayVarHostBirth(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(AGENT_COUNT): 
-            a = FLAMEGPU.newAgent("agent_name")
+            a = FLAMEGPU.agent("agent_name").newAgent()
             a.setVariableUInt("id", i)
             a.setVariableArrayInt("array_var", (2 + i, 4 + i, 8 + i, 16 + i) )
             a.setVariableInt("array_var2", 0, 3 + i)
@@ -102,7 +102,7 @@ class ArrayVarHostBirthSetGet(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(AGENT_COUNT): 
-            a = FLAMEGPU.newAgent("agent_name")
+            a = FLAMEGPU.agent("agent_name").newAgent()
             a.setVariableUInt("id", i)
             # Set
             a.setVariableArrayInt("array_var", (2 + i, 4 + i, 8 + i, 16 + i) )
@@ -125,77 +125,77 @@ class ArrayVarHostBirth_DefaultWorks(pyflamegpu.HostFunctionCallback):
 
     def run(self, FLAMEGPU):
         for i in range(AGENT_COUNT): 
-            FLAMEGPU.newAgent("agent_name")
+            FLAMEGPU.agent("agent_name").newAgent()
                
 class ArrayVarHostBirth_LenWrong(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableArrayInt("array_var", [0]*8)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableArrayInt("array_var", [0]*8)
         
 class ArrayVarHostBirth_LenWrong2(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableInt("array_var", 5, 0)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableInt("array_var", 5, 0)
         
 class ArrayVarHostBirth_TypeWrong(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableArrayFloat("array_var", [0]*4)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableArrayFloat("array_var", [0]*4)
         
 class ArrayVarHostBirth_TypeWrong2(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableFloat("array_var", 4, 0.0)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableFloat("array_var", 4, 0.0)
         
 class ArrayVarHostBirth_NameWrong(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableArrayInt("array_varAAAAAA", [0]*4)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableArrayInt("array_varAAAAAA", [0]*4)
         
 class ArrayVarHostBirth_NameWrong2(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableInt("array_varAAAAAA", 4, 0)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableInt("array_varAAAAAA", 4, 0)
         
 class ArrayVarHostBirth_ArrayNotSuitableSet(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableInt("array_var", 12)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableInt("array_var", 12)
         
 class ArrayVarHostBirth_ArrayNotSuitableGet(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").getVariableInt("array_var")
+        FLAMEGPU.agent("agent_name").newAgent().getVariableInt("array_var")
      
 class reserved_name_step(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableInt("_", 0)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableInt("_", 0)
         
 class reserved_name_step_array(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.newAgent("agent_name").setVariableArrayInt("_", [0]*3)
+        FLAMEGPU.agent("agent_name").newAgent().setVariableArrayInt("_", [0]*3)
 
      
         

--- a/tests/swig/python/runtime/test_host_agent_sort.py
+++ b/tests/swig/python/runtime/test_host_agent_sort.py
@@ -15,28 +15,28 @@ class sort_ascending_float(pyflamegpu.HostFunctionCallback):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.agent("agent").sortFloat("float", pyflamegpu.HostAgentInstance.Asc)
+        FLAMEGPU.agent("agent").sortFloat("float", pyflamegpu.HostAgentAPI.Asc)
         
 class sort_descending_float(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.agent("agent").sortFloat("float",  pyflamegpu.HostAgentInstance.Desc)
+        FLAMEGPU.agent("agent").sortFloat("float",  pyflamegpu.HostAgentAPI.Desc)
     
 class sort_ascending_int(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.agent("agent").sortInt("int",  pyflamegpu.HostAgentInstance.Asc)
+        FLAMEGPU.agent("agent").sortInt("int",  pyflamegpu.HostAgentAPI.Asc)
    
 class sort_descending_int(pyflamegpu.HostFunctionCallback):
     def __init__(self):
         super().__init__()
 
     def run(self, FLAMEGPU):
-        FLAMEGPU.agent("agent").sortInt("int",  pyflamegpu.HostAgentInstance.Desc)
+        FLAMEGPU.agent("agent").sortInt("int",  pyflamegpu.HostAgentAPI.Desc)
 
 class HostAgentSort(TestCase):
 

--- a/tests/test_cases/exception/test_device_exception.cu
+++ b/tests/test_cases/exception/test_device_exception.cu
@@ -254,7 +254,7 @@ class DeviceExceptionTest : public testing::Test {
 };
 }  // namespace
 //
-// FLAMEGPU_READ_ONLY_DEVICE_API::getVariable<T, N>()
+// ReadOnlyDeviceAPI::getVariable<T, N>()
 FLAMEGPU_AGENT_FUNCTION(GetUnknownAgentVariable, MsgNone, MsgNone) {
     FLAMEGPU->getVariable<int>("nope");
     return ALIVE;
@@ -276,7 +276,7 @@ TEST_F(DeviceExceptionTest, GetAgentVariableBadType) {
     ms->run(1);
 }
 
-// FLAMEGPU_READ_ONLY_DEVICE_API::getVariable<T, N, M>()
+// ReadOnlyDeviceAPI::getVariable<T, N, M>()
 FLAMEGPU_AGENT_FUNCTION(GetUnknownAgentVariableArray, MsgNone, MsgNone) {
     FLAMEGPU->getVariable<int, 3>("nope", 0);
     return ALIVE;
@@ -308,7 +308,7 @@ TEST_F(DeviceExceptionTest, GetAgentVariableArrayOutOfRange) {
     ms->run(1);
 }
 
-// FLAMEGPU_DEVICE_API::setVariable<T, N>()
+// DeviceAPI::setVariable<T, N>()
 FLAMEGPU_AGENT_FUNCTION(SetUnknownAgentVariable, MsgNone, MsgNone) {
     FLAMEGPU->setVariable<int>("nope", 2);
     return ALIVE;
@@ -330,7 +330,7 @@ TEST_F(DeviceExceptionTest, SetAgentVariableBadType) {
     ms->run(1);
 }
 
-// FLAMEGPU_DEVICE_API::setVariable<T, N, M>()
+// DeviceAPI::setVariable<T, N, M>()
 FLAMEGPU_AGENT_FUNCTION(SetUnknownAgentVariableArray, MsgNone, MsgNone) {
     FLAMEGPU->setVariable<int, 3>("nope", 0, 2);
     return ALIVE;

--- a/tests/test_cases/gpu/test_cuda_subagent.cu
+++ b/tests/test_cases/gpu/test_cuda_subagent.cu
@@ -136,12 +136,12 @@ FLAMEGPU_EXIT_CONDITION(ExitAlways) {
     return EXIT;
 }
 FLAMEGPU_HOST_FUNCTION(HostBirth) {
-    auto a = FLAMEGPU->newAgent(AGENT_NAME);
+    auto a = FLAMEGPU->agent(AGENT_NAME).newAgent();
     a.setVariable<unsigned int>(AGENT_VAR1_NAME, 5);
     a.setVariable<unsigned int>(AGENT_VAR2_NAME, 500);
 }
 FLAMEGPU_HOST_FUNCTION(HostBirth2) {
-    auto a = FLAMEGPU->newAgent(AGENT_NAME);
+    auto a = FLAMEGPU->agent(AGENT_NAME).newAgent();
     a.setVariable<unsigned int>(AGENT_VAR1_NAME, 5);
 }
 FLAMEGPU_AGENT_FUNCTION(HostBirthUpdate, MsgNone, MsgNone) {
@@ -1503,7 +1503,7 @@ TEST(TestCUDASubAgent, AgentStateTransition_UnmapToMap_BeforeSubModel) {
 }
 FLAMEGPU_INIT_FUNCTION(InitCreateAgents_AgentStateTransition_UnmapToUnmap_InSubModel) {
     for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
-        auto a = FLAMEGPU->newAgent(AGENT_NAME, UNMAPPED_STATE1);
+        auto a = FLAMEGPU->agent(AGENT_NAME, UNMAPPED_STATE1).newAgent();
         a.setVariable<unsigned int>(AGENT_VAR1_NAME, UINT_MAX/2);
     }
 }

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -314,8 +314,9 @@ TEST(LoggingTest, CUDASimulationSimulate) {
 }
 FLAMEGPU_INIT_FUNCTION(logging_ensemble_init) {
     const int instance_id  = FLAMEGPU->environment.getProperty<int>("instance_id");
+    auto agt = FLAMEGPU->agent(AGENT_NAME1);
     for (int i = instance_id; i < instance_id + 101; ++i) {
-        auto instance = FLAMEGPU->newAgent(AGENT_NAME1);
+        auto instance = agt.newAgent();
         instance.setVariable<float>("float_var", static_cast<float>(i));
         instance.setVariable<int>("int_var", static_cast<int>(i+1));
         instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i+2));

--- a/tests/test_cases/pop/test_device_agent_vector.cu
+++ b/tests/test_cases/pop/test_device_agent_vector.cu
@@ -1,0 +1,1321 @@
+#include <string>
+
+#include "flamegpu/flame_api.h"
+
+#include "gtest/gtest.h"
+
+namespace DeviceAgentVectorTest {
+    const unsigned int AGENT_COUNT = 10;
+    const std::string MODEL_NAME = "model";
+    const std::string SUBMODEL_NAME = "submodel";
+    const std::string AGENT_NAME = "agent";
+
+FLAMEGPU_STEP_FUNCTION(SetGet) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    DeviceAgentVector av = agent.getPopulationData();
+    for (AgentVector::Agent ai : av) {
+        ai.setVariable<int>("int", ai.getVariable<int>("int") + 12);
+    }
+}
+FLAMEGPU_STEP_FUNCTION(SetGetHalf) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    DeviceAgentVector av = agent.getPopulationData();
+    for (unsigned int i = av.size()/4; i < av.size() - av.size()/4; ++i) {
+        av[i].setVariable<int>("int", av[i].getVariable<int>("int") + 12);
+    }
+    // agent.setPopulationData(av);
+}
+
+
+TEST(DeviceAgentVectorTest, SetGet) {
+    // Initialise an agent population with values in a variable [0,1,2..N]
+    // Inside a step function, retrieve the agent population as a DeviceAgentVector
+    // Update all agents by adding 12 to their value
+    // After model completion, retrieve the agent population and check their values are [12,13,14..N+12]
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 0);
+    model.addStepFunction(SetGet);
+
+    // Init agent pop
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i)
+      av[i].setVariable<int>("int", static_cast<int>(i));
+
+    // Create and step simulation
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i) + 12);
+    }
+
+    // Step again
+    sim.step();
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i) + 24);
+    }
+}
+TEST(DeviceAgentVectorTest, SetGetHalf) {
+    // Initialise an agent population with values in a variable [0,1,2..N]
+    // Inside a step function, retrieve the agent population as a DeviceAgentVector
+    // Update half agents (contiguous block) by adding 12 to their value
+    // After model completion, retrieve the agent population and check their values are [12,13,14..N+12]
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 0);
+    model.addStepFunction(SetGetHalf);
+
+    // Init agent pop
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i)
+        av[i].setVariable<int>("int", static_cast<int>(i));
+
+    // Create and step simulation
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        if (i < AGENT_COUNT/4 || i >= AGENT_COUNT - AGENT_COUNT/4) {
+            ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i));
+        } else  {
+            ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i) + 12);
+        }
+    }
+
+    // Step again
+    sim.step();
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        if (i < AGENT_COUNT / 4 || i >= AGENT_COUNT - AGENT_COUNT / 4) {
+            ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i));
+        } else {
+            ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i) + 24);
+        }
+    }
+}
+FLAMEGPU_AGENT_FUNCTION(MasterIncrement, MsgNone, MsgNone) {
+    FLAMEGPU->setVariable<unsigned int>("uint", FLAMEGPU->getVariable<unsigned int>("uint") + 1);
+    return ALIVE;
+}
+
+FLAMEGPU_STEP_FUNCTION(Resize) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    DeviceAgentVector av = agent.getPopulationData();
+    unsigned int av_size = av.size();
+    av.resize(av_size + AGENT_COUNT);
+    // Continue the existing variable pattern
+    for (unsigned int i = av_size; i < av_size + AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", i);
+    }
+}
+TEST(DeviceAgentVectorTest, Resize) {
+    // In void CUDAFatAgentStateList::resize() (as of 2021-03-04)
+    // The minimum buffer len is 1024 and resize grows by 25%
+    // So to trigger resize, we can grow from 1024->2048
+
+    // The intention of this test is to check that agent birth via DeviceAgentVector works as expected (when CUDAAgent resizes)
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 0);
+    model.addStepFunction(Resize);
+
+    // Init agent pop
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i)
+        av[i].setVariable<int>("int", static_cast<int>(i));
+
+    // Create and step simulation
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), AGENT_COUNT * 2);
+    for (unsigned int i = 0; i < AGENT_COUNT * 2; ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i));
+    }
+
+    // Step again
+    sim.step();
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), AGENT_COUNT * 3);
+    for (unsigned int i = 0; i < AGENT_COUNT * 3; ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(i));
+    }
+}
+FLAMEGPU_STEP_FUNCTION(Insert) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    DeviceAgentVector av = agent.getPopulationData();
+    AgentInstance ai(av[0]);
+    av.insert(av.size() - AGENT_COUNT/2, AGENT_COUNT, ai);
+}
+FLAMEGPU_STEP_FUNCTION(Erase) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    DeviceAgentVector av = agent.getPopulationData();
+    av.erase(AGENT_COUNT / 4, AGENT_COUNT / 2);
+    av.push_back();
+    av.back().setVariable<int>("int", -2);
+}
+FLAMEGPU_EXIT_CONDITION(AlwaysExit) {
+    return EXIT;
+}
+TEST(DeviceAgentVectorTest, SubmodelResize) {
+    // In void CUDAFatAgentStateList::resize() (as of 2021-03-04)
+    // The minimum buffer len is 1024 and resize grows by 25%
+    // So to trigger resize, we can grow from 1024->2048
+
+    // The intention of this test is to check that agent birth via DeviceAgentVector works as expected
+    // Specifically, that when the agent population is resized, unbound variabled in the master-model are default init
+    ModelDescription sub_model(SUBMODEL_NAME);
+    AgentDescription& sub_agent = sub_model.newAgent(AGENT_NAME);
+    sub_agent.newVariable<int>("int", 0);
+    sub_model.addStepFunction(Resize);
+    sub_model.addExitCondition(AlwaysExit);
+
+
+    ModelDescription master_model(MODEL_NAME);
+    AgentDescription& master_agent = master_model.newAgent(AGENT_NAME);
+    master_agent.newVariable<int>("int", 0);
+    master_agent.newVariable<unsigned int>("uint", 12u);
+    master_agent.newFunction("MasterIncrement", MasterIncrement);
+    SubModelDescription &sub_desc = master_model.newSubModel(SUBMODEL_NAME, sub_model);
+    sub_desc.bindAgent(AGENT_NAME, AGENT_NAME, true);
+    master_model.newLayer().addAgentFunction(MasterIncrement);
+    master_model.newLayer().addSubModel(sub_desc);
+
+    // Init agent pop
+    AgentVector av(master_agent, AGENT_COUNT);
+    std::vector<int> vec_int;
+    std::vector<unsigned int> vec_uint;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+        av[i].setVariable<unsigned int>("uint", static_cast<int>(i));
+        vec_int.push_back(i);
+        vec_uint.push_back(i);
+    }
+
+    // Create and step simulation
+    CUDASimulation sim(master_model);
+    sim.setPopulationData(av);
+    sim.step();
+    // Update vectors to match
+    for (unsigned int i = 0; i < vec_uint.size(); ++i)
+        vec_uint[i]++;
+    vec_int.resize(vec_int.size() + AGENT_COUNT, 0);
+    vec_uint.resize(vec_uint.size() + AGENT_COUNT, 12u);
+    for (unsigned int i = AGENT_COUNT; i < 2 * AGENT_COUNT; ++i)
+      vec_int[i] = static_cast<int>(i);
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), vec_int.size());
+    for (unsigned int i = 0; i < av.size(); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), vec_int[i]);
+        ASSERT_EQ(av[i].getVariable<unsigned int>("uint"), vec_uint[i]);
+    }
+
+    // Step again
+    sim.step();
+    // Update vectors to match
+    for (unsigned int i = 0; i < vec_uint.size(); ++i)
+        vec_uint[i]++;
+    vec_int.resize(vec_int.size() + AGENT_COUNT, 0);
+    vec_uint.resize(vec_uint.size() + AGENT_COUNT, 12u);
+    for (unsigned int i = 2 * AGENT_COUNT; i < 3 *AGENT_COUNT; ++i)
+        vec_int[i] = static_cast<int>(i);
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), vec_int.size());
+    for (unsigned int i = 0; i < av.size(); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), vec_int[i]);
+        ASSERT_EQ(av[i].getVariable<unsigned int>("uint"), vec_uint[i]);
+    }
+}
+TEST(DeviceAgentVectorTest, SubmodelInsert) {
+    // In void CUDAFatAgentStateList::resize() (as of 2021-03-04)
+    // The minimum buffer len is 1024 and resize grows by 25%
+    // So to trigger resize, we can grow from 1024->2048
+
+    // The intention of this test is to check that agent birth via DeviceAgentVector::insert works as expected
+    // Specifically, that when the agent population is resized, unbound variabled in the master-model are default init
+    ModelDescription sub_model(SUBMODEL_NAME);
+    AgentDescription& sub_agent = sub_model.newAgent(AGENT_NAME);
+    sub_agent.newVariable<int>("int", 0);
+    sub_model.addStepFunction(Insert);
+    sub_model.addExitCondition(AlwaysExit);
+
+
+    ModelDescription master_model(MODEL_NAME);
+    AgentDescription& master_agent = master_model.newAgent(AGENT_NAME);
+    master_agent.newVariable<int>("int", 0);
+    master_agent.newVariable<unsigned int>("uint", 12u);
+    master_agent.newFunction("MasterIncrement", MasterIncrement);
+    SubModelDescription& sub_desc = master_model.newSubModel(SUBMODEL_NAME, sub_model);
+    sub_desc.bindAgent(AGENT_NAME, AGENT_NAME, true);
+    master_model.newLayer().addAgentFunction(MasterIncrement);
+    master_model.newLayer().addSubModel(sub_desc);
+
+    // Init agent pop
+    AgentVector av(master_agent, AGENT_COUNT);
+    std::vector<int> vec_int;
+    std::vector<unsigned int> vec_uint;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+        av[i].setVariable<unsigned int>("uint", static_cast<int>(i));
+        vec_int.push_back(i);
+        vec_uint.push_back(i);
+    }
+
+    // Create and step simulation
+    CUDASimulation sim(master_model);
+    sim.setPopulationData(av);
+    sim.step();
+    // Update vectors to match
+    for (unsigned int i = 0; i < vec_uint.size(); ++i)
+        vec_uint[i]++;
+    vec_int.insert(vec_int.begin() + (vec_int.size() - AGENT_COUNT / 2), AGENT_COUNT, vec_int[0]);
+    vec_uint.insert(vec_uint.begin() + (vec_uint.size() - AGENT_COUNT / 2), AGENT_COUNT, 12u);
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), vec_int.size());
+    for (unsigned int i = 0; i < av.size(); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), vec_int[i]);
+        ASSERT_EQ(av[i].getVariable<unsigned int>("uint"), vec_uint[i]);
+    }
+
+    // Step again
+    sim.step();
+    // Update vectors to match
+    for (unsigned int i = 0; i < vec_uint.size(); ++i)
+        vec_uint[i]++;
+    vec_int.insert(vec_int.begin() + (vec_int.size() - AGENT_COUNT / 2), AGENT_COUNT, vec_int[0]);
+    vec_uint.insert(vec_uint.begin() + (vec_uint.size() - AGENT_COUNT / 2), AGENT_COUNT, 12u);
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), vec_int.size());
+    for (unsigned int i = 0; i < av.size(); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), vec_int[i]);
+        ASSERT_EQ(av[i].getVariable<unsigned int>("uint"), vec_uint[i]);
+    }
+}
+TEST(DeviceAgentVectorTest, SubmodelErase) {
+    // The intention of this test is to check that agent death via DeviceAgentVector::erase works as expected
+    ModelDescription sub_model(SUBMODEL_NAME);
+    AgentDescription& sub_agent = sub_model.newAgent(AGENT_NAME);
+    sub_agent.newVariable<int>("int", 0);
+    sub_model.addStepFunction(Erase);
+    sub_model.addExitCondition(AlwaysExit);
+
+
+    ModelDescription master_model(MODEL_NAME);
+    AgentDescription& master_agent = master_model.newAgent(AGENT_NAME);
+    master_agent.newVariable<int>("int", -1);
+    master_agent.newVariable<float>("float", 12.0f);
+    SubModelDescription& sub_desc = master_model.newSubModel(SUBMODEL_NAME, sub_model);
+    sub_desc.bindAgent(AGENT_NAME, AGENT_NAME, true);
+    master_model.newLayer().addSubModel(sub_desc);
+
+    // Init agent pop, and test vectors
+    AgentVector av(master_agent, AGENT_COUNT);
+    std::vector<int> vec_int;
+    std::vector<float> vec_flt;
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+        vec_int.push_back(static_cast<int>(i));
+        vec_flt.push_back(12.0f);
+    }
+    // Create and step simulation
+    CUDASimulation sim(master_model);
+    sim.setPopulationData(av);
+    sim.step();
+    // Update vectors to match
+    vec_int.erase(vec_int.begin() + (AGENT_COUNT / 4), vec_int.begin() + (AGENT_COUNT / 2));
+    vec_flt.erase(vec_flt.begin() + (AGENT_COUNT /4), vec_flt.begin() + (AGENT_COUNT / 2));
+    vec_int.push_back(-2);
+    vec_flt.push_back(12.0f);
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), vec_int.size());
+    for (unsigned int i = 0; i < vec_int.size(); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), vec_int[i]);
+        ASSERT_EQ(av[i].getVariable<float>("float"), vec_flt[i]);
+    }
+
+    // Step again
+    sim.step();
+    // Update vectors to match
+    vec_int.erase(vec_int.begin() + (AGENT_COUNT / 4), vec_int.begin() + (AGENT_COUNT / 2));
+    vec_flt.erase(vec_flt.begin() + (AGENT_COUNT / 4), vec_flt.begin() + (AGENT_COUNT / 2));
+    vec_int.push_back(-2);
+    vec_flt.push_back(12.0f);
+
+    // Retrieve and validate agents match
+    sim.getPopulationData(av);
+    ASSERT_EQ(av.size(), vec_int.size());
+    for (unsigned int i = 0; i < vec_int.size(); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), vec_int[i]);
+        ASSERT_EQ(av[i].getVariable<float>("float"), vec_flt[i]);
+    }
+}
+FLAMEGPU_CUSTOM_REDUCTION(bespoke_sum, a, b) {
+    return a + b;
+}
+FLAMEGPU_CUSTOM_TRANSFORM(bespoke_triple, a) {
+    return a * 3;
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_count) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(agent.count(), AGENT_COUNT);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    av.erase(0, 4);
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.count(), AGENT_COUNT - 4);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_sum) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    int sum_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        sum_result += i;
+    }
+    ASSERT_EQ(agent.sum<int>("int"), sum_result);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    sum_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j *= 2;
+        sum_result += j;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.sum<int>("int"), sum_result);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_min) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    int min_result = INT_MAX;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        min_result = min_result < i ? min_result : i;
+    }
+    ASSERT_EQ(agent.min<int>("int"), min_result);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    min_result = INT_MAX;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j *= 2;
+        min_result = min_result < j ? min_result : j;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.min<int>("int"), min_result);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_max) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    int max_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        max_result = max_result > i ? max_result : i;
+    }
+    ASSERT_EQ(agent.max<int>("int"), max_result);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    max_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j *= 2;
+        max_result = max_result > j ? max_result : j;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.max<int>("int"), max_result);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_countif) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    unsigned int count_if_result = 0;
+    const int count_if_test = 3;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        count_if_result += i == count_if_test ? 1 : 0;
+    }
+    ASSERT_EQ(agent.count<int>("int", count_if_test), count_if_result);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    count_if_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j *= 2;
+        count_if_result += j == count_if_test ? 1 : 0;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.count<int>("int", count_if_test), count_if_result);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_histogrameven) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    const int histogram_even_bins = 5;
+    std::array<unsigned int, histogram_even_bins> histogram_even_result = { 0, 0, 0, 0, 0 };
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        histogram_even_result[i / (AGENT_COUNT / 5)] += 1;
+    }
+    std::vector<unsigned int> histogram_even_test = agent.histogramEven<int>("int", histogram_even_bins, 0, AGENT_COUNT);
+    for (size_t i = 0; i < histogram_even_result.size(); ++i) {
+        ASSERT_EQ(histogram_even_test[i], histogram_even_result[i]);
+    }
+    // Update the agent pop
+    DeviceAgentVector av = agent.getPopulationData();
+    histogram_even_result = { 0, 0, 0, 0, 0 };
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j /= 2;
+        histogram_even_result[j / (AGENT_COUNT / 5)] += 1;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    histogram_even_test = agent.histogramEven<int>("int", histogram_even_bins, 0, AGENT_COUNT);
+    for (size_t i = 0; i < histogram_even_result.size(); ++i) {
+        ASSERT_EQ(histogram_even_test[i], histogram_even_result[i]);
+    }
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_reduce) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    int sum_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        sum_result += i;
+    }
+    ASSERT_EQ(agent.reduce<int>("int", bespoke_sum, 0), sum_result);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    sum_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j *= 2;
+        sum_result += j;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.reduce<int>("int", bespoke_sum, 0), sum_result);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_transformreduce) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    int sum_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        sum_result += i;
+    }
+    ASSERT_EQ(agent.transformReduce<int>("int", bespoke_triple, bespoke_sum, 0), sum_result * 3);
+    // Update the agent pop (erase first 4 items)
+    DeviceAgentVector av = agent.getPopulationData();
+    sum_result = 0;
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        int j = av[i].getVariable<int>("int");
+        j *= 2;
+        sum_result += j;
+        av[i].setVariable<int>("int", j);
+    }
+    // Test reduce again (need to test each with it's own update)
+    ASSERT_EQ(agent.transformReduce<int>("int", bespoke_triple, bespoke_sum, 0), sum_result * 3);
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_sort1) {
+    // Sort1, sort first
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    // Reverse sort order
+    agent.sort<int>("int", HostAgentAPI::Desc);
+    // Check the device agent vector sees the result correctly
+    DeviceAgentVector av = agent.getPopulationData();
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), static_cast<int>(AGENT_COUNT - 1 - i));
+    }
+}
+FLAMEGPU_STEP_FUNCTION(HostReduceAutoSync_step_sort2) {
+    // Sort2, transform via device agent vector first
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    // Reverse sort order
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(AGENT_COUNT - 1 - i));
+    }
+    // Reverse sort order again
+    agent.sort<int>("int", HostAgentAPI::Asc);
+    // Check the device agent vector sees the result correctly
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), i);
+    }
+}
+// This macro acts as a test fixture for executing a test in the named step function
+#define AUTOSYNCTEST(name)\
+TEST(DeviceAgentVectorTest, HostReduceAutoSync_ ## name) {\
+    ModelDescription model(MODEL_NAME);\
+    AgentDescription& agent = model.newAgent(AGENT_NAME);\
+    agent.newVariable<int>("int", 10);\
+    model.addStepFunction(HostReduceAutoSync_step_ ## name);\
+    AgentVector av(agent, AGENT_COUNT);\
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {\
+        av[i].setVariable<int>("int", static_cast<int>(i));\
+    }\
+    CUDASimulation sim(model);\
+    sim.setPopulationData(av);\
+    sim.step();\
+}
+AUTOSYNCTEST(count)
+AUTOSYNCTEST(sum)
+AUTOSYNCTEST(min)
+AUTOSYNCTEST(max)
+AUTOSYNCTEST(countif)
+AUTOSYNCTEST(histogrameven)
+AUTOSYNCTEST(reduce)
+AUTOSYNCTEST(transformreduce)
+AUTOSYNCTEST(sort1)
+AUTOSYNCTEST(sort2)
+
+/**
+ * The following tests all test the interaction between host agent birth and DeviceAgentVector
+ * All DeviceAgentVector methods are tested individually, to confirm they do apply host agent births before
+ * performing their actions.
+ */
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_at) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < 4; ++i) {
+        ASSERT_EQ(av.at(AGENT_COUNT + i).getVariable<int>("int"), -i);
+    }
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        ASSERT_EQ(av.at(i).getVariable<int>("int"), i);
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_at) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_at);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 4);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_front) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), 0u);
+    // Host agent birth 1 agent
+    agent.newAgent().setVariable<int>("int", -12);
+    // Test again (need to test each with it's own update)
+    ASSERT_EQ(av.front().getVariable<int>("int"), -12);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_front) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_front);
+    AgentVector av(agent, AGENT_COUNT);
+    CUDASimulation sim(model);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), 1u);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_back) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    ASSERT_EQ(av.back().getVariable<int>("int"), -3);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_back) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_back);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 4);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_begin) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    int i = 0;
+    for (auto a = av.begin(); a != av.end(); ++a) {
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ((*a).getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ((*a).getVariable<int>("int"), - static_cast<int>(i- AGENT_COUNT));
+        }
+        ++i;
+    }
+    // Check we iterated the expected amount
+    ASSERT_EQ(static_cast<unsigned int>(i), AGENT_COUNT * 2u);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_begin) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_begin);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + AGENT_COUNT);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_begin2) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    int i = 0;
+    for (auto a : av) {
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ(a.getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ(a.getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));
+        }
+        ++i;
+    }
+    // Check we iterated the expected amount
+    ASSERT_EQ(static_cast<unsigned int>(i), AGENT_COUNT * 2u);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_begin2) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_begin2);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + AGENT_COUNT);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_cbegin) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    int i = 0;
+    for (auto a = av.cbegin(); a != av.cend(); ++a) {
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ((*a).getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ((*a).getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));
+        }
+        ++i;
+    }
+    // Check we iterated the expected amount
+    ASSERT_EQ(static_cast<unsigned int>(i), AGENT_COUNT * 2u);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_cbegin) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_cbegin);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + AGENT_COUNT);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_rbegin) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    int i = AGENT_COUNT * 2;
+    for (auto a = av.rbegin(); a != av.rend(); ++a) {
+        --i;
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ((*a).getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ((*a).getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));
+        }
+    }
+    // Check we iterated the expected amount
+    ASSERT_EQ(i, 0);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_rbegin) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_rbegin);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + AGENT_COUNT);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_crbegin) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Test again (need to test each with it's own update)
+    int i = AGENT_COUNT * 2;
+    for (auto a = av.crbegin(); a != av.crend(); ++a) {
+        --i;
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ((*a).getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ((*a).getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));
+        }
+    }
+    // Check we iterated the expected amount
+    ASSERT_EQ(i, 0);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_crbegin) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_crbegin);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + AGENT_COUNT);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_empty) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), 0u);
+    ASSERT_EQ(av.empty(), true);
+    // Host agent birth 1 agent
+    agent.newAgent().setVariable<int>("int", -12);
+    // Test again (need to test each with it's own update)
+    ASSERT_EQ(av.empty(), false);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_empty) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_empty);
+    AgentVector av(agent, AGENT_COUNT);
+    CUDASimulation sim(model);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), 1u);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_size) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i)
+      agent.newAgent();  // This creates the agent, we don't actually care about it's values at this point
+    // Test again (need to test each with it's own update)
+    ASSERT_EQ(av.size(), AGENT_COUNT + 4u);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_size) {
+    ModelDescription model(MODEL_NAME);
+        AgentDescription& agent = model.newAgent(AGENT_NAME);
+        agent.newVariable<int>("int", 10);
+        model.addStepFunction(HostAgentBirthAutoSync_step_size);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_capacity) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i)
+        agent.newAgent();  // This creates the agent, we don't actually care about it's values at this point
+    // Force auto resize
+    EXPECT_EQ(av.size(), AGENT_COUNT + 4u);  // Don't need to test this here, but lint doesn't like us ignoring the value it returns
+    ASSERT_GE(av.capacity(), AGENT_COUNT + 4u);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_capacity) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_capacity);
+    AgentVector av(agent, AGENT_COUNT);
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_shrink_to_fit) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Add agents until we reach a state where av.capacity() > av.size()
+    unsigned int total_size = AGENT_COUNT;
+    int ct = 0;
+    while (av.capacity() == av.size()) {
+        // Exit the test early if capacity always equals size.
+        if (ct >= 10)
+            return;
+        for (int i = 0; i < 4; ++i) {
+            agent.newAgent();  // This creates the agent, we don't actually care about it's values at this point
+            ++total_size;
+        }
+        // Force auto resize
+        EXPECT_EQ(av.size(), total_size);  // Don't need to test this here, but lint doesn't like us ignoring the value it returns
+        ++ct;
+    }
+    ASSERT_GT(av.capacity(), av.size());
+    // Add 1 more agent and shrink to fit
+    agent.newAgent();  // This creates the agent, we don't actually care about it's values at this point
+    ++total_size;
+    av.shrink_to_fit();
+    // Check capacity now equals total_count
+    ASSERT_GE(av.capacity(), total_size);
+    ASSERT_GE(av.size(), total_size);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_step_shrink_to_fit) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_shrink_to_fit);
+    AgentVector av(agent, AGENT_COUNT);
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_clear) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i)
+        agent.newAgent();  // This creates the agent, we don't actually care about it's values at this point
+    av.clear();
+    // Test again after clear, to ensure it doesn't miss the host agent birth'd agents
+    ASSERT_EQ(av.size(), 0u);
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_clear) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_clear);
+    AgentVector av(agent, AGENT_COUNT);
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_insert1) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Insert 4 agents at the end of the initial list
+    av.insert(AGENT_COUNT, 4, av[1]);
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT  + 8u);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT + 8); ++i) {
+        auto a = av[i];
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ(a.getVariable<int>("int"), i);
+        } else if (static_cast<unsigned int>(i) < AGENT_COUNT + 4) {
+            ASSERT_EQ(a.getVariable<int>("int"), 1);  // We inserted 4 copies of i
+        } else  {
+            ASSERT_EQ(a.getVariable<int>("int"), -static_cast<int>(i - (AGENT_COUNT + 4)));  // Host new agents
+        }
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_insert1) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_insert1);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 8);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_insert2) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Insert 4 agents at the end of the initial list
+    auto it1 = av.begin();
+    for (int i = 0; i < 1; ++i)
+        ++it1;
+    auto it5 = av.begin();
+    for (int i = 0; i < 5; ++i)
+        ++it5;
+    av.insert(AGENT_COUNT, it1, it5);
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT + 8u);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT + 8); ++i) {
+        auto a = av[i];
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ(a.getVariable<int>("int"), i);
+        } else if (static_cast<unsigned int>(i) < AGENT_COUNT + 4) {
+            ASSERT_EQ(a.getVariable<int>("int"), 1 + static_cast<int>(i - AGENT_COUNT));  // We inserted copies of first items [1,4]
+        } else {
+            ASSERT_EQ(a.getVariable<int>("int"), -static_cast<int>(i - (AGENT_COUNT + 4)));  // Host new agents
+        }
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_insert2) {
+    // Test the templated insert method, it doesn't use the common insert
+    // This is kind of redundant, as begin() will be called before insert()
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_insert2);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 8);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_erase) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Remove 4 agents, 2 from end of initial list, 2 from start of new list
+    av.erase(AGENT_COUNT - 2, AGENT_COUNT + 2);
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
+        auto a = av[i];
+        if (static_cast<unsigned int>(i) < AGENT_COUNT - 2) {
+            ASSERT_EQ(a.getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ(a.getVariable<int>("int"), -static_cast<int>(i + 4 - AGENT_COUNT));  // Host new agents
+        }
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_erase) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", 10);
+    model.addStepFunction(HostAgentBirthAutoSync_step_erase);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_push_back) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Insert 4 agents at the end of the initial list
+    av.push_back();
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT + 5u);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT + 5); ++i) {
+        auto a = av[i];
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ(a.getVariable<int>("int"), i);
+        } else if (static_cast<unsigned int>(i) < AGENT_COUNT + 4u) {
+            ASSERT_EQ(a.getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));  // Host new agents
+        } else {
+            ASSERT_EQ(a.getVariable<int>("int"), -12);  // push_back
+        }
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_puck_back) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", -12);
+    model.addStepFunction(HostAgentBirthAutoSync_step_push_back);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 5u);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_pop_back) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Insert 4 agents at the end of the initial list
+    av.pop_back();
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT + 3u);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT + 3); ++i) {
+        auto a = av[i];
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ(a.getVariable<int>("int"), i);
+        } else {
+            ASSERT_EQ(a.getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));  // Host new agents
+        }
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_pop_back) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", -12);
+    model.addStepFunction(HostAgentBirthAutoSync_step_pop_back);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 3u);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_resize_up) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Insert 4 agents at the end of the initial list
+    av.resize(AGENT_COUNT + 8u);
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT + 8u);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT + 3); ++i) {
+        if (static_cast<unsigned int>(i) < AGENT_COUNT) {
+            ASSERT_EQ(av[i].getVariable<int>("int"), i);
+        } else if (static_cast<unsigned int>(i) < AGENT_COUNT + 4u) {
+            ASSERT_EQ(av[i].getVariable<int>("int"), -static_cast<int>(i - AGENT_COUNT));  // Host new agents
+        } else {
+            ASSERT_EQ(av[i].getVariable<int>("int"), -12);  // resize added agents should be default value
+        }
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_resize_up) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", -12);
+    model.addStepFunction(HostAgentBirthAutoSync_step_resize_up);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT + 8u);
+}
+FLAMEGPU_STEP_FUNCTION(HostAgentBirthAutoSync_step_resize_down) {
+    HostAgentAPI agent = FLAMEGPU->agent(AGENT_NAME);
+    // It shouldn't matter whether this is called before/after
+    DeviceAgentVector av = agent.getPopulationData();
+    // Agent begins with AGENT_COUNT agents, value 0- (AGENT_COUNT-1)
+    ASSERT_EQ(av.size(), AGENT_COUNT);
+    // Host agent birth 4 agents
+    for (int i = 0; i < 4; ++i) {
+        auto a = agent.newAgent();
+        a.setVariable<int>("int", -i);
+    }
+    // Insert 4 agents at the end of the initial list
+    av.resize(AGENT_COUNT - 4u);
+    // Check the size has changed correctly
+    ASSERT_EQ(av.size(), AGENT_COUNT - 4u);
+    // Test again (need to test each with it's own update)
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT - 4); ++i) {
+        ASSERT_EQ(av[i].getVariable<int>("int"), i);
+    }
+}
+TEST(DeviceAgentVectorTest, HostAgentBirthAutoSync_resize_down) {
+    ModelDescription model(MODEL_NAME);
+    AgentDescription& agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<int>("int", -12);
+    model.addStepFunction(HostAgentBirthAutoSync_step_resize_down);
+    AgentVector av(agent, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        av[i].setVariable<int>("int", static_cast<int>(i));
+    }
+    CUDASimulation sim(model);
+    sim.setPopulationData(av);
+    sim.step();
+    sim.getPopulationData(av);
+    // Also confirm the agents weren't added twice
+    ASSERT_EQ(av.size(), AGENT_COUNT - 4u);
+}
+
+}  // namespace DeviceAgentVectorTest

--- a/tests/test_cases/runtime/host_reduction/test_misc.cu
+++ b/tests/test_cases/runtime/host_reduction/test_misc.cu
@@ -12,35 +12,35 @@ FLAMEGPU_CUSTOM_TRANSFORM(customTransform2, a) {
 }
 
 FLAMEGPU_STEP_FUNCTION(step_sumException) {
-    EXPECT_THROW(FLAMEGPU->agent("agedddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("agedddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").sum<unsigned char>("float"), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").sum<int64_t>("uint64_t"), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").sum<double>("intsssssssss16_t"), InvalidAgentVar);
     EXPECT_THROW(FLAMEGPU->agent("agent").sum<uint64_t>("isssssssssssnt"), InvalidAgentVar);
 }
 FLAMEGPU_STEP_FUNCTION(step_minException) {
-    EXPECT_THROW(FLAMEGPU->agent("agsssedddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("agsssedddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").min<uint64_t>("char"), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").min<int64_t>("uint64_t"), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").min<double>("intssssssssssssss16_t"), InvalidAgentVar);
     EXPECT_THROW(FLAMEGPU->agent("agent").min<uint64_t>("issssssssssssnt"), InvalidAgentVar);
 }
 FLAMEGPU_STEP_FUNCTION(step_maxException) {
-    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").max<double>("float"), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").max<float>("uint64_t"), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").max<double>("intsssssssssss16_t"), InvalidAgentVar);
     EXPECT_THROW(FLAMEGPU->agent("agent").max<uint64_t>("ssssssssssssssint"), InvalidAgentVar);
 }
 FLAMEGPU_STEP_FUNCTION(step_customReductionException) {
-    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").reduce<double>("float", customMax2, 0), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").reduce<float>("uint64_t", customMax2, 0), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").reduce<double>("intsssssssssss16_t", customMax2, 0), InvalidAgentVar);
     EXPECT_THROW(FLAMEGPU->agent("agent").reduce<uint64_t>("ssssssssssssssint", customMax2, 0), InvalidAgentVar);
 }
 FLAMEGPU_STEP_FUNCTION(step_histogramEvenException) {
-    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").histogramEven<double>("float", 10, 0, 10), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").histogramEven<float>("uint64_t", 10, 0, 10), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").histogramEven<double>("intsssssssssss16_t", 10, 0, 10), InvalidAgentVar);
@@ -49,14 +49,14 @@ FLAMEGPU_STEP_FUNCTION(step_histogramEvenException) {
     EXPECT_THROW(FLAMEGPU->agent("agent").histogramEven<double>("double", 10, 11, 10), InvalidArgument);
 }
 FLAMEGPU_STEP_FUNCTION(step_transformReduceException) {
-    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").transformReduce<int32_t>("uint16_t", customTransform2, customSum2, 0), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").transformReduce<float>("uint64_t", customTransform2, customSum2, 0), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").transformReduce<double>("intsssssssssss16_t", customTransform2, customSum2, 0), InvalidAgentVar);
     EXPECT_THROW(FLAMEGPU->agent("agent").transformReduce<uint64_t>("ssssssssssssssint", customTransform2, customSum2, 0), InvalidAgentVar);
 }
 FLAMEGPU_STEP_FUNCTION(step_countException) {
-    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidCudaAgent);
+    EXPECT_THROW(FLAMEGPU->agent("ageaadddnt"), InvalidAgent);
     EXPECT_THROW(FLAMEGPU->agent("agent").count<int32_t>("double", 0), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").count<float>("uint64_t", 0), InvalidVarType);
     EXPECT_THROW(FLAMEGPU->agent("agent").count<double>("intsssssssssss16_t", 0), InvalidAgentVar);

--- a/tests/test_cases/runtime/test_host_agent_creation.cu
+++ b/tests/test_cases/runtime/test_host_agent_creation.cu
@@ -18,41 +18,46 @@ namespace test_host_agent_creation {
 const unsigned int INIT_AGENT_COUNT = 512;
 const unsigned int NEW_AGENT_COUNT = 512;
 FLAMEGPU_STEP_FUNCTION(BasicOutput) {
+    auto t = FLAMEGPU->agent("agent");
     for (unsigned int i = 0; i < NEW_AGENT_COUNT; ++i)
-        FLAMEGPU->newAgent("agent").setVariable<float>("x", 1.0f);
+        t.newAgent().setVariable<float>("x", 1.0f);
 }
 FLAMEGPU_EXIT_CONDITION(BasicOutputCdn) {
+    auto t = FLAMEGPU->agent("agent");
     for (unsigned int i = 0; i < NEW_AGENT_COUNT; ++i)
-        FLAMEGPU->newAgent("agent").setVariable<float>("x", 1.0f);
+        t.newAgent().setVariable<float>("x", 1.0f);
     return CONTINUE;  // New agents wont be created if EXIT is passed
 }
 FLAMEGPU_STEP_FUNCTION(OutputState) {
+    auto t = FLAMEGPU->agent("agent", "b");
     for (unsigned int i = 0; i < NEW_AGENT_COUNT; ++i)
-        FLAMEGPU->newAgent("agent", "b").setVariable<float>("x", 1.0f);
+        t.newAgent().setVariable<float>("x", 1.0f);
 }
 FLAMEGPU_STEP_FUNCTION(OutputMultiAgent) {
+    auto t = FLAMEGPU->agent("agent", "b");
+    auto t2 = FLAMEGPU->agent("agent2");
     for (unsigned int i = 0; i < NEW_AGENT_COUNT; ++i) {
-        FLAMEGPU->newAgent("agent", "b").setVariable<float>("x", 1.0f);
-        FLAMEGPU->newAgent("agent2").setVariable<float>("y", 2.0f);
+        t.newAgent().setVariable<float>("x", 1.0f);
+        t2.newAgent().setVariable<float>("y", 2.0f);
     }
 }
 FLAMEGPU_STEP_FUNCTION(BadVarName) {
-    FLAMEGPU->newAgent("agent").setVariable<float>("nope", 1.0f);
+    FLAMEGPU->agent("agent").newAgent().setVariable<float>("nope", 1.0f);
 }
 FLAMEGPU_STEP_FUNCTION(BadVarType) {
-    FLAMEGPU->newAgent("agent").setVariable<int64_t>("x", static_cast<int64_t>(1.0f));
+    FLAMEGPU->agent("agent").newAgent().setVariable<int64_t>("x", static_cast<int64_t>(1.0f));
 }
 FLAMEGPU_STEP_FUNCTION(Getter) {
     for (unsigned int i = 0; i < NEW_AGENT_COUNT; ++i) {
-        auto newAgt = FLAMEGPU->newAgent("agent");
+        auto newAgt = FLAMEGPU->agent("agent").newAgent();
         newAgt.setVariable<float>("x", newAgt.getVariable<float>("default"));
     }
 }
 FLAMEGPU_STEP_FUNCTION(GetBadVarName) {
-    FLAMEGPU->newAgent("agent").getVariable<float>("nope");
+    FLAMEGPU->agent("agent").newAgent().getVariable<float>("nope");
 }
 FLAMEGPU_STEP_FUNCTION(GetBadVarType) {
-    FLAMEGPU->newAgent("agent").getVariable<int64_t>("x");
+    FLAMEGPU->agent("agent").newAgent().getVariable<int64_t>("x");
 }
 TEST(HostAgentCreationTest, FromInit) {
     // Define model
@@ -394,8 +399,9 @@ TEST(HostAgentCreationTest, GetterBadVarType) {
 // array variable stuff
 const unsigned int AGENT_COUNT = 1024;
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth) {
+    auto t = FLAMEGPU->agent("agent_name");
     for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
-        auto a = FLAMEGPU->newAgent("agent_name");
+        auto a = t.newAgent();
         a.setVariable<unsigned int>("id", i);
         a.setVariable<int, 4>("array_var", { 2 + i, 4 + i, 8 + i, 16 + i });
         a.setVariable<int>("array_var2", 0, 3 + i);
@@ -406,8 +412,9 @@ FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth) {
     }
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirthSetGet) {
+    auto t = FLAMEGPU->agent("agent_name");
     for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
-        auto a = FLAMEGPU->newAgent("agent_name");
+        auto a = t.newAgent();
         a.setVariable<unsigned int>("id", i);
         // Set
         a.setVariable<int, 4>("array_var", { 2 + i, 4 + i, 8 + i, 16 + i });
@@ -426,33 +433,34 @@ FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirthSetGet) {
     }
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_DefaultWorks) {
+    auto t = FLAMEGPU->agent("agent_name");
     for (int i = 0; i < static_cast<int>(AGENT_COUNT); ++i) {
-        FLAMEGPU->newAgent("agent_name");
+        t.newAgent();
     }
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_LenWrong) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int, 5>("array_var", {});
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int, 5>("array_var", {});
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_LenWrong2) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int>("array_var", 5, 0);
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int>("array_var", 5, 0);
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_TypeWrong) {
-    FLAMEGPU->newAgent("agent_name").setVariable<float, 4>("array_var", {});
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<float, 4>("array_var", {});
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_TypeWrong2) {
-    FLAMEGPU->newAgent("agent_name").setVariable<float>("array_var", 4, 0.0F);
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<float>("array_var", 4, 0.0F);
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_NameWrong) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int, 4>("array_varAAAAAA", {});
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int, 4>("array_varAAAAAA", {});
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_NameWrong2) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int>("array_varAAAAAA", 4, 0);
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int>("array_varAAAAAA", 4, 0);
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_ArrayNotSuitableSet) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int>("array_var", 12);
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int>("array_var", 12);
 }
 FLAMEGPU_STEP_FUNCTION(ArrayVarHostBirth_ArrayNotSuitableGet) {
-    FLAMEGPU->newAgent("agent_name").getVariable<int>("array_var");
+    FLAMEGPU->agent("agent_name").newAgent().getVariable<int>("array_var");
 }
 TEST(HostAgentCreationTest, HostAgentBirth_ArraySet) {
     const std::array<int, 4> TEST_REFERENCE = { 2, 4, 8, 16 };
@@ -635,10 +643,10 @@ TEST(HostAgentCreationTest, HostAgentBirth_ArrayNotSuitableGet) {
     EXPECT_THROW(sim.step(), InvalidAgentVar);
 }
 FLAMEGPU_STEP_FUNCTION(reserved_name_step) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int>("_", 0);
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int>("_", 0);
 }
 FLAMEGPU_STEP_FUNCTION(reserved_name_step_array) {
-    FLAMEGPU->newAgent("agent_name").setVariable<int, 3>("_", {});
+    FLAMEGPU->agent("agent_name").newAgent().setVariable<int, 3>("_", {});
 }
 TEST(HostAgentCreationTest, reserved_name) {
     ModelDescription model("model");

--- a/tests/test_cases/runtime/test_host_agent_sort.cu
+++ b/tests/test_cases/runtime/test_host_agent_sort.cu
@@ -6,16 +6,16 @@ namespace test_host_agent_sort {
 
 const unsigned int AGENT_COUNT = 1024;
 FLAMEGPU_STEP_FUNCTION(sort_ascending_float) {
-    FLAMEGPU->agent("agent").sort<float>("float", HostAgentInstance::Asc);
+    FLAMEGPU->agent("agent").sort<float>("float", HostAgentAPI::Asc);
 }
 FLAMEGPU_STEP_FUNCTION(sort_descending_float) {
-    FLAMEGPU->agent("agent").sort<float>("float", HostAgentInstance::Desc);
+    FLAMEGPU->agent("agent").sort<float>("float", HostAgentAPI::Desc);
 }
 FLAMEGPU_STEP_FUNCTION(sort_ascending_int) {
-  FLAMEGPU->agent("agent").sort<int>("int", HostAgentInstance::Asc);
+  FLAMEGPU->agent("agent").sort<int>("int", HostAgentAPI::Asc);
 }
 FLAMEGPU_STEP_FUNCTION(sort_descending_int) {
-    FLAMEGPU->agent("agent").sort<int>("int", HostAgentInstance::Desc);
+    FLAMEGPU->agent("agent").sort<int>("int", HostAgentAPI::Desc);
 }
 
 TEST(HostAgentSort, Ascending_float) {
@@ -172,22 +172,22 @@ TEST(HostAgentSort, Descending_int) {
 }
 
 FLAMEGPU_STEP_FUNCTION(sort2x_ascending_float) {
-    FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentInstance::Asc, "float2", HostAgentInstance::Asc);
+    FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentAPI::Asc, "float2", HostAgentAPI::Asc);
 }
 FLAMEGPU_STEP_FUNCTION(sort2x_descending_float) {
-    FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentInstance::Desc, "float2", HostAgentInstance::Desc);
+    FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentAPI::Desc, "float2", HostAgentAPI::Desc);
 }
 FLAMEGPU_STEP_FUNCTION(sort2x_ascending_int) {
-    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Asc, "int2", HostAgentInstance::Asc);
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentAPI::Asc, "int2", HostAgentAPI::Asc);
 }
 FLAMEGPU_STEP_FUNCTION(sort2x_descending_int) {
-    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Desc, "int2", HostAgentInstance::Desc);
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentAPI::Desc, "int2", HostAgentAPI::Desc);
 }
 FLAMEGPU_STEP_FUNCTION(sort2x_ascdesc_int) {
-    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Asc, "int2", HostAgentInstance::Desc);
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentAPI::Asc, "int2", HostAgentAPI::Desc);
 }
 FLAMEGPU_STEP_FUNCTION(sort2x_descasc_int) {
-    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentInstance::Desc, "int2", HostAgentInstance::Asc);
+    FLAMEGPU->agent("agent").sort<int, int>("int1", HostAgentAPI::Desc, "int2", HostAgentAPI::Asc);
 }
 TEST(HostAgentSort, 2x_Ascending_float) {
     // Define model


### PR DESCRIPTION
Requires squash before rebase/merge, haven't pre-squashed because I don't like some components (e.g. automatically performing host agent birth), easier to remove if i can revert some commits.

`HostAgentAPI` direct access to agent data.

**TODO**
- [x] Rename `HostAgentInstance` to `HostAgentAPI` (and all the `FLAMEGPU_` runtime classes too)
- [x] Add `HostAgentTools::getPopulation()`/`setPopulation()`
- [x] Add internal change tracking to `AgentVector` (it doesn't need to be publicly user accessible)
- [x] Make `DeviceAgentVector` use the change tracking.
- [x] Perform auto sync on step function exit
- [x] Perform auto sync on host reductions 
- [x] Download variable data on-demand?
- [x] Do something about Host Agent Birth 🤷‍♂️
- [x] Decide if we want to hide any `AgentVector` functionality.
- [x] C tests
- [x] Implement SWIG interface
- [x] Py tests


Relates to #246
Closes #51 
Closes #71 

Current interface proposal (Changed from @ptheywood's #246, after brief discussion at meeting).

```c++
FLAMEGPU_STEP_FUNCTION(step_function) {
    // State argument can be ommitted if model does not use states
    HostAgentAPI agent = FLAMEGPU->agent("agent", "default");
    // Get a population (HostAgentVector inherits from AgentVector to allow method hiding etc, may not be necessary)
    HostAgentVector population = agent.getPopulation();

    // Perform a parallel reduction over the whole population
    // Variable hasn't changed within pop so device reduction is fine
    int sum_a = population.sum<int>("a");

    // Iterate the population on the host
    for(auto agentInstance : population){
        // Access variables - with JIT copying
        float x = agentInstance.getVariable<float>("x");
        // Host modification, sets flags to push to device when required
        agentInstance.setVariable<float>("x", x+1);
    }
    
    // Support agent death with normal AgentVector mechanics
    population.erase(4);    

    // Also support setting a common value over the entire population.
    // This is not currently present in AgentVector (do we want to make it generally applicable? would it better to force this to occur via custom reduce/transform?)
    population.setVariableAll<float>("x", 1.0f);

    // The population must be restored if (the particular variable is) changed, before a reduction would be applied
    // SEATBELTS warns about this if it's missing
    agent.setPopulation(population);
    float reduction = agent.reduce<float>("x");

    // Host agent birth needs some thought
    // As it's desirable for it to also affect reductions
    // It should be more efficient than creation via AgentVector, but agent vector makes it a bit redundant.
    auto newInstance = population.newAgent();
    newInstance.setVariable<float>("x", 0.0f);

    // If a user forgets to set a modified population, SEATBELTS will complain
    // We need a means of allowing users to flag they don't wish to return a changed population
}
````
------------

Other notes from discussion:
* Is `FLAMEGPU->agentPopulation("agent");` supposed to return an (equivalent to) `AgentVector`
   *  `FLAMEGPU->agent("agent");` currently returns a `HostAgentInstance`, potentially better renamed `HostAgentTools`? This could then have a method `HostAgentTools::getAgentVector()` (or a better name), which returns the `HostAgentVector`.
* If `population` is equivalent to `AgentVector`, why is it `AgentInstance::die()`, rather than `AgentVector::erase(). I would expect consistency to be preferable.
* Should a host api reduction really cause downloaded agent populations to be upload early?
     * If that's the case, should host agent birth also be applied early?
* The downloaded populations are automatically re-uploaded to device.
* Direct access to agents via an `AgentVector` analogue, essentially makes (the more efficient?) host agent birth redundant. Should this be removed?
* Should the host reductions be accessible via the `AgentVector` analogue or should the analogue be distinct, and named in a manner to discourage use?

It seems as though this `HostAgentVector` should wrap a regular `AgentVector`, providing essentially duplicate/compatible functionality with additional features for creating an effective changelog, to reduce data transfer. It will also need to link pretty deeply with the HostAPI object, to be checked whenever a reduction occurs.

Simplifying these mechanics, at the cost of performance could be preferable, so this requires discussion (or rather clarification from @mondus regarding how 'easy' he wants it to be for people to do very expensive host-agent transactions).

It may also be simpler to make the changelog a core `protected` visibility internal component of `AgentVector`, which is updated within normal usage, but only ever read by the HostAPI.

With regards to mechanics of the changelog. Tracking the first and last modified items for each variable is the obvious way to go. Allowing copies to minimised. Obviously certain methods would savage this, and essentially require all agent data to be updated. However by private overloading `AgentVector`, we could selectively expose the permitted methods.

Rough List of question/answers
> Should the downloaded agent data be automatically updated at the end? (otherwise user must explicitly commit changes, we could detect when a user forgot to upload [with seatbelts?]).

Erring on the side of manual upload/download.

> Should an agent reduction force upload agent data and clear the change log? (otherwise a user must explicitly commit changes before the reduction)

Manual, but give users a seatbelts warning/error.

> Should the host-agent reductions be moved inside the `AgentVector` analogue? (or kept separate, in-order to discourage host-agent access, rather than it be a 'default')

Keep separate

> Should `HostAgentInstance` be renamed `HostAgentTools` (or something else?)

Yes

> Should the changelog be built into `AgentVector` to make dependent class far simpler.

Yes
> How much `AgentVector` functionality should be exposed? (e.g. do we want to go as far as allowing them to insert externally defined `AgentVector`s?

Everything for the time being, can restrict it later

> Should the existing (more efficient?) host agent birth be removed? as host agent access duplicates this behaviour.

No

> How should host agent birth interact with host agent access/reductions (should they be distinct or not)

Yes it should interact with reductions
