### PR TITLE
Add NVCC_THREADS option for CUDA 11.2+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,20 @@ option(BUILD_TESTS "Enable building tests" OFF)
 
 # Option to enable/disable NVTX markers for improved profiling
 option(USE_NVTX "Build with NVTX markers enabled" OFF)
+
 # Option to enable/disable logging of dynamic RTC files to disk
 option(EXPORT_RTC_SOURCES "Export RTC source files to disk at runtime" OFF)
+
+# If CUDA >= 11.2, add an option to enable using NVCC_THREASD
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2)
+    option(USE_NVCC_THREADS "Enable parallel compilation of multiple NVCC targets. See NVCC_THREADS for more control." ON)
+    # The number of threads to use defaults to 0, telling the compiler to use as many threads as required.
+    # In some cases, this may increase total runtime due to excessive thread creation, and lowering the number of threads, or lowering the value of `-j` passed to cmake may be beneficial.
+    if(NOT DEFINED NVCC_THREADS)
+        set(NVCC_THREADS "0")
+    endif()
+    SET(NVCC_THREADS "${NVCC_THREADS}" CACHE STRING "Number of concurrent threads for building multiple target architectures. 0 indicates use as many as required." FORCE)
+endif()
 
 # Control target CUDA_ARCH to compile for
 SET(CUDA_ARCH "${CUDA_ARCH}" CACHE STRING "List of CUDA Architectures to target. E.g. 61;70" FORCE)

--- a/cmake/cuda_arch.cmake
+++ b/cmake/cuda_arch.cmake
@@ -112,3 +112,9 @@ endif()
 # But this is challenging due to multiline string detection.
 # Could potentially compile a simple program, without this flag to detect if its valid/deprecated? Would likely increase build time.
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+
+# If CUDA 11.2+, can build multiple architectures in parallel. Note this will be multiplicative against the number of threads launched for parallel cmake build, which may anger some systems.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2" AND USE_NVCC_THREADS AND DEFINED NVCC_THREADS AND NVCC_THREADS GREATER_EQUAL 0)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --threads ${NVCC_THREADS}")
+endif()
+


### PR DESCRIPTION
CUDA 11.2 introduces the `-t/--threads` option for parallel compilation of targets.

This PR adds a 2 new cmake options (when CUDA is 11.2+) which allows the user to set the value of `--threads`  to opt into this behaviour. 

```
// On, default behaivour. sets --threads 0
cmake .. -DUSE_NVCC_THREADS=ON
// On, using a non-default value for --threads of 2
cmake .. -DUSE_NVCC_THREADS=ON -DNVCC_THREADS=2
// Off
cmake .. -DUSE_NVCC_THREADS=OFF
```

There is a compromise to be made between `-j` and `--threads` to truly minimise runtime. See #481 for some crude benchmarking.

This has been tested on:

+ [x] Linux
+ [x] Windows via `cmake --build . -j N` 
+ [ ]  Windows vis MSVC (Will just use a lot of threads)

Closes #481