### PR TITLE
Remove some ../ from include paths via cmake

### DIFF
--- a/cmake/Tinyxml2.cmake
+++ b/cmake/Tinyxml2.cmake
@@ -51,7 +51,9 @@ if(NOT tinyxml2_POPULATED)
     
         # Specify the interface headers library, to be forwarded.
         # For our use  case, this is up a folder so we can use tinyxml2/tinyxml2.h as the include.
-        target_include_directories(tinyxml2 INTERFACE ${tinyxml2_SOURCE_DIR}/..)
+        # Find the resolved abs path to this. 
+        get_filename_component(tinyxml2_inc_dir ${tinyxml2_SOURCE_DIR}/../ REALPATH)
+        target_include_directories(tinyxml2 INTERFACE ${tinyxml2_inc_dir})
         
         # Add some compile time definitions
         target_compile_definitions(tinyxml2 INTERFACE $<$<CONFIG:Debug>:TINYXML2_DEBUG>)

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 # set include directories for module build
 target_include_directories(${PYTHON_MODULE_NAME}
   PRIVATE
-  ../../include
+  ${FLAMEGPU_ROOT}/include
   ${Python3_INCLUDE_DIRS}
   )
   


### PR DESCRIPTION
This will sliglty clean up the use of `__FILE__` in some exceptions (swig) so that they do not include any `..` steps, makeing them a bit clearer to the user. 