### PR TITLE
Fix Windows CI

### DIFF
--- a/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial2D/Spatial2DDevice.h
@@ -291,8 +291,8 @@ __device__ T MsgSpatial2D::In::Filter::Message::getVariable(const char(&variable
 __device__ __forceinline__ MsgSpatial2D::GridPos2D getGridPosition2D(const MsgSpatial2D::MetaData *md, float x, float y) {
     // Clamp each grid coord to 0<=x<dim
     int gridPos[2] = {
-        static_cast<int>(floor(((x-md->min[0]) / md->environmentWidth[0])*md->gridDim[0])),
-        static_cast<int>(floor(((y-md->min[1]) / md->environmentWidth[1])*md->gridDim[1]))
+        static_cast<int>(floorf(((x-md->min[0]) / md->environmentWidth[0])*md->gridDim[0])),
+        static_cast<int>(floorf(((y-md->min[1]) / md->environmentWidth[1])*md->gridDim[1]))
     };
     MsgSpatial2D::GridPos2D rtn = {
         gridPos[0] < 0 ? 0 : (gridPos[0] >= static_cast<int>(md->gridDim[0]) ? static_cast<int>(md->gridDim[0]) - 1 : gridPos[0]),

--- a/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.h
@@ -303,9 +303,9 @@ __device__ T MsgSpatial3D::In::Filter::Message::getVariable(const char(&variable
 __device__ __forceinline__ MsgSpatial3D::GridPos3D getGridPosition3D(const MsgSpatial3D::MetaData *md, float x, float y, float z) {
     // Clamp each grid coord to 0<=x<dim
     int gridPos[3] = {
-        static_cast<int>(floor(((x-md->min[0]) / md->environmentWidth[0])*md->gridDim[0])),
-        static_cast<int>(floor(((y-md->min[1]) / md->environmentWidth[1])*md->gridDim[1])),
-        static_cast<int>(floor(((z-md->min[2]) / md->environmentWidth[2])*md->gridDim[2]))
+        static_cast<int>(floorf(((x-md->min[0]) / md->environmentWidth[0])*md->gridDim[0])),
+        static_cast<int>(floorf(((y-md->min[1]) / md->environmentWidth[1])*md->gridDim[1])),
+        static_cast<int>(floorf(((z-md->min[2]) / md->environmentWidth[2])*md->gridDim[2]))
     };
     MsgSpatial3D::GridPos3D rtn = {
         gridPos[0] < 0 ? 0 : (gridPos[0] >= static_cast<int>(md->gridDim[0]) ? static_cast<int>(md->gridDim[0]) - 1 : gridPos[0]),


### PR DESCRIPTION
An update to the CI server between Sunday/Monday has caused windows builds of the lib to fail due to __floorf() not being defined in device code.

Appears the latest update to visual studio is to blame: https://devtalk.blender.org/t/cuda-compile-error-windows-10/17886/5