### PR TITLE
Improve SWIG exceptions

### DIFF
--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -155,6 +155,7 @@ class FGPURuntimeException : public std::exception {
      FGPURuntimeException(std::string msg, std::string type) {
          err_message = msg;
          type_str = type;
+         str_str = std::string("(") + type + ") " + msg;
      }
      const char* what() const noexcept {
          return err_message.c_str();
@@ -162,9 +163,13 @@ class FGPURuntimeException : public std::exception {
      const char* type() const {
          return type_str.c_str();
      }
+     const char* __str__() const {
+         return str_str.c_str();
+     }
  protected:
     std::string err_message;
     std::string type_str;
+    std::string str_str;
 };
 %}
 // Exception handling


### PR DESCRIPTION
Python now writes out their type/message by default when the exception is unhandled.

Closes #441

It still outputs pyflamegpu.pyflamegpu.FGPURuntimeException: at the start, as this is the pythone exception class we use.

Converting that to the relevant exception type would require something hacky (or unstable), as SWIG doesn't provide a dynamic way to convert any object to it's PyObject.

Similarly, I couldn't find a way to override that by setting _repr_ or similar.