### PR TITLE
Visualise Agent Direction 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ include(CMakeDependentOption)
 # Option to enable/disable building the static library
 option(BUILD_FLAMEGPU2 "Enable building FLAMEGPU2 library" ON)
 
+# Option to enable/disable building the static library
+option(VISUALISATION "Enable visualisation support" OFF)
+
 # Option to enable building all examples
 option(BUILD_ALL_EXAMPLES "Enable building examples" ON)
 
@@ -52,12 +55,11 @@ option(BUILD_EXAMPLE_CIRCLES_SPATIAL3D "Enable building examples/circles_spatial
 option(BUILD_EXAMPLE_GAME_OF_LIFE "Enable building examples/game_of_life" OFF)
 option(BUILD_EXAMPLE_HOST_FUNCTIONS "Enable building examples/host_functions" OFF)
 option(BUILD_EXAMPLE_ENSEMBLE "Enable building examples/ensemble" OFF)
+                       
 option(BUILD_SWIG_PYTHON "Enable python bindings via SWIG" OFF)
 cmake_dependent_option(BUILD_SWIG_PYTHON_VIRTUALENV "Enable building of SWIG Python Virtual Env for Python Testing" OFF
                        "BUILD_SWIG_PYTHON" OFF)
 
-# Option to enable/disable building the static library
-option(VISUALISATION "Enable visualisation support" OFF)
 
 
 # Option to enable/disable tests.

--- a/examples/boids_bruteforce/src/main.cu
+++ b/examples/boids_bruteforce/src/main.cu
@@ -372,9 +372,13 @@ int main(int argc, const char ** argv) {
         float envWidth = env.getProperty<float>("MAX_POSITION") - env.getProperty<float>("MIN_POSITION");
         const float INIT_CAM = env.getProperty<float>("MAX_POSITION") * 1.25f;
         visualisation.setInitialCameraLocation(INIT_CAM, INIT_CAM, INIT_CAM);
-        visualisation.setCameraSpeed(0.002f * envWidth);
+        visualisation.setCameraSpeed(0.001f * envWidth);
+        visualisation.setViewClips(0.00001f, 50);
         auto &circ_agt = visualisation.addAgent("Boid");
         // Position vars are named x, y, z; so they are used by default
+        circ_agt.setForwardXVariable("fx");
+        circ_agt.setForwardYVariable("fy");
+        circ_agt.setForwardZVariable("fz");
         circ_agt.setModel(Stock::Models::ICOSPHERE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS"));
     }

--- a/examples/boids_rtc_bruteforce/src/main.cu
+++ b/examples/boids_rtc_bruteforce/src/main.cu
@@ -416,9 +416,13 @@ int main(int argc, const char ** argv) {
         float envWidth = env.getProperty<float>("MAX_POSITION") - env.getProperty<float>("MIN_POSITION");
         const float INIT_CAM = env.getProperty<float>("MAX_POSITION") * 1.25f;
         visualisation.setInitialCameraLocation(INIT_CAM, INIT_CAM, INIT_CAM);
-        visualisation.setCameraSpeed(0.002f * envWidth);
+        visualisation.setCameraSpeed(0.001f * envWidth);
+        visualisation.setViewClips(0.00001f, 50);
         auto &circ_agt = visualisation.addAgent("Boid");
         // Position vars are named x, y, z; so they are used by default
+        circ_agt.setForwardXVariable("fx");
+        circ_agt.setForwardYVariable("fy");
+        circ_agt.setForwardZVariable("fz");
         circ_agt.setModel(Stock::Models::ICOSPHERE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS"));
     }

--- a/examples/boids_rtc_spatial3D/src/main.cu
+++ b/examples/boids_rtc_spatial3D/src/main.cu
@@ -338,7 +338,7 @@ int main(int argc, const char ** argv) {
     EnvironmentDescription &env = model.Environment();
     {
         // Population size to generate, if no agents are loaded from disk
-        env.newProperty("POPULATION_TO_GENERATE", 32768u);
+        env.newProperty("POPULATION_TO_GENERATE", 1024u);
 
         // Environment Bounds
         env.newProperty("MIN_POSITION", -0.5f);
@@ -418,10 +418,14 @@ int main(int argc, const char ** argv) {
         float envWidth = env.getProperty<float>("MAX_POSITION") - env.getProperty<float>("MIN_POSITION");
         const float INIT_CAM = env.getProperty<float>("MAX_POSITION") * 1.25f;
         visualisation.setInitialCameraLocation(INIT_CAM, INIT_CAM, INIT_CAM);
-        visualisation.setCameraSpeed(0.002f * envWidth);
+        visualisation.setCameraSpeed(0.001f * envWidth);
+        visualisation.setViewClips(0.00001f, 50);
         auto &circ_agt = visualisation.addAgent("Boid");
         // Position vars are named x, y, z; so they are used by default
-        circ_agt.setModel(Stock::Models::ICOSPHERE);
+        circ_agt.setForwardXVariable("fx");
+        circ_agt.setForwardYVariable("fy");
+        circ_agt.setForwardZVariable("fz");
+        circ_agt.setModel(Stock::Models::STUNTPLANE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS"));
     }
     visualisation.activate();

--- a/examples/boids_spatial3D/src/main.cu
+++ b/examples/boids_spatial3D/src/main.cu
@@ -379,9 +379,13 @@ int main(int argc, const char ** argv) {
         float envWidth = env.getProperty<float>("MAX_POSITION") - env.getProperty<float>("MIN_POSITION");
         const float INIT_CAM = env.getProperty<float>("MAX_POSITION") * 1.25f;
         visualisation.setInitialCameraLocation(INIT_CAM, INIT_CAM, INIT_CAM);
-        visualisation.setCameraSpeed(0.002f * envWidth);
+        visualisation.setCameraSpeed(0.001f * envWidth);
+        visualisation.setViewClips(0.00001f, 50);
         auto &circ_agt = visualisation.addAgent("Boid");
         // Position vars are named x, y, z; so they are used by default
+        circ_agt.setForwardXVariable("fx");
+        circ_agt.setForwardYVariable("fy");
+        circ_agt.setForwardZVariable("fz");
         circ_agt.setModel(Stock::Models::ICOSPHERE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS"));
     }

--- a/examples/swig_boids_spatial3D/boids_spatial3D.py
+++ b/examples/swig_boids_spatial3D/boids_spatial3D.py
@@ -405,10 +405,14 @@ if pyflamegpu.VISUALISATION:
     envWidth = env.getPropertyFloat("MAX_POSITION") - env.getPropertyFloat("MIN_POSITION");
     INIT_CAM = env.getPropertyFloat("MAX_POSITION") * 1.25;
     visualisation.setInitialCameraLocation(INIT_CAM, INIT_CAM, INIT_CAM);
-    visualisation.setCameraSpeed(0.002 * envWidth);
+    visualisation.setCameraSpeed(0.001 * envWidth);
+    visualisation.setViewClips(0.00001, 50);
     circ_agt = visualisation.addAgent("Boid");
     # Position vars are named x, y, z; so they are used by default
-    circ_agt.setModel(pyflamegpu.ICOSPHERE);
+    circ_agt.setForwardXVariable("fx");
+    circ_agt.setForwardYVariable("fy");
+    circ_agt.setForwardZVariable("fz");
+    circ_agt.setModel(pyflamegpu.STUNTPLANE);
     circ_agt.setModelScale(env.getPropertyFloat("SEPARATION_RADIUS") * 10);
     visualisation.activate();
 

--- a/include/flamegpu/visualiser/AgentVis.h
+++ b/include/flamegpu/visualiser/AgentVis.h
@@ -6,10 +6,12 @@
 #include <unordered_map>
 #include <memory>
 #include <string>
+#include <map>
 
 #include "flamegpu/visualiser/AgentStateVis.h"
 #include "config/AgentStateConfig.h"
 #include "config/Stock.h"
+#include "config/TexBufferConfig.h"
 
 struct Palette;
 struct AgentData;
@@ -27,6 +29,7 @@ class AutoPalette;
 class AgentVis {
     friend class ModelVis;
     friend class AgentStateVis;
+
  public:
     /**
      * @param agent The CUDAAgent this class is configuring the visualisation for
@@ -43,40 +46,126 @@ class AgentVis {
     AgentStateVis &State(const std::string &state_name);
 
     /**
-     * Set the name of the variable representing the agents x location
+     * Set the name of the variable representing the agents x/y/z location coordinates
      * @param var_name Name of the agent variable
-     * @note unnecessary if the variable is "x"
+     * @note unnecessary if the variables are named "x", "y", "z" respectively
      */
     void setXVariable(const std::string &var_name);
-    /**
-     * Set the name of the variable representing the agents y location
-     * @param var_name Name of the agent variable
-     * @note unnecessary if the variable is "y"
-     */
     void setYVariable(const std::string &var_name);
-    /**
-     * Set the name of the variable representing the agents z location
-     * @param var_name Name of the agent variable
-     * @note unnecessary if the variable is "z", or the model is 2D
-     */
     void setZVariable(const std::string &var_name);
     /**
-     * Clears the agent's z variable binding
-     * @see setZVariable(const std::string &)
+     * Set the name of the variable representing the agents x/y/z direction vector components
+     * Single axis rotation only requires x/z components
+     * Double axis rotation requires all 3 components
+     * Triple axis rotation requires all 3 components and additionally all 3 Up components
+     * @param var_name Name of the agent variable
      */
-    void clearZVariables();
+    void setForwardXVariable(const std::string& var_name);
+    void setForwardYVariable(const std::string& var_name);
+    void setForwardZVariable(const std::string& var_name);
     /**
-     * Returns the variable used for the agent's location's x coordinate
+     * Set the name of the variable representing the agents x/y/z UP vector
+     * This should be 90 degrees perpendicular to the direction vector
+     * @param var_name Name of the agent variable
+     */
+    void setUpXVariable(const std::string& var_name);
+    void setUpYVariable(const std::string& var_name);
+    void setUpZVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents yaw rotation angle (radians)
+     * This is an alternate to providing a direction vector, setting this will erase direction x/z if bound
+     *
+     * @param var_name Name of the agent variable
+     * @note setRollVariable() can be used in place of the UP vector if preferred
+     */
+    void setYawVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents pitch rotation angle (radians)
+     * This is an alternate to providing a direction vector, setting this will erase direction y if bound
+     *
+     * @param var_name Name of the agent variable
+     */
+    void setPitchVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents yaw rotation angle (radians)
+     * This is an alternate to providing an UP vector, setting this will erase up x/y/z if bound
+     *
+     * @param var_name Name of the agent variable
+     * @note setRollVariable() can be used in place of the UP vector if preferred
+     */
+    void setRollVariable(const std::string& var_name);
+    /**
+     * Clears the agent's x/y/z location variable bindings
+     * @see setXVariable(conCst std::string &)
+     * @see setYVariable(conCst std::string &)
+     * @see setZVariable(conCst std::string &)
+     */
+    void clearXVariable();
+    void clearYVariable();
+    void clearZVariable();
+    /**
+     * Clears the agent's x/y/z direction variable bindings
+     * @see setForwardXVariable(const std::string &)
+     * @see setForwardYVariable(const std::string &)
+     * @see setForwardZVariable(const std::string &)
+     */
+    void clearForwardXVariable();
+    void clearForwardYVariable();
+    void clearForwardZVariable();
+    /**
+     * Clears the agent's x/y/z UP variable bindings
+     * @see setUpXVariable(const std::string &)
+     * @see setUpYVariable(const std::string &)
+     * @see setUpZVariable(const std::string &)
+     */
+    void clearUpXVariable();
+    void clearUpYVariable();
+    void clearUpZVariable();
+    /**
+     * Clears the agent's yaw angle variable bindings
+     * @see setYawVariable(const std::string &)
+     */
+    void clearYawVariable();
+    /**
+     * Clears the agent's pitch angle variable bindings
+     * @see setPitchVariable(const std::string &)
+     */
+    void clearPitchVariable();
+    /**
+     * Clears the agent's roll angle variable bindings
+     * @see setRollVariable(const std::string &)
+     */
+    void clearRollVariable();
+    /**
+     * Returns the variable used for the agent's x/y/z location coordinates
      */
     std::string getXVariable() const;
-    /**
-     * Returns the variable used for the agent's location's y coordinate
-     */
     std::string getYVariable() const;
-    /**
-     * Returns the variable used for the agent's location's z coordinate
-     */
     std::string getZVariable() const;
+    /**
+     * Returns the variable used for the agent's x/y/z direction vector components
+     */
+    std::string getForwardXVariable() const;
+    std::string getForwardYVariable() const;
+    std::string getForwardZVariable() const;
+    /**
+     * Returns the variable used for the agent's x/y/z direction vector components
+     */
+    std::string getUpXVariable() const;
+    std::string getUpYVariable() const;
+    std::string getUpZVariable() const;
+    /**
+     * Returns the variable used for the agent's yaw angle
+     */
+    std::string getYawVariable() const;
+    /**
+     * Returns the variable used for the agent's pitch angle
+     */
+    std::string getPitchVariable() const;
+    /**
+     * Returns the variable used for the agent's roll angle
+     */
+    std::string getRollVariable() const;
 
     /**
      * Use a model from file
@@ -160,12 +249,10 @@ class AgentVis {
      */
     const AgentData &agentData;
     /**
-     * Names of the agent variables holding the agent's location
-     * @see setXVariable(const std::string &)
-     * @see setYVariable(const std::string &)
-     * @see setZVariable(const std::string &)
+     * Holds information on core agent-wide texture buffers
+     * e.g. location/direction
      */
-    std::string x_var, y_var, z_var;
+    std::map<TexBufferConfig::Function, TexBufferConfig> core_tex_buffers;
 };
 
 #endif  // VISUALISATION

--- a/src/flamegpu/visualiser/AgentStateVis.cpp
+++ b/src/flamegpu/visualiser/AgentStateVis.cpp
@@ -38,12 +38,12 @@ void AgentStateVis::setModelScale(float maxLen) {
     configFlags.model_scale = 1;
 }
 void AgentStateVis::setColor(const ColorFunction& cf) {
-    config.color_var = cf.getAgentVariableName();
+    // Remove old, we only ever want 1 color value
+    config.tex_buffers.erase(TexBufferConfig::Color);
+    config.tex_buffers.emplace(TexBufferConfig::Color, CustomTexBufferConfig{ cf.getAgentVariableName(), cf.getSamplerName() });
     config.color_shader_src = cf.getSrc();
-    config.color_var_name = cf.getSamplerName();
 }
 void AgentStateVis::clearColor() {
-    config.color_var = "";
+    config.tex_buffers.erase(TexBufferConfig::Color);
     config.color_shader_src = "";
-    config.color_var_name = "";
 }

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -57,7 +57,9 @@ void ModelVis::activate() {
         visualiser = std::make_unique<FLAMEGPU_Visualisation>(modelCfg);  // Window resolution
         for (auto &agent : agents) {
             // If x and y aren't set, throw exception
-            if (agent.second.x_var.empty() && agent.second.y_var.empty() && agent.second.z_var.empty()) {
+            if (agent.second.core_tex_buffers.find(TexBufferConfig::Position_x) == agent.second.core_tex_buffers.end() &&
+                agent.second.core_tex_buffers.find(TexBufferConfig::Position_y) == agent.second.core_tex_buffers.end() &&
+                agent.second.core_tex_buffers.find(TexBufferConfig::Position_z) == agent.second.core_tex_buffers.end()) {
                 THROW VisualisationException("Agent '%s' has not had x, y or z variables set, agent requires location to render, "
                     "in ModelVis::activate()\n",
                     agent.second.agentData.name.c_str());


### PR DESCRIPTION
* Adds support for visualising agent direction via 1/2/3 axis rotation.
    * Direction can be specified as forward/up vectors, or the individual rotations for each axis.
* Also reworked how texture buffer requirements for an agent are passed to the visualiser, this is now more dynamic and will more easily support extensions in future (e.g. 2-frame animation, bespoke shaders).
* Updates agents to use `LightsBuffer` lighting, fixing phong shader.
* Adds a new model of a stunt plane.
* Updates boids example visualisations to specify forward variables.
* Updates spatial boids example visualisations to use stunt plane model.

Closes https://github.com/FLAMEGPU/FLAMEGPU2_visualiser/issues/34

Relevant vis PR: https://github.com/FLAMEGPU/FLAMEGPU2_visualiser/pull/40

**todo**
- [ ] Vis currently treats Y as up, and expects the initial direction of a model to be `(1,0,0)`. Do we want to change this?