### PR TITLE
Suppress EnvironmentManager::init() Curve warnings for PureRTC models.

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -527,6 +527,18 @@ class CUDASimulation : public Simulation {
      * This controls access to active_device_instances, active_device_mutex
      */
     static std::shared_timed_mutex active_device_maps_mutex;
+    /**
+     * Returns false if any agent functions or agent function conditions are not RTC
+     * Used by constructor to set isPureRTC constant value
+     * @param _model The agent model hierarchy to check
+     */
+    static bool detectPureRTC(const std::shared_ptr<const ModelData>& _model);
+
+ protected:
+    /**
+     * If true, the model is pureRTC, and hence does not use non-RTC curve
+     */
+    const bool isPureRTC;
 
  public:
     /**

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -215,18 +215,20 @@ class EnvironmentManager {
      * Activates a models environment properties, by adding them to constant cache
      * @param instance_id instance_id of the CUDASimulation instance the properties are attached to
      * @param desc environment properties description to use
+     * @param isPureRTC If true, Curve collision warnings (debug build only) will be suppressed as they are irrelevant to RTC models
      */
-    void init(const unsigned int &instance_id, const EnvironmentDescription &desc);
+    void init(const unsigned int &instance_id, const EnvironmentDescription &desc, bool isPureRTC);
     /**
      * Submodel variant of init()
      * Activates a models unmapped environment properties, by adding them to constant cache
      * Maps a models mapped environment properties to their master property
      * @param instance_id instance_id of the CUDASimulation instance the properties are attached to
      * @param desc environment properties description to use
+     * @param isPureRTC If true, Curve collision warnings (debug build only) will be suppressed as they are irrelevant to RTC models
      * @param master_instance_id instance_id of the CUDASimulation instance of the parent of the submodel
      * @param mapping Metadata for which environment properties are mapped between master and submodels
      */
-    void init(const unsigned int &instance_id, const EnvironmentDescription &desc, const unsigned int &master_instance_id, const SubEnvironmentData &mapping);
+    void init(const unsigned int &instance_id, const EnvironmentDescription &desc, bool isPureRTC, const unsigned int &master_instance_id, const SubEnvironmentData &mapping);
     /**
      * RTC functions hold their own unique constants for environment variables. This function copies all environment variable to the RTC copies.
      * It can not be incorporated into init() as init will be called before RTC functions have been compiled.
@@ -646,9 +648,10 @@ class EnvironmentManager {
      * @param curve The curve instance to use (important if thread has cuda device set wrong)
      * @param mergeProps Used by init to defragement whilst merging in new data
      * @param newmaps Namepairs of newly mapped properties, yet to to be setup (essentially ones not yet registered in curve)
+     * @param isPureRTC If true, Curve collision warnings (debug build only) will be suppressed as they are irrelevant to RTC models
      * @note any EnvPROP
      */
-    void defragment(Curve &curve, const DefragMap * mergeProps = nullptr, std::set<NamePair> newmaps = {});
+    void defragment(Curve &curve, const DefragMap * mergeProps = nullptr, std::set<NamePair> newmaps = {}, bool isPureRTC = false);
     /**
      * This is the RTC version of defragment()
      * RTC Constant offsets are fixed at RTC time, and exist in their own constant block.


### PR DESCRIPTION
This should fix all current routes to the warning, but there are 3 other cases which implicitly can't be reached by RTC pure models.

Closes #523

This should fix the minor bug affecting py predator, prey (Reported by JPyle in Slack iirc). Haven't actually tested it though.