### PR TITLE
Make RTC headers available from Python module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,6 +290,7 @@ SET(ALL_SRC
     ${SRC_INCLUDE}
     ${SRC_FLAMEGPU2}
 )
+SET(FGPU2_INCLUDE ${SRC_INCLUDE} CACHE INTERNAL "Include files required by FLAMEGPU2 RTC")
 
 # Setup Visual Studio (and eclipse) filters
 source_group(TREE ${FLAMEGPU_ROOT}/include/flamegpu PREFIX include FILES ${SRC_INCLUDE})

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -96,10 +96,15 @@ if(MSVC)
   target_link_libraries(${PYTHON_MODULE_NAME} PRIVATE ${Python3_LIBRARIES} flamegpu2 cuda)
 endif()
 
-
 #######################
 ## Python Packaging  ##
 #######################
+# cleanup the flamegpu2 include file paths, so they're relative (begin `include/`) and seperated by `", "`
+foreach(FGPU2_INC_FILE IN LISTS FGPU2_INCLUDE)
+  file(RELATIVE_PATH FGPU2_INC_FILE_CLEAN "${FLAMEGPU_ROOT}" "${FGPU2_INC_FILE}")
+  set(FGPU2_INCLUDE_CLEAN "${FGPU2_INCLUDE_CLEAN}'${FGPU2_INC_FILE_CLEAN}', ")
+endforeach()
+
 # configure the python setup.py and __init__.py files for packaging and output to the final lib output folder
 configure_file(
 	setup.py.in
@@ -143,6 +148,17 @@ endfunction()
 search_python_module(setuptools)
 search_python_module(wheel)
 
+# Create the package directory before we try and copy files to it
+add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${PYTHON_LIB_OUTPUT_DIRECTORY}/${PYTHON_MODULE_NAME}/include")
+
+# Copy the FGPU2 headers to a local path, this must occur before the wheel is built
+add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD     # Adds a post-build event to MyTest
+    COMMAND ${CMAKE_COMMAND} -E copy_directory              # which executes "cmake - E copy_directory..."
+        "${FLAMEGPU_ROOT}/include"                                     # <--this is in-dir
+        "${PYTHON_LIB_OUTPUT_DIRECTORY}/${PYTHON_MODULE_NAME}/include" # <--this is out-dir path
+    ) 
+
 # Copy the visualisation dlls if required, this must occur before the wheel is built
 if (VISUALISATION)
     # Copy DLLs
@@ -152,9 +168,6 @@ if (VISUALISATION)
         get_filename_component(GLEW_RUNTIME_LIB_NAME ${GLEW_RUNTIME_LIBRARIES} NAME)
         get_filename_component(IL_RUNTIME_LIB_NAME ${IL_RUNTIME_LIBRARIES} NAME)
         #get_filename_component(ILUT_RUNTIME_LIB_NAME ${ILUT_RUNTIME_LIBRARIES} NAME)
-        # create the directory first (this is normally created by the following post-build commands
-        add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E make_directory "${PYTHON_LIB_OUTPUT_DIRECTORY}/${PYTHON_MODULE_NAME}")
         # sdl 
         add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD     # Adds a post-build event to MyTest
             COMMAND ${CMAKE_COMMAND} -E copy_if_different              # which executes "cmake - E copy_if_different..."

--- a/swig/python/__init__.py.in
+++ b/swig/python/__init__.py.in
@@ -1,2 +1,9 @@
+# Notify @PYTHON_MODULE_NAME@ of where to find RTC headers (This must occur before module load)
+import sys, os;
+if not "FLAMEGPU2_INC_DIR" in os.environ:
+    os.environ["FLAMEGPU2_INC_DIR"] = os.path.dirname(os.path.realpath(__file__)) + "/include";
+else:
+  print("@PYTHON_MODULE_NAME@ warning: env var 'FLAMEGPU2_INC_DIR' is present, RTC headers may be incorrect.", file=sys.stderr);
+# Normal module stuff
 __all__ = ["@PYTHON_MODULE_NAME@"]
 from .@PYTHON_MODULE_NAME@ import *

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -18,12 +18,12 @@ setup(
   version='@FLAMEGPU_PROJECT_VERSION@',
   author='Paul Richmond',
   author_email='\"Paul Richmond\" <p.richmond@sheffield.ac.uk>',
-  url='https://github.com/FLAMEGPU/FLAMEGPU2_dev',
+  url='https://github.com/FLAMEGPU/FLAMEGPU2',
   distclass=BinaryDistribution,
   cmdclass={'install': InstallPlatlib},
   packages=find_packages(),
   package_data={
-  '@PYTHON_MODULE_NAME@':['$<TARGET_FILE_NAME:@PYTHON_MODULE_NAME@>', 'glew32.dll', 'SDL2.dll', 'DevIL.dll'],
+  '@PYTHON_MODULE_NAME@':['$<TARGET_FILE_NAME:@PYTHON_MODULE_NAME@>', @FGPU2_INCLUDE_CLEAN@'glew32.dll', 'SDL2.dll', 'DevIL.dll'],
   },
   include_package_data=True,
   classifiers=[


### PR DESCRIPTION
Tested by running venv, then changing to a different drive and trying to run swig boids (and clearing relevant files from JitifyCache). Fails before this, works after.

It has two minor things which could be improved in future:
* Only package headers required by RTC (we don't currently have these cleanly separated enough to make it worthwhile).
* Detect if the python module is in an archive format (e.g. .egg?), and extract the include directory to somewhere that nvrtc can see.

Closes #529