### PR TITLE
Visualise Scale

### DIFF
--- a/include/flamegpu/visualiser/AgentVis.h
+++ b/include/flamegpu/visualiser/AgentVis.h
@@ -214,10 +214,11 @@ class AgentVis {
     /**
      * This requests that the visualisation resizes buffers
      * @param vis The affected visualisation
+     * @param force When true is passed, vis will delay closing the splash screen until this update has been processed
      * Used when agent population has grown
      * @return Returns true if a non-0 buffer was requested
      */
-    bool requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation> &vis);
+    bool requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation> &vis, bool force);
     /**
      * This passes the correct device pointers to the visualisation and forces it to update the data used for rendering
      * @param vis The affected visualisation

--- a/include/flamegpu/visualiser/AgentVis.h
+++ b/include/flamegpu/visualiser/AgentVis.h
@@ -59,6 +59,11 @@ class AgentVis {
      * Double axis rotation requires all 3 components
      * Triple axis rotation requires all 3 components and additionally all 3 Up components
      * @param var_name Name of the agent variable
+     * @note setForwardXVariable() and setForwardZVariable() are an alternate to providing a yaw angle, setting either of these will erase yaw if bound
+     * @see setYawVariable(const std::string&)
+     * @note setForwardYVariable() is an alternate to providing a pitch angle, setting this will erase pitch if bound
+     * @see setPitchVariable(const std::string&)
+     * @note Forward is a synonym for Direction
      */
     void setForwardXVariable(const std::string& var_name);
     void setForwardYVariable(const std::string& var_name);
@@ -67,33 +72,70 @@ class AgentVis {
      * Set the name of the variable representing the agents x/y/z UP vector
      * This should be 90 degrees perpendicular to the direction vector
      * @param var_name Name of the agent variable
+     * @note setUpXVariable(), setUpYVariable() and setUpZVariable() are an alternate to providing a roll angle, setting any of these will erase roll if bound
+     * @see setRollVariable(const std::string&)
      */
     void setUpXVariable(const std::string& var_name);
     void setUpYVariable(const std::string& var_name);
     void setUpZVariable(const std::string& var_name);
     /**
      * Set the name of the variable representing the agents yaw rotation angle (radians)
-     * This is an alternate to providing a direction vector, setting this will erase direction x/z if bound
      *
      * @param var_name Name of the agent variable
-     * @note setRollVariable() can be used in place of the UP vector if preferred
+     * @note This is an alternate to providing a direction vector, setting this will erase forward x/z if bound
+     * @see setForwardXVariable(const std::string&)
+     * @see setForwardZVariable(const std::string&)
+     * @note Heading is a synonym for Yaw
      */
     void setYawVariable(const std::string& var_name);
     /**
      * Set the name of the variable representing the agents pitch rotation angle (radians)
-     * This is an alternate to providing a direction vector, setting this will erase direction y if bound
      *
      * @param var_name Name of the agent variable
+     * @note This is an alternate to providing a direction vector, setting this will erase forward y if bound
+     * @see setForwardYVariable(const std::string&)
      */
     void setPitchVariable(const std::string& var_name);
     /**
      * Set the name of the variable representing the agents yaw rotation angle (radians)
-     * This is an alternate to providing an UP vector, setting this will erase up x/y/z if bound
      *
      * @param var_name Name of the agent variable
-     * @note setRollVariable() can be used in place of the UP vector if preferred
+     * @note This is an alternate to providing an UP vector, setting this will erase up x/y/z if bound
+     * @see setUpXVariable(const std::string&)
+     * @see setUpYVariable(const std::string&)
+     * @see setUpZVariable(const std::string&)
+     * @note Bank is a synonym for Roll
      */
     void setRollVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents uniform scale multiplier
+     *
+     * The scale multiplier is multiplied by the model scale
+     *
+     * @param var_name Name of the agent variable
+     * @note This is an alternate to providing individual scale components, setting this will erase scale x/y/z if bound
+     * @see setScaleXVariable(const std::string&)
+     * @see setScaleYVariable(const std::string&)
+     * @see setScaleZVariable(const std::string&)
+     * @see setModelScale(float)
+     * @see setModelScale(float, float, float)
+     */
+    void setUniformScaleVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents x/y/z scale multiplier components
+     * It is not necessary to set all 3 components if only 1 or 2 are required. Unset values will be treated as a 1.0 multiplier
+     *
+     * The scale multiplier is multiplied by the model scale
+     *
+     * @param var_name Name of the agent variable
+     * @note This is an alternate to providing a single uniform scale multiplier, setting this will erase uniform scale if bound
+     * @see setUniformScaleVariable(const std::string&)
+     * @see setModelScale(float)
+     * @see setModelScale(float, float, float)
+     */
+    void setScaleXVariable(const std::string& var_name);
+    void setScaleYVariable(const std::string& var_name);
+    void setScaleZVariable(const std::string& var_name);
     /**
      * Clears the agent's x/y/z location variable bindings
      * @see setXVariable(conCst std::string &)
@@ -104,7 +146,7 @@ class AgentVis {
     void clearYVariable();
     void clearZVariable();
     /**
-     * Clears the agent's x/y/z direction variable bindings
+     * Clears the agent's x/y/z forward variable bindings
      * @see setForwardXVariable(const std::string &)
      * @see setForwardYVariable(const std::string &)
      * @see setForwardZVariable(const std::string &)
@@ -137,19 +179,33 @@ class AgentVis {
      */
     void clearRollVariable();
     /**
+     * Clears the agent's uniform scale multiplier variable bindings
+     * @see setUniformScaleVariable(const std::string &)
+     */
+    void clearUniformScaleVariable();
+    /**
+     * Clears the agent's x/y/z scale multiplier variable bindings
+     * @see setScaleXVariable(const std::string &)
+     * @see setScaleYVariable(const std::string &)
+     * @see setScaleZVariable(const std::string &)
+     */
+    void clearScaleXVariable();
+    void clearScaleYVariable();
+    void clearScaleZVariable();
+    /**
      * Returns the variable used for the agent's x/y/z location coordinates
      */
     std::string getXVariable() const;
     std::string getYVariable() const;
     std::string getZVariable() const;
     /**
-     * Returns the variable used for the agent's x/y/z direction vector components
+     * Returns the variable used for the agent's x/y/z forward vector components
      */
     std::string getForwardXVariable() const;
     std::string getForwardYVariable() const;
     std::string getForwardZVariable() const;
     /**
-     * Returns the variable used for the agent's x/y/z direction vector components
+     * Returns the variable used for the agent's x/y/z up vector components
      */
     std::string getUpXVariable() const;
     std::string getUpYVariable() const;
@@ -166,6 +222,16 @@ class AgentVis {
      * Returns the variable used for the agent's roll angle
      */
     std::string getRollVariable() const;
+    /**
+     * Returns the variable used for the agent's uniform scaling multiplier
+     */
+    std::string getUniformScaleVariable() const;
+    /**
+     * Returns the variable used for the agent's x/y/z scale multiplier components
+     */
+    std::string getScaleXVariable() const;
+    std::string getScaleYVariable() const;
+    std::string getScaleZVariable() const;
 
     /**
      * Use a model from file

--- a/include/flamegpu/visualiser/color/ColorFunction.h
+++ b/include/flamegpu/visualiser/color/ColorFunction.h
@@ -2,6 +2,7 @@
 #define INCLUDE_FLAMEGPU_VISUALISER_COLOR_COLORFUNCTION_H_
 
 #include <string>
+#include <typeindex>
 
 /**
  * Interface for generating shader code for a function that generates a color during model execution
@@ -27,6 +28,12 @@ class ColorFunction {
      * Otherwise empty string
      */
     virtual std::string getAgentVariableName() const { return ""; }
+    /**
+     * If the shader source contains a samplerBuffer definition
+     * This should be the type of the agent variable so that the buffer can be bound to it
+     * Otherwise void typeid is returned.
+     */
+    virtual std::type_index getAgentVariableRequiredType() const { return std::type_index(typeid(void)); }
 };
 
 #endif  // INCLUDE_FLAMEGPU_VISUALISER_COLOR_COLORFUNCTION_H_

--- a/include/flamegpu/visualiser/color/DiscreteColor.h
+++ b/include/flamegpu/visualiser/color/DiscreteColor.h
@@ -71,6 +71,10 @@ class DiscreteColor : public ColorFunction, public std::map<T, Color> {
      * Returns variable_name
      */
     std::string getAgentVariableName() const override;
+    /**
+     * Returns std::type_index(typeid(T))
+     */
+    std::type_index getAgentVariableRequiredType() const override;
 
     /**
      * Checks whether the current components can be used as a valid RGBA colour

--- a/include/flamegpu/visualiser/color/HSVInterpolation.h
+++ b/include/flamegpu/visualiser/color/HSVInterpolation.h
@@ -61,6 +61,10 @@ class HSVInterpolation : public ColorFunction {
      * Returns variable_name
      */
     std::string getAgentVariableName() const override;
+    /**
+     * Returns std::type_index(typeid(float))
+     */
+    std::type_index getAgentVariableRequiredType() const override;
 
  private:
     /**

--- a/include/flamegpu/visualiser/color/ViridisInterpolation.h
+++ b/include/flamegpu/visualiser/color/ViridisInterpolation.h
@@ -47,6 +47,10 @@ class ViridisInterpolation : public ColorFunction {
      */
     std::string getAgentVariableName() const override;
     /**
+     * Returns std::type_index(typeid(float))
+     */
+    std::type_index getAgentVariableRequiredType() const override;
+    /**
      * Returns the raw colors used to generate the palette
      */
     static const std::array<const Color, 256>& rawColors();

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -240,11 +240,11 @@ void AgentVis::initBindings(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {
         vis->addAgentState(agentData.name, state, vc, core_tex_buffers, vc.tex_buffers);
     }
 }
-bool AgentVis::requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {
+bool AgentVis::requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation> &vis, bool force) {
     unsigned int agents_requested = 0;
     for (auto &state : agentData.states) {
         auto &state_map = agent.state_map.at(state);
-        vis->requestBufferResizes(agentData.name, state, state_map->getSize());
+        vis->requestBufferResizes(agentData.name, state, state_map->getSize(), force);
         agents_requested += state_map->getSize();
     }
     return agents_requested;

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -11,13 +11,13 @@ AgentVis::AgentVis(CUDAAgent &_agent, const std::shared_ptr<AutoPalette>& autopa
     , agent(_agent)
     , agentData(_agent.getAgentDescription()) {
     if (_agent.getAgentDescription().variables.find("x") != _agent.getAgentDescription().variables.end()) {
-        core_tex_buffers.emplace(TexBufferConfig::Position_x, "x");
+        setXVariable("x");
     }
     if (_agent.getAgentDescription().variables.find("y") != _agent.getAgentDescription().variables.end()) {
-        core_tex_buffers.emplace(TexBufferConfig::Position_y, "y");
+        setYVariable("y");
     }
     if (_agent.getAgentDescription().variables.find("z") != _agent.getAgentDescription().variables.end()) {
-        core_tex_buffers.emplace(TexBufferConfig::Position_z, "z");
+        setZVariable("z");
     }
     if (autopalette) {
         setColor(autopalette->next());
@@ -49,98 +49,158 @@ AgentStateVis &AgentVis::State(const std::string &state_name) {
 
 
 void AgentVis::setXVariable(const std::string &var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setXVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation position x variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setXVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Position_x].agentVariableName = var_name;
 }
 void AgentVis::setYVariable(const std::string &var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation position Y variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setYVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Position_y].agentVariableName = var_name;
 }
 void AgentVis::setZVariable(const std::string &var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation position z variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Position_z].agentVariableName = var_name;
 }
 void AgentVis::setForwardXVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setDirectionXVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation forward x variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setDirectionXVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Forward_x].agentVariableName = var_name;
 }
 void AgentVis::setForwardYVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setDirectionYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation forward y variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setDirectionYVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Forward_y].agentVariableName = var_name;
 }
 void AgentVis::setForwardZVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setDirectionZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation forward z variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setDirectionZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Forward_z].agentVariableName = var_name;
 }
 void AgentVis::setUpXVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setUpXVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation up x variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setUpXVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Up_x].agentVariableName = var_name;
 }
 void AgentVis::setUpYVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setUpYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation up y variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setUpYVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Up_y].agentVariableName = var_name;
 }
 void AgentVis::setUpZVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setUpZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation up z variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setUpZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Up_z].agentVariableName = var_name;
 }
 void AgentVis::setYawVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setYawVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation yaw variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setYawVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Heading].agentVariableName = var_name;
 }
 void AgentVis::setPitchVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setPitchVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation pitch variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setPitchVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Pitch].agentVariableName = var_name;
 }
 void AgentVis::setRollVariable(const std::string& var_name) {
-    if (agentData.variables.find(var_name) == agentData.variables.end()) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
         THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
             "in AgentVis::setRollVariable()\n",
             var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation roll variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setRollVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers[TexBufferConfig::Bank].agentVariableName = var_name;
 }
@@ -331,6 +391,20 @@ void AgentVis::setAutoPalette(const Palette& ap) {
     auto_palette = owned_auto_palette;
 }
 void AgentVis::setColor(const ColorFunction& cf) {
+    // Validate agent variable exists
+    if (!cf.getAgentVariableName().empty()) {
+        auto it = agentData.variables.find(cf.getAgentVariableName());
+        if (it == agentData.variables.end()) {
+            THROW InvalidAgentVar("Variable '%s' bound to color function was not found within agent '%s', "
+                "in AgentVis::setColor()\n",
+                cf.getAgentVariableName().c_str(), agentData.name.c_str());
+        }
+        if (it->second.type != cf.getAgentVariableRequiredType() || it->second.elements != 1) {
+            THROW InvalidAgentVar("Visualisation color function variable must be type %s[1], agent '%s' variable '%s' is type %s[%u], "
+                "in AgentVis::setColor()\n",
+                cf.getAgentVariableRequiredType().name(), agentData.name.c_str(), cf.getAgentVariableName().c_str(), it->second.type.name(), it->second.elements);
+        }
+    }
     // Remove old, we only ever want 1 color value
     defaultConfig.tex_buffers.erase(TexBufferConfig::Color);
     if (!cf.getAgentVariableName().empty() && !cf.getSamplerName().empty())

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -68,7 +68,7 @@ void AgentVis::setYVariable(const std::string &var_name) {
             "in AgentVis::setYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation position Y variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation position Y variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setYVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
@@ -81,7 +81,7 @@ void AgentVis::setZVariable(const std::string &var_name) {
             "in AgentVis::setZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation position z variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation position z variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setZVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
@@ -94,10 +94,11 @@ void AgentVis::setForwardXVariable(const std::string& var_name) {
             "in AgentVis::setDirectionXVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation forward x variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation forward x variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setDirectionXVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Heading);
     core_tex_buffers[TexBufferConfig::Forward_x].agentVariableName = var_name;
 }
 void AgentVis::setForwardYVariable(const std::string& var_name) {
@@ -107,10 +108,11 @@ void AgentVis::setForwardYVariable(const std::string& var_name) {
             "in AgentVis::setDirectionYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation forward y variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation forward y variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setDirectionYVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Pitch);
     core_tex_buffers[TexBufferConfig::Forward_y].agentVariableName = var_name;
 }
 void AgentVis::setForwardZVariable(const std::string& var_name) {
@@ -120,10 +122,11 @@ void AgentVis::setForwardZVariable(const std::string& var_name) {
             "in AgentVis::setDirectionZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation forward z variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation forward z variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setDirectionZVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Heading);
     core_tex_buffers[TexBufferConfig::Forward_z].agentVariableName = var_name;
 }
 void AgentVis::setUpXVariable(const std::string& var_name) {
@@ -133,10 +136,11 @@ void AgentVis::setUpXVariable(const std::string& var_name) {
             "in AgentVis::setUpXVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation up x variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation up x variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setUpXVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Bank);
     core_tex_buffers[TexBufferConfig::Up_x].agentVariableName = var_name;
 }
 void AgentVis::setUpYVariable(const std::string& var_name) {
@@ -146,10 +150,11 @@ void AgentVis::setUpYVariable(const std::string& var_name) {
             "in AgentVis::setUpYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation up y variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation up y variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setUpYVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Bank);
     core_tex_buffers[TexBufferConfig::Up_y].agentVariableName = var_name;
 }
 void AgentVis::setUpZVariable(const std::string& var_name) {
@@ -159,10 +164,11 @@ void AgentVis::setUpZVariable(const std::string& var_name) {
             "in AgentVis::setUpZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation up z variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation up z variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setUpZVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Bank);
     core_tex_buffers[TexBufferConfig::Up_z].agentVariableName = var_name;
 }
 void AgentVis::setYawVariable(const std::string& var_name) {
@@ -172,10 +178,12 @@ void AgentVis::setYawVariable(const std::string& var_name) {
             "in AgentVis::setYawVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation yaw variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation yaw variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setYawVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Forward_x);
+    core_tex_buffers.erase(TexBufferConfig::Forward_z);
     core_tex_buffers[TexBufferConfig::Heading].agentVariableName = var_name;
 }
 void AgentVis::setPitchVariable(const std::string& var_name) {
@@ -185,10 +193,11 @@ void AgentVis::setPitchVariable(const std::string& var_name) {
             "in AgentVis::setPitchVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation pitch variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation pitch variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setPitchVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Forward_y);
     core_tex_buffers[TexBufferConfig::Pitch].agentVariableName = var_name;
 }
 void AgentVis::setRollVariable(const std::string& var_name) {
@@ -198,11 +207,72 @@ void AgentVis::setRollVariable(const std::string& var_name) {
             "in AgentVis::setRollVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
-        THROW InvalidAgentVar("Visualisation roll variable must be a single float, agent '%s' variable '%s' is type %s[%u], "
+        THROW InvalidAgentVar("Visualisation roll variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
             "in AgentVis::setRollVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Up_x);
+    core_tex_buffers.erase(TexBufferConfig::Up_y);
+    core_tex_buffers.erase(TexBufferConfig::Up_z);
     core_tex_buffers[TexBufferConfig::Bank].agentVariableName = var_name;
+}
+void AgentVis::setUniformScaleVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setUniformScaleVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation scale variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setUniformScaleVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Scale_x);
+    core_tex_buffers.erase(TexBufferConfig::Scale_y);
+    core_tex_buffers.erase(TexBufferConfig::Scale_z);
+    core_tex_buffers[TexBufferConfig::UniformScale].agentVariableName = var_name;
+}
+void AgentVis::setScaleXVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setScaleXVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation scale x variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setScaleXVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers[TexBufferConfig::Scale_x].agentVariableName = var_name;
+}
+void AgentVis::setScaleYVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setScaleYVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation scale y variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setScaleYVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers[TexBufferConfig::Scale_y].agentVariableName = var_name;
+}
+void AgentVis::setScaleZVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setScaleZVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
+        THROW InvalidAgentVar("Visualisation scale z variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setScaleZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers[TexBufferConfig::Scale_z].agentVariableName = var_name;
 }
 void AgentVis::clearXVariable() {
     core_tex_buffers.erase(TexBufferConfig::Position_x);
@@ -239,6 +309,18 @@ void AgentVis::clearPitchVariable() {
 }
 void AgentVis::clearRollVariable() {
     core_tex_buffers.erase(TexBufferConfig::Bank);
+}
+void AgentVis::clearUniformScaleVariable() {
+    core_tex_buffers.erase(TexBufferConfig::UniformScale);
+}
+void AgentVis::clearScaleXVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Scale_x);
+}
+void AgentVis::clearScaleYVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Scale_y);
+}
+void AgentVis::clearScaleZVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Scale_z);
 }
 std::string AgentVis::getXVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Position_x);
@@ -286,6 +368,22 @@ std::string AgentVis::getPitchVariable() const {
 }
 std::string AgentVis::getRollVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Bank);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getUniformScaleVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::UniformScale);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getScaleXVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Scale_x);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getScaleYVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Scale_y);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getScaleZVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Scale_z);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
 void AgentVis::initBindings(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {

--- a/src/flamegpu/visualiser/color/DiscreteColor.cpp
+++ b/src/flamegpu/visualiser/color/DiscreteColor.cpp
@@ -34,6 +34,10 @@ template<typename T>
 std::string DiscreteColor<T>::getAgentVariableName() const {
     return variable_name;
 }
+template<typename T>
+std::type_index DiscreteColor<T>::getAgentVariableRequiredType() const {
+    return std::type_index(typeid(T));
+}
 
 template<typename T>
 bool DiscreteColor<T>::validate() const {

--- a/src/flamegpu/visualiser/color/HSVInterpolation.cpp
+++ b/src/flamegpu/visualiser/color/HSVInterpolation.cpp
@@ -124,3 +124,6 @@ std::string HSVInterpolation::getSamplerName() const {
 std::string HSVInterpolation::getAgentVariableName() const {
     return variable_name;
 }
+std::type_index HSVInterpolation::getAgentVariableRequiredType() const {
+    return std::type_index(typeid(float));
+}

--- a/src/flamegpu/visualiser/color/ViridisInterpolation.cpp
+++ b/src/flamegpu/visualiser/color/ViridisInterpolation.cpp
@@ -62,6 +62,9 @@ std::string ViridisInterpolation::getSamplerName() const {
 std::string ViridisInterpolation::getAgentVariableName() const {
     return variable_name;
 }
+std::type_index ViridisInterpolation::getAgentVariableRequiredType() const {
+    return std::type_index(typeid(float));
+}
 const std::array<const Color, 256> &ViridisInterpolation::rawColors() {
     static const std::array<const Color, 256> raw_colors = {
         Color{ 0.267004, 0.004874, 0.329415 },


### PR DESCRIPTION
* Correct issue with previous vis change, that caused model step rate to be wrong.
* Add better checks for correctness to all `AgentVis` texture buffer binds.
* Add support for specifying an agent's unique scale, either as a uniform value, or per axis of the original model.
* Also fixed a bug in `DirectionFunction` that I noticed by chance. Specifying up vector would have generated a shader with bad syntax.

Happy for these commits to be merged without a squash, they should all be distinct.

Paired with vis PR: https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/57