### PR TITLE
Update CI to Cuda 11.3

### DIFF
--- a/.github/scripts/install_cuda_ubuntu.sh
+++ b/.github/scripts/install_cuda_ubuntu.sh
@@ -140,9 +140,17 @@ fi
 CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
 echo "CUDA_PATH=${CUDA_PATH}"
 export CUDA_PATH=${CUDA_PATH}
-
-
-# Quick test. @temp
 export PATH="$CUDA_PATH/bin:$PATH"
 export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+# Check nvcc is now available.
 nvcc -V
+
+
+# If executed on github actions, make the appropriate echo statements to update the environment
+if [[ $GITHUB_ACTIONS ]]; then
+    # Set paths for subsequent steps, using ${CUDA_PATH}
+    echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
+    echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
+    echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
+    echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+fi

--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -168,3 +168,12 @@ Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
 # PATH needs updating elsewhere, anything in here won't persist.
 # Append $CUDA_PATH/bin to path.
 # Set CUDA_PATH as an environmental variable
+
+# If executing on github actions, emit the appropriate echo statements to update environment variables
+if (Test-Path "env:GITHUB_ACTIONS") { 
+    # Set paths for subsequent steps, using $env:CUDA_PATH
+    echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+    echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+}

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -25,16 +25,8 @@ jobs:
     - name: Install CUDA
       env:
         cuda: ${{ matrix.cuda }}
-      run: |
-        source ./scripts/actions/install_cuda_ubuntu.sh
-        if [[ $? -eq 0 ]]; then
-          # Set paths for subsequent steps, using ${CUDA_PATH}
-          echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
-          echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
-          echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
-          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-        fi
       shell: bash
+      run: .github/scripts/install_cuda_ubuntu.sh
 
     # Also install the linter.
     - name: Install cpplint

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            cuda: "11.1"
+            cuda: "11.3"
     env:
       build_dir: "build"
       build_tests: "ON"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -43,16 +43,8 @@ jobs:
     - name: Install CUDA
       env:
         cuda: ${{ matrix.cuda }}
-      run: |
-        source ./scripts/actions/install_cuda_ubuntu.sh
-        if [[ $? -eq 0 ]]; then
-          # Set paths for subsequent steps, using ${CUDA_PATH}
-          echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
-          echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
-          echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
-          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-        fi
       shell: bash
+      run: .github/scripts/install_cuda_ubuntu.sh
 
     # Specify the correct host compilers
     - name: Install/Select gcc and g++ 

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           # 20.04 supports CUDA 11.0+ (gcc >= 5 && gcc <= 10). SM < 52 deprecated since 11.0
           - os: ubuntu-20.04
-            cuda: "11.2"
+            cuda: "11.3"
             cuda_arch: "52"
             gcc: 10
           # 18.04 supports CUDA 10.0+ (gcc <=8), 11.0+ (gcc<=9), 11.1+ (gcc<=10)

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,28 +15,21 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
-            cuda: "11.2.0"
+            cuda: "11.3.0"
+            cuda_arch: 52
             visual_studio: "Visual Studio 16 2019"
           # - os: windows-2019
-          #   cuda: "11.1.1"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "11.0.3"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "10.2.89"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "10.1.243"
+          #  cuda: "10.1.243"
+          #  cuda_arch: 35
           #   visual_studio: "Visual Studio 16 2019"
 
           # Windows2016 & VS 2017 supports 10.0+
           # - os: windows-2016
-          #   cuda: "10.0.130"
+          #  cuda: "10.0.130"
+          #  cuda_arch: 35
           #   visual_studio: "Visual Studio 15 2017"
 
     env:
-      cuda_arch: "35"
       build_dir: "build"
       config: "Release"
       build_tests: "OFF"
@@ -73,7 +66,7 @@ jobs:
     # Windows GHA fix: specify Python3_ROOT_DIR and _EXECUTABLE to make sure python.exe is found, not python3.exe which does not work with venv
     - name: Configure CMake
       id: configure
-      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ env.cuda_arch }}" -Werror=dev -DBUILD_SWIG_PYTHON=ON -DBUILD_SWIG_PYTHON_VIRTUALENV=ON -DPython3_ROOT_DIR=$(dirname $(which python)) -DPython3_EXECUTABLE=$(which python)
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DBUILD_SWIG_PYTHON=ON -DBUILD_SWIG_PYTHON_VIRTUALENV=ON -DPython3_ROOT_DIR=$(dirname $(which python)) -DPython3_EXECUTABLE=$(which python)
       shell: bash
 
     - name: Build flamegpu2
@@ -94,7 +87,7 @@ jobs:
       working-directory: ${{ env.build_dir }}
 
     - name: Configure Individual example
-      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ env.cuda_arch }}" -Werror=dev
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev
       working-directory: examples/${{ env.individual_example }}
     
     - name: Build Individual example

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -51,17 +51,8 @@ jobs:
       env: 
         cuda: ${{ matrix.cuda }}
         visual_studio: ${{ matrix.visual_studio }}
-      run: |
-        # Install CUDA via a powershell script
-        .\scripts\actions\install_cuda_windows.ps1
-        if ($?) {
-          # Set paths for subsequent steps, using $env:CUDA_PATH
-          echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
-          echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        }
       shell: powershell
+      run: .github\scripts\install_cuda_windows.ps1
 
     # Windows GHA fix: specify Python3_ROOT_DIR and _EXECUTABLE to make sure python.exe is found, not python3.exe which does not work with venv
     - name: Configure CMake

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -249,6 +249,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Suppress nodiscard warnings from the cuda frontend
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=2809")
 endif()
+# Supress CUDA 11.3 specific warnings.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
+    # Suppress 117-D, declared_but_not_referenced
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=declared_but_not_referenced")
+endif()
 
 # Common CUDA args
 
@@ -368,6 +373,7 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
     if (TARGET flamegpu2)
         target_link_libraries(${NAME} flamegpu2)
         # Workaround for incremental rebuilds on MSVC, where device link was not being performed.
+        # https://github.com/FLAMEGPU/FLAMEGPU2/issues/483
         if(MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.1")
             # Provide the absolute path to the lib file, rather than the relative version cmake provides.
             target_link_libraries(${NAME} "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE:flamegpu2>")
@@ -565,12 +571,9 @@ function(add_flamegpu_library NAME SRC FLAMEGPU_ROOT)
         message(AUTHOR_WARNING "MSVC and NVCC <= 10.2 may encounter compiler errors due to an NVCC bug exposed by Thrust. Cosider using a newer CUDA toolkit.")
     endif()
     if(MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS_EQUAL "11.0")
+        # https://github.com/FLAMEGPU/FLAMEGPU2/issues/483
         message(AUTHOR_WARNING "MSVC and NVCC <= 11.0 may encounter errors at link time with incremental rebuilds. Cosider using a newer CUDA toolkit.")
     endif()
-    if(MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER "11.3")
-        message(AUTHOR_WARNING "A workaround for incremental builds is in place for CUDA >= 11.1 which may be unstable in future CUDA versions. See https://github.com:FLAMEGPU/FLAMEGPU2/issues/483")
-    endif()
-
 endfunction()
 
 #-----------------------------------------------------------------------

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -22,6 +22,9 @@ $CUDA_KNOWN_URLS = @{
     "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
     "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
     "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
+    "11.2.1" = "https://developer.download.nvidia.com/compute/cuda/11.2.1/network_installers/cuda_11.2.1_win10_network.exe";
+    "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
+    "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?


### PR DESCRIPTION
+ CUDA 11.3 on CI. 
+ Scripts moved to `.github/scripts` rather than `scripts/actions`, as it is the only place these scripts are intended to be ran
+ Moves github actions setting of environment variables into the scripts, which are only emmitted if the `GITHUB_ACTIONS` env var is set.
+ Windows CI includes `CUDA_ARCH` in the `matrix` so it can be set to an appropriate version for the installed CUDA verison.
+ Also removes a cmake dev-warning on MSVC about possible future compiler issues that would trip CI for each new CUDA  version