### PR TITLE
Visualiser: Update step count earlier.

### DIFF
--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -12,11 +12,11 @@
 #include "flamegpu/visualiser/StaticModelVis.h"
 #include "flamegpu/visualiser/LineVis.h"
 #include "flamegpu/visualiser/color/AutoPalette.h"
-#include "FLAMEGPU_Visualisation.h"
 #include "config/ModelConfig.h"
 
 struct ModelData;
 class CUDASimulation;
+class FLAMEGPU_Visualisation;
 
 /**
  * This provides an interface for managing the render options for a specific CUDASimulation

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -22,6 +22,9 @@
 #include "flamegpu/gpu/CUDAMessage.h"
 #include "flamegpu/sim/LoggingConfig.h"
 #include "flamegpu/sim/LogFrame.h"
+#ifdef VISUALISATION
+#include "FLAMEGPU_Visualisation.h"
+#endif
 
 std::map<int, std::atomic<int>> CUDASimulation::active_device_instances;
 std::map<int, std::shared_timed_mutex> CUDASimulation::active_device_mutex;

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -4,7 +4,7 @@
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/visualiser/color/ColorFunction.h"
 #include "flamegpu/visualiser/color/StaticColor.h"
-#include "FLAMEGPU_Visualisation.h"  // TODO - This should probably be flamegpu2-visualiser/FLAMEGPU_Visualisation.h?
+#include "FLAMEGPU_Visualisation.h"
 
 AgentVis::AgentVis(CUDAAgent &_agent, const std::shared_ptr<AutoPalette>& autopalette)
     : owned_auto_palette(nullptr)


### PR DESCRIPTION
This fixes step count being 1 ahead when vis pauses sim.

Also moved an include of FLAMEGPU_Visualisation.h from header to src to help incremental builds.

Relates to https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/issues/54

Will merge as soon as CI passes.