### PR TITLE
Visualiser Bugfix: Python would not build with visualiser enabled.

### DIFF
--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -31,7 +31,11 @@ class ModelVis {
      * > On resize, also update textures
      */
     explicit ModelVis(const CUDASimulation &model/*TBD*/);
-
+    /**
+     * Default destructor behaviour
+     * Defined explicitly, so that header include does not require including FLAMEGPU_Visualisation for std::unique_ptr destruction.
+     */
+    ~ModelVis();
     /**
      * Sets the palette to automatically give color to agent added to the model
      * This can be overriden at an agent level or disabled

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -11,7 +11,9 @@ ModelVis::ModelVis(const CUDASimulation &_model)
     , autoPalette(std::make_shared<AutoPalette>(Stock::Palettes::DARK2))
     , model(_model)
     , modelData(_model.getModelDescription()) { }
-
+ModelVis::~ModelVis() {
+    // Default behaviour
+}
 void ModelVis::setAutoPalette(const Palette& palette) {
     autoPalette = std::make_shared<AutoPalette>(palette);
 }

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -9,7 +9,6 @@
 //#pragma SWIG nowarn=325,302,401
 //#pragma SWIG nowarn=302
 
-
 // string support
 %include <stl.i>
 %include <std_string.i>
@@ -585,6 +584,8 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, HostRandom::logNormal)
         $self->setColor(cf);
    }
 }
+// Disable functions which return std::type_index
+%ignore getAgentVariableRequiredType;
 // Disable functions which use C++
 %ignore Palette::const_iterator;
 %ignore Palette::begin;


### PR DESCRIPTION
At the weekend I improved validation inside `AgentStateVis` (80f9ac58), part of this involved extending ColorFunctions to specify the required type of the variable bound to mapping the colour.

SWIG doesn't appear to like wrapping functions which return `std::type_index`, therefore I have disabled this function which should be fine as user has no real reason to call the function themselves.

Also minor change to `ModelVis` as this caused me a link error.