### PR TITLE
Array Message Improvements

### DIFF
--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -11,7 +11,7 @@ FLAMEGPU_AGENT_FUNCTION(update, flamegpu::MsgArray2D, flamegpu::MsgNone) {
 
     unsigned int living_neighbours = 0;
     // Iterate 3x3 Moore neighbourhood (this does no include the central cell)
-    for (auto &msg : FLAMEGPU->message_in(my_x, my_y)) {
+    for (auto &msg : FLAMEGPU->message_in.wrap(my_x, my_y)) {
         living_neighbours += msg.getVariable<char>("is_alive") ? 1 : 0;
     }
     // Using count, decide and output new value for is_alive

--- a/examples/sugarscape/src/main.cu
+++ b/examples/sugarscape/src/main.cu
@@ -90,7 +90,7 @@ FLAMEGPU_AGENT_FUNCTION(movement_request, flamegpu::MsgArray2D, flamegpu::MsgArr
 
     // if occupied then look for empty cells
     if (status == AGENT_STATUS_MOVEMENT_UNRESOLVED) {
-        for (auto current_message : FLAMEGPU->message_in(agent_x, agent_y)) {
+        for (auto current_message : FLAMEGPU->message_in.wrap(agent_x, agent_y)) {
             // if location is unoccupied then check for empty locations
             if (current_message.getVariable<int>("status") == AGENT_STATUS_UNOCCUPIED) {
                 // if the sugar level at current location is better than currently stored then update
@@ -131,7 +131,7 @@ FLAMEGPU_AGENT_FUNCTION(movement_response, flamegpu::MsgArray2D, flamegpu::MsgAr
     const unsigned int agent_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
     const unsigned int agent_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
 
-    for (auto current_message : FLAMEGPU->message_in(agent_x, agent_y)) {
+    for (auto current_message : FLAMEGPU->message_in.wrap(agent_x, agent_y)) {
         // if the location is unoccupied then check for agents requesting to move here
         if (status == AGENT_STATUS_UNOCCUPIED) {
             // check if request is to move to this location
@@ -169,7 +169,7 @@ FLAMEGPU_AGENT_FUNCTION(movement_transaction, flamegpu::MsgArray2D, flamegpu::Ms
     unsigned int agent_x = FLAMEGPU->getVariable<unsigned int, 2>("pos", 0);
     unsigned int agent_y = FLAMEGPU->getVariable<unsigned int, 2>("pos", 1);
 
-    for (auto current_message : FLAMEGPU->message_in(agent_x, agent_y)) {
+    for (auto current_message : FLAMEGPU->message_in.wrap(agent_x, agent_y)) {
         // if location contains an agent wanting to move then look for responses allowing relocation
         if (status == AGENT_STATUS_MOVEMENT_REQUESTED) {  // if the movement response request came from this location
             if (current_message.getVariable<int>("agent_id") == agent_id) {

--- a/include/flamegpu/runtime/messaging/Array/ArrayDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Array/ArrayDevice.cuh
@@ -70,11 +70,11 @@ class MsgArray::In {
      * This class is created when a search origin is provided to MsgArray::In::operator()(size_type, size_type, size_type = 1)
      * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
      *
-     * @see MsgArray::In::operator()(size_type, size_type)
+     * @see MsgArray::In::wrap(size_type, size_type)
      */
-    class Filter {
+    class WrapFilter {
         /**
-         * Message has full access to Filter, they are treated as the same class so share everything
+         * Message has full access to WrapFilter, they are treated as the same class so share everything
          * Reduces/memory data duplication
          */
         friend class Message;
@@ -83,13 +83,13 @@ class MsgArray::In {
         /**
          * Provides access to a specific message
          * Returned by the iterator
-         * @see In::Filter::iterator
+         * @see In::WrapFilter::iterator
          */
         class Message {
             /**
-             * Paired Filter class which created the iterator
+             * Paired WrapFilter class which created the iterator
              */
-            const Filter &_parent;
+            const WrapFilter&_parent;
             /**
              * Relative position within the Moore neighbourhood
              * This is initialised based on user provided radius
@@ -105,7 +105,7 @@ class MsgArray::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter &parent, const int &relative_x)
+            __device__ Message(const WrapFilter&parent, const int &relative_x)
                 : _parent(parent) {
                 relative_cell = relative_x;
             }
@@ -115,8 +115,8 @@ class MsgArray::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->index_1d == rhs.index_1d
-                    && this->_parent.loc == rhs._parent.loc;
+                return this->relative_cell == rhs.relative_cell;
+                // && this->_parent.loc == rhs._parent.loc;
             }
             /**
              * Inequality operator
@@ -146,7 +146,7 @@ class MsgArray::In {
             __device__ T getVariable(const char(&variable_name)[N]) const;
         };
         /**
-         * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+         * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
          */
         class iterator {
             /**
@@ -157,10 +157,10 @@ class MsgArray::In {
          public:
             /**
              * Constructor
-             * This iterator is constructed by MsgArray::In::Filter::begin()(size_type, size_type)
-             * @see MsgArray::In::Operator()(size_type, size_type)
+             * This iterator is constructed by MsgArray::In::WrapFilter::begin()(size_type, size_type)
+             * @see MsgArray::In::wrap(size_type, size_type)
              */
-            __device__ iterator(const Filter &parent, const int &relative_x)
+            __device__ iterator(const WrapFilter&parent, const int &relative_x)
                 : _message(parent, relative_x) {
                 // Increment to find first message
                 ++_message;
@@ -199,13 +199,13 @@ class MsgArray::In {
             __device__ Message* operator->() { return &_message; }
         };
         /**
-         * Constructor, takes the search parameters requried
+         * Constructor, takes the search parameters required
          * @param _length Pointer to message list length
          * @param _combined_hash agentfn+message hash for accessing message data
          * @param x Search origin x coord
          * @param _radius Search radius
          */
-        __device__ inline Filter(const size_type &_length, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius);
+        __device__ inline WrapFilter(const size_type &_length, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius);
         /**
          * Returns an iterator to the start of the message list subset about the search origin
          */
@@ -242,6 +242,191 @@ class MsgArray::In {
         detail::curve::Curve::NamespaceHash combined_hash;
     };
     /**
+     * This class is created when a search origin is provided to MsgArray::In::operator()(size_type, size_type, size_type = 1)
+     * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius does not wrap the message list bounds
+     *
+     * @see MsgArray::In::operator()(size_type, size_type)
+     */
+    class Filter {
+        /**
+         * Message has full access to Filter, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class Message;
+
+     public:
+        /**
+         * Provides access to a specific message
+         * Returned by the iterator
+         * @see In::Filter::iterator
+         */
+        class Message {
+            /**
+             * Paired Filter class which created the iterator
+             */
+            const Filter& _parent;
+            /**
+             * Relative position within the Moore neighbourhood
+             * This is initialised based on user provided radius
+             */
+            int relative_cell;
+            /**
+             * Index into memory of currently pointed message
+             */
+            size_type index_1d = 0;
+
+         public:
+            /**
+             * Constructs a message and directly initialises all of it's member variables
+             * @note See member variable documentation for their purposes
+             */
+            __device__ Message(const Filter& parent, const int& relative_x)
+                : _parent(parent) {
+                relative_cell = relative_x;
+            }
+            /**
+             * Equality operator
+             * Compares all internal member vars for equality
+             * @note Does not compare _parent
+             */
+            __device__ bool operator==(const Message& rhs) const {
+                return this->relative_cell == rhs.relative_cell;
+                    // && this->_parent.loc == rhs._parent.loc;
+            }
+            /**
+             * Inequality operator
+             * Returns inverse of equality operator
+             * @see operator==(const Message&)
+             */
+            __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+            /**
+             * Updates the message to return variables from the next cell in the Moore neighbourhood
+             * @return Returns itself
+             */
+            __device__ inline Message& operator++();
+            /**
+             * Returns x array index of message
+             */
+            __device__ size_type getX() const {
+                return this->_parent.loc + relative_cell;
+            }
+            /**
+             * Returns the value for the current message attached to the named variable
+             * @param variable_name Name of the variable
+             * @tparam T type of the variable
+             * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+             * @return The specified variable, else 0x0 if an error occurs
+             */
+            template<typename T, unsigned int N>
+            __device__ T getVariable(const char(&variable_name)[N]) const;
+        };
+        /**
+         * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+         */
+        class iterator {
+            /**
+             * The message returned to the user
+             */
+            Message _message;
+
+         public:
+            /**
+             * Constructor
+             * This iterator is constructed by MsgArray::In::Filter::begin()(size_type, size_type)
+             * @see MsgArray::In::Operator()(size_type, size_type)
+             */
+            __device__ iterator(const Filter& parent, const int& relative_x)
+                : _message(parent, relative_x) {
+                // Increment to find first message
+                ++_message;
+            }
+            /**
+             * Moves to the next message
+             * (Prefix increment operator)
+             */
+            __device__ iterator& operator++() { ++_message;  return *this; }
+            /**
+             * Moves to the next message
+             * (Postfix increment operator, returns value prior to increment)
+             */
+            __device__ iterator operator++(int) {
+                iterator temp = *this;
+                ++* this;
+                return temp;
+            }
+            /**
+             * Equality operator
+             * Compares message
+             */
+            __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+            /**
+             * Inequality operator
+             * Compares message
+             */
+            __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message& operator*() { return _message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message* operator->() { return &_message; }
+        };
+        /**
+         * Constructor, takes the search parameters required
+         * @param _length Pointer to message list length
+         * @param _combined_hash agentfn+message hash for accessing message data
+         * @param x Search origin x coord
+         * @param _radius Search radius
+         */
+
+        __device__ inline Filter(const size_type& _length, const detail::curve::Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& _radius);
+        /**
+         * Returns an iterator to the start of the message list subset about the search origin
+         */
+        inline __device__ iterator begin(void) const {
+            // Bin before initial bin, as the constructor calls increment operator
+            return iterator(*this, min_cell - 1);
+        }
+        /**
+         * Returns an iterator to the position beyond the end of the message list subset
+         * @note This iterator is the same for all message list subsets
+         */
+        inline __device__ iterator end(void) const {
+            // Final bin, as the constructor calls increment operator
+            return iterator(*this, max_cell);
+        }
+
+     private:
+        /**
+         * Search origin
+         */
+        size_type loc;
+        /**
+         * Min offset to be accessed (inclusive)
+         */
+        int min_cell;
+        /**
+         * Max offset to be accessed (inclusive)
+         */
+        int max_cell;
+        /**
+         * Search radius
+         */
+        const size_type radius;
+        /**
+         * Message list length
+         */
+        const size_type length;
+        /**
+         * CURVE hash for accessing message data
+         * agent function hash + message hash
+         */
+        detail::curve::Curve::NamespaceHash combined_hash;
+    };
+    /**
      * Constructer
      * Initialises member variables
      * @param agentfn_hash Added to msg_hash to produce combined_hash
@@ -256,18 +441,53 @@ class MsgArray::In {
      * Returns a Filter object which provides access to message iterator
      * for iterating a subset of messages including those within the radius of the search origin
      * this excludes the message at the search origin
+     * The radius will wrap over environment bounds
      *
      * @param x Search origin x coord
      * @param radius Search radius
      * @note radius 1 is 2 cells
      * @note radius 2 is 4 cells
-     * @note If radius is >= half of the array dimensions, cells will be doubly read
+     * @note radius which produce a message read dimension (radius*2 + 1) greater than the length of the messagelist are unsupported
      * @note radius of 0 is unsupported
+     * @note The location x must be within the bounds of the message list
+     */
+    inline __device__ WrapFilter wrap(const size_type &x, const size_type &radius = 1) const {
+#if !defined(SEATBELTS) || SEATBELTS
+        if (radius == 0) {
+            DTHROW("Invalid radius %u for accessing array messagelist of length %u\n", radius, length);
+        } else if ((radius * 2) + 1 > length) {
+            unsigned int min_r = length % 2 == 0 ? length - 2 : length - 1;
+            min_r /= 2;
+            DTHROW("%u is not a valid radius for accessing Array message lists, as the diameter of messages accessed exceeds the message list length (%u)."
+                " Maximum supported radius for this message list is %u.\n",
+                radius, length, min_r);
+        } else if (x >= length) {
+            DTHROW("%u is not a valid position for iterating an Array message list of length %u, location must be within bounds.",
+                x, length);
+        }
+#endif
+        return WrapFilter(length, combined_hash, x, radius);
+    }
+    /**
+     * Returns a Filter object which provides access to message iterator
+     * for iterating a subset of messages including those within the radius of the search origin
+     * this excludes the message at the search origin
+     * The radius will not wrap over environment bounds
+     *
+     * @param x Search origin x coord
+     * @param radius Search radius
+     * @note radius 1 is 2 cells in 3
+     * @note radius 2 is 4 cells in 5
+     * @note radius of 0 is unsupported
+     * @note The location x must be within the bounds of the message list
      */
     inline __device__ Filter operator() (const size_type &x, const size_type &radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
-        if (radius == 0 || radius > length) {
-            DTHROW("Invalid radius %llu for accessing array messaglist of length %u\n", radius, length);
+        if (radius == 0) {
+            DTHROW("Invalid radius %u for accessing array messagelist of length %u\n", radius, length);
+        } else if (x >= length) {
+            DTHROW("%u is not a valid position for iterating an Array message list of length %u, location must be within bounds.",
+                x, length);
         }
 #endif
         return Filter(length, combined_hash, x, radius);
@@ -365,6 +585,18 @@ __device__ T MsgArray::In::Message::getVariable(const char(&variable_name)[N]) c
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
+__device__ T MsgArray::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.length) {
+        DTHROW("Invalid Array message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, unsigned int N>
 __device__ T MsgArray::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -408,13 +640,13 @@ __device__ void MsgArray::Out::setIndex(const size_type &id) const {
     // Set scan flag incase the message is optional
     this->scan_flag[index] = 1;
 }
-__device__ MsgArray::In::Filter::Filter(const size_type &_length, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius)
+__device__ MsgArray::In::WrapFilter::WrapFilter(const size_type &_length, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius)
     : radius(_radius)
     , length(_length)
     , combined_hash(_combined_hash) {
     loc = x;
 }
-__device__ MsgArray::In::Filter::Message& MsgArray::In::Filter::Message::operator++() {
+__device__ MsgArray::In::WrapFilter::Message& MsgArray::In::WrapFilter::Message::operator++() {
     relative_cell++;
     // Skip origin cell
     if (relative_cell == 0) {
@@ -422,6 +654,24 @@ __device__ MsgArray::In::Filter::Message& MsgArray::In::Filter::Message::operato
     }
     // Wrap over boundaries
     index_1d = (this->_parent.loc + relative_cell + this->_parent.length) % this->_parent.length;
+    return *this;
+}
+__device__ MsgArray::In::Filter::Filter(const size_type &_length, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &_radius)
+    : radius(_radius)
+    , length(_length)
+    , combined_hash(_combined_hash) {
+    loc = x;
+    min_cell = static_cast<int>(x) - static_cast<int>(_radius) < 0 ? -static_cast<int>(x) : -static_cast<int>(_radius);
+    max_cell = x + _radius >= _length ? static_cast<int>(_length) - 1 - static_cast<int>(x) : static_cast<int>(_radius);
+}
+__device__ MsgArray::In::Filter::Message& MsgArray::In::Filter::Message::operator++() {
+    relative_cell++;
+    // Skip origin cell
+    if (relative_cell == 0) {
+        relative_cell++;
+    }
+    // Solve to 1 dimensional bin index
+    index_1d = this->_parent.loc + relative_cell;
     return *this;
 }
 

--- a/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.cuh
@@ -66,7 +66,194 @@ class MsgArray2D::In {
     /**
      * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
      * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
-     * 
+     * The radius wraps the message list bounds
+     *
+     * @see MsgArray2D::In::wrap(size_type, size_type, size_type)
+     */
+    class WrapFilter {
+        /**
+         * Message has full access to WrapFilter, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class Message;
+
+     public:
+        /**
+         * Provides access to a specific message
+         * Returned by the iterator
+         * @see In::WrapFilter::iterator
+         */
+        class Message {
+            /**
+             * Paired WrapFilter class which created the iterator
+             */
+            const WrapFilter&_parent;
+            /**
+             * Relative position within the Moore neighbourhood
+             * This is initialised based on user provided radius
+             */
+            int relative_cell[2];
+            /**
+             * Index into memory of currently pointed message
+             */
+            size_type index_1d = 0;
+
+         public:
+            /**
+             * Constructs a message and directly initialises all of it's member variables
+             * @note See member variable documentation for their purposes
+             */
+            __device__ Message(const WrapFilter&parent, const int &relative_x, const int &relative_y)
+                : _parent(parent) {
+                relative_cell[0] = relative_x;
+                relative_cell[1] = relative_y;
+            }
+            /**
+             * Equality operator
+             * Compares all internal member vars for equality
+             * @note Does not compare _parent
+             */
+            __device__ bool operator==(const Message& rhs) const {
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1];
+                // && this->_parent.loc[0] == rhs._parent.loc[0]
+                // && this->_parent.loc[1] == rhs._parent.loc[1];
+            }
+            /**
+             * Inequality operator
+             * Returns inverse of equality operator
+             * @see operator==(const Message&)
+             */
+            __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+            /**
+             * Updates the message to return variables from the next cell in the Moore neighbourhood
+             * @return Returns itself
+             */
+            inline __device__ Message& operator++();
+            /**
+             * Returns x array index of message
+             */
+            __device__ size_type getX() const {
+                return (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+            }
+            /**
+             * Returns y array index of message
+             */
+            __device__ size_type getY() const {
+                return (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+            }
+            /**
+             * Returns the value for the current message attached to the named variable
+             * @param variable_name Name of the variable
+             * @tparam T type of the variable
+             * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+             * @return The specified variable, else 0x0 if an error occurs
+             */
+            template<typename T, unsigned int N>
+            __device__ T getVariable(const char(&variable_name)[N]) const;
+        };
+        /**
+         * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
+         */
+        class iterator {
+            /**
+             * The message returned to the user
+             */
+            Message _message;
+
+         public:
+            /**
+             * Constructor
+             * This iterator is constructed by MsgArray2D::In::WrapFilter::begin()(size_type, size_type, size_type)
+             * @see MsgArray2D::In::wrap(size_type, size_type, size_type)
+             */
+            __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y)
+                : _message(parent, relative_x, relative_y) {
+                // Increment to find first message
+                ++_message;
+            }
+            /**
+             * Moves to the next message
+             * (Prefix increment operator)
+             */
+            __device__ iterator& operator++() { ++_message;  return *this; }
+            /**
+             * Moves to the next message
+             * (Postfix increment operator, returns value prior to increment)
+             */
+            __device__ iterator operator++(int) {
+                iterator temp = *this;
+                ++*this;
+                return temp;
+            }
+            /**
+             * Equality operator
+             * Compares message
+             */
+            __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+            /**
+             * Inequality operator
+             * Compares message
+             */
+            __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message& operator*() { return _message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message* operator->() { return &_message; }
+        };
+        /**
+         * Constructor, takes the search parameters required
+         * @param _metadata Pointer to message list metadata
+         * @param _combined_hash agentfn+message hash for accessing message data
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param _radius Search radius
+         */
+        inline __device__ WrapFilter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius);
+        /**
+         * Returns an iterator to the start of the message list subset about the search origin
+         */
+        inline __device__ iterator begin(void) const {
+            // Bin before initial bin, as the constructor calls increment operator
+            return iterator(*this, -static_cast<int>(radius), -static_cast<int>(radius)-1);
+        }
+        /**
+         * Returns an iterator to the position beyond the end of the message list subset
+         * @note This iterator is the same for all message list subsets
+         */
+        inline __device__ iterator end(void) const {
+            // Final bin, as the constructor calls increment operator
+            return iterator(*this, radius, radius);
+        }
+
+     private:
+        /**
+         * Search origin
+         */
+        size_type loc[2];
+        /**
+         * Search radius
+         */
+        const size_type radius;
+        /**
+         * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+         */
+        const MetaData *metadata;
+        /**
+         * CURVE hash for accessing message data
+         * agent function hash + message hash
+         */
+        detail::curve::Curve::NamespaceHash combined_hash;
+    };
+    /**
+     * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
+     * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius does not wrap the message list bounds
+     *
      * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
      */
     class Filter {
@@ -113,9 +300,10 @@ class MsgArray2D::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->index_1d == rhs.index_1d
-                    && this->_parent.loc[0] == rhs._parent.loc[0]
-                    && this->_parent.loc[1] == rhs._parent.loc[1];
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1];
+                    // && this->_parent.loc[0] == rhs._parent.loc[0]
+                    // && this->_parent.loc[1] == rhs._parent.loc[1];
             }
             /**
              * Inequality operator
@@ -132,13 +320,13 @@ class MsgArray2D::In {
              * Returns x array index of message
              */
             __device__ size_type getX() const {
-                return (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+                return this->_parent.loc[0] + relative_cell[0];
             }
             /**
              * Returns y array index of message
              */
             __device__ size_type getY() const {
-                return (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+                return this->_parent.loc[1] + relative_cell[1];
             }
             /**
              * Returns the value for the current message attached to the named variable
@@ -204,7 +392,7 @@ class MsgArray2D::In {
             __device__ Message* operator->() { return &_message; }
         };
         /**
-         * Constructor, takes the search parameters requried
+         * Constructor, takes the search parameters required
          * @param _metadata Pointer to message list metadata
          * @param _combined_hash agentfn+message hash for accessing message data
          * @param x Search origin x coord
@@ -217,7 +405,7 @@ class MsgArray2D::In {
          */
         inline __device__ iterator begin(void) const {
             // Bin before initial bin, as the constructor calls increment operator
-            return iterator(*this, -static_cast<int>(radius), -static_cast<int>(radius)-1);
+            return iterator(*this, min_cell[0], min_cell[1] - 1);
         }
         /**
          * Returns an iterator to the position beyond the end of the message list subset
@@ -225,7 +413,7 @@ class MsgArray2D::In {
          */
         inline __device__ iterator end(void) const {
             // Final bin, as the constructor calls increment operator
-            return iterator(*this, radius, radius);
+            return iterator(*this, max_cell[0], max_cell[1]);
         }
 
      private:
@@ -233,6 +421,14 @@ class MsgArray2D::In {
          * Search origin
          */
         size_type loc[2];
+        /**
+         * Min offset to be accessed (inclusive)
+         */
+        int min_cell[2];
+        /**
+         * Max offset to be accessed (inclusive)
+         */
+        int max_cell[2];
         /**
          * Search radius
          */
@@ -262,19 +458,58 @@ class MsgArray2D::In {
      * Returns a Filter object which provides access to message iterator
      * for iterating a subset of messages including those within the radius of the search origin
      * this excludes the message at the search origin
+     * The radius will wrap over environment bounds
      *
      * @param x Search origin x coord
      * @param y Search origin y coord
      * @param radius Search radius
      * @note radius 1 is 8 cells in 3x3
      * @note radius 2 is 24 cells in 5x5
-     * @note If radius is >= half of the array dimensions, cells will be doubly read
+     * @note radius which produce a message read dimension (radius*2 + 1) greater than one of the message list dimensions are unsupported
      * @note radius of 0 is unsupported
+     * @note The location [x, y] must be within the bounds of the message list
+     */
+    inline __device__ WrapFilter wrap(const size_type & x, const size_type & y, const size_type & radius = 1) const {
+#if !defined(SEATBELTS) || SEATBELTS
+        if (radius == 0) {
+            DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
+        } else if ((radius * 2) + 1 > metadata->dimensions[0] ||
+                   (radius * 2) + 1 > metadata->dimensions[1]) {
+            unsigned int min_r = metadata->dimensions[0] < metadata->dimensions[1] ? metadata->dimensions[0] : metadata->dimensions[1];
+            min_r = min_r % 2 == 0 ? min_r - 2: min_r - 1;
+            min_r /= 2;
+            DTHROW("%u is not a valid radius for accessing Array2D message lists, as the diameter of messages accessed exceeds one or more of the message list dimensions (%u, %u)."
+            " Maximum supported radius for this message list is %u.\n",
+            radius, metadata->dimensions[0], metadata->dimensions[1], min_r);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1]) {
+            DTHROW("(%u, %u) is not a valid position for iterating an Array2D message list of dimensions (%u, %u), location must be within bounds.",
+                x, y, metadata->dimensions[0], metadata->dimensions[1]);
+        }
+#endif
+        return WrapFilter(metadata, combined_hash, x, y, radius);
+    }
+    /**
+     * Returns a Filter object which provides access to message iterator
+     * for iterating a subset of messages including those within the radius of the search origin
+     * this excludes the message at the search origin
+     *
+     * @param x Search origin x coord
+     * @param y Search origin y coord
+     * @param radius Search radius
+     * @note radius 1 is 8 cells in 3x3
+     * @note radius 2 is 24 cells in 5x5
+     * @note radius of 0 is unsupported
+     * @note The location [x, y] must be within the bounds of the message list
      */
     inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
-            DTHROW("%llu is not a valid radius for accessing Array2D message lists.\n", radius);
+            DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1]) {
+            DTHROW("(%u, %u) is not a valid position for iterating an Array2D message list of dimensions (%u, %u), location must be within bounds.",
+                x, y, metadata->dimensions[0], metadata->dimensions[1]);
         }
 #endif
         return Filter(metadata, combined_hash, x, y, radius);
@@ -387,6 +622,18 @@ __device__ T MsgArray2D::In::Message::getVariable(const char(&variable_name)[N])
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
+__device__ T MsgArray2D::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array2D message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, unsigned int N>
 __device__ T MsgArray2D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -433,14 +680,14 @@ __device__ void MsgArray2D::Out::setIndex(const size_type &x, const size_type &y
     // Set scan flag incase the message is optional
     this->scan_flag[index] = 1;
 }
-__device__ MsgArray2D::In::Filter::Filter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius)
+__device__ MsgArray2D::In::WrapFilter::WrapFilter(const MetaData* _metadata, const detail::curve::Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& y, const size_type& _radius)
     : radius(_radius)
     , metadata(_metadata)
     , combined_hash(_combined_hash) {
     loc[0] = x;
     loc[1] = y;
 }
-__device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::operator++() {
+__device__ MsgArray2D::In::WrapFilter::Message& MsgArray2D::In::WrapFilter::Message::operator++() {
     if (relative_cell[1] >= static_cast<int>(_parent.radius)) {
         relative_cell[1] = -static_cast<int>(_parent.radius);
         relative_cell[0]++;
@@ -456,7 +703,39 @@ __device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::ope
     const unsigned int their_y = (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
     // Solve to 1 dimensional bin index
     index_1d = their_y * this->_parent.metadata->dimensions[0] +
-        their_x;
+               their_x;
+    return *this;
+}
+__device__ MsgArray2D::In::Filter::Filter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius)
+    : radius(_radius)
+    , metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    loc[0] = x;
+    loc[1] = y;
+    min_cell[0] = static_cast<int>(x) - static_cast<int>(_radius) < 0 ? -static_cast<int>(x) : -static_cast<int>(_radius);
+    min_cell[1] = static_cast<int>(y) - static_cast<int>(_radius) < 0 ? -static_cast<int>(y) : -static_cast<int>(_radius);
+    max_cell[0] = x + _radius >= _metadata->dimensions[0] ? static_cast<int>(_metadata->dimensions[0]) - 1 - static_cast<int>(x) : static_cast<int>(_radius);
+    max_cell[1] = y + _radius >= _metadata->dimensions[1] ? static_cast<int>(_metadata->dimensions[1]) - 1 - static_cast<int>(y) : static_cast<int>(_radius);
+}
+__device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::operator++() {
+    if (relative_cell[1] >= _parent.max_cell[1]) {
+        relative_cell[1] = _parent.min_cell[1];
+        relative_cell[0]++;
+    } else {
+        relative_cell[1]++;
+    }
+    // Skip origin cell
+    if (relative_cell[0] == 0 && relative_cell[1] == 0) {
+        if (relative_cell[1] >= _parent.max_cell[1]) {
+            relative_cell[1] = _parent.min_cell[1];
+            relative_cell[0]++;
+        } else {
+            relative_cell[1]++;
+        }
+    }
+    // Solve to 1 dimensional bin index
+    index_1d = (this->_parent.loc[1] + relative_cell[1]) * this->_parent.metadata->dimensions[0] +
+               (this->_parent.loc[0] + relative_cell[0]);
     return *this;
 }
 

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.cuh
@@ -71,12 +71,13 @@ class MsgArray3D::In {
     /**
      * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
      * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius wraps the message list bounds
      * 
-     * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
+     * @see MsgArray2D::In::wrap()(size_type, size_type, size_type)
      */
-    class Filter {
+    class WrapFilter {
         /**
-         * Message has full access to Filter, they are treated as the same class so share everything
+         * Message has full access to WrapFilter, they are treated as the same class so share everything
          * Reduces/memory data duplication
          */
         friend class Message;
@@ -85,13 +86,13 @@ class MsgArray3D::In {
         /**
          * Provides access to a specific message
          * Returned by the iterator
-         * @see In::Filter::iterator
+         * @see In::WrapFilter::iterator
          */
         class Message {
             /**
-             * Paired Filter class which created the iterator
+             * Paired WrapFilter class which created the iterator
              */
-            const Filter &_parent;
+            const WrapFilter&_parent;
             /**
              * Relative position within the Moore neighbourhood
              * This is initialised based on user provided radius
@@ -107,7 +108,7 @@ class MsgArray3D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter &parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ Message(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -119,10 +120,12 @@ class MsgArray3D::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->index_1d == rhs.index_1d
-                    && this->_parent.loc[0] == rhs._parent.loc[0]
-                    && this->_parent.loc[1] == rhs._parent.loc[1]
-                    && this->_parent.loc[2] == rhs._parent.loc[2];
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1]
+                    && this->relative_cell[2] == rhs.relative_cell[2];
+                    // && this->_parent.loc[0] == rhs._parent.loc[0]
+                    // && this->_parent.loc[1] == rhs._parent.loc[1]
+                    // && this->_parent.loc[2] == rhs._parent.loc[2];
             }
             /**
              * Inequality operator
@@ -164,7 +167,7 @@ class MsgArray3D::In {
             __device__ T getVariable(const char(&variable_name)[N]) const;
         };
         /**
-         * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+         * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
          */
         class iterator {
             /**
@@ -175,10 +178,10 @@ class MsgArray3D::In {
          public:
             /**
              * Constructor
-             * This iterator is constructed by MsgArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
-             * @see MsgArray3D::In::Operator()(size_type, size_type, size_type, size_type)
+             * This iterator is constructed by MsgArray3D::In::WrapFilter::begin()(size_type, size_type, size_type, size_type)
+             * @see MsgArray3D::In::wrap(size_type, size_type, size_type, size_type)
              */
-            __device__ iterator(const Filter &parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
                 // Increment to find first message
                 ++_message;
@@ -217,7 +220,7 @@ class MsgArray3D::In {
             __device__ Message* operator->() { return &_message; }
         };
         /**
-         * Constructor, takes the search parameters requried
+         * Constructor, takes the search parameters required
          * @param _metadata Pointer to message list metadata
          * @param _combined_hash agentfn+message hash for accessing message data
          * @param x Search origin x coord
@@ -225,7 +228,7 @@ class MsgArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ Filter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
+        inline __device__ WrapFilter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
         /**
          * Returns an iterator to the start of the message list subset about the search origin
          */
@@ -262,6 +265,205 @@ class MsgArray3D::In {
         detail::curve::Curve::NamespaceHash combined_hash;
     };
     /**
+     * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
+     * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius does not wrap the message list bounds
+     *
+     * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
+     */
+    class Filter {
+        /**
+         * Message has full access to Filter, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class Message;
+
+     public:
+        /**
+         * Provides access to a specific message
+         * Returned by the iterator
+         * @see In::Filter::iterator
+         */
+        class Message {
+            /**
+             * Paired Filter class which created the iterator
+             */
+            const Filter& _parent;
+            /**
+             * Current offset
+             */
+            int relative_cell[3];
+            /**
+             * Index into memory of currently pointed message
+             */
+            size_type index_1d = 0;
+
+         public:
+            /**
+             * Constructs a message and directly initialises all of it's member variables
+             * @note See member variable documentation for their purposes
+             */
+            __device__ Message(const Filter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+                : _parent(parent) {
+                relative_cell[0] = relative_x;
+                relative_cell[1] = relative_y;
+                relative_cell[2] = relative_z;
+            }
+            /**
+             * Equality operator
+             * Compares all internal member vars for equality
+             * @note Does not compare _parent
+             */
+            __device__ bool operator==(const Message& rhs) const {
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1]
+                    && this->relative_cell[2] == rhs.relative_cell[2];
+                    // && this->_parent.loc[0] == rhs._parent.loc[0]
+                    // && this->_parent.loc[1] == rhs._parent.loc[1]
+                    // && this->_parent.loc[2] == rhs._parent.loc[2];
+            }
+            /**
+             * Inequality operator
+             * Returns inverse of equality operator
+             * @see operator==(const Message&)
+             */
+            __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+            /**
+             * Updates the message to return variables from the next cell in the Moore neighbourhood
+             * @return Returns itself
+             */
+            inline __device__ Message& operator++();
+            /**
+             * Returns x array index of message
+             */
+            __device__ size_type getX() const {
+                return this->_parent.loc[0] + relative_cell[0];
+            }
+            /**
+             * Returns y array index of message
+             */
+            __device__ size_type getY() const {
+                return this->_parent.loc[1] + relative_cell[1];
+            }
+            /**
+             * Returns z array index of message
+             */
+            __device__ size_type getZ() const {
+                return this->_parent.loc[2] + relative_cell[2];
+            }
+            /**
+             * Returns the value for the current message attached to the named variable
+             * @param variable_name Name of the variable
+             * @tparam T type of the variable
+             * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+             * @return The specified variable, else 0x0 if an error occurs
+             */
+            template<typename T, unsigned int N>
+            __device__ T getVariable(const char(&variable_name)[N]) const;
+        };
+        /**
+         * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+         */
+        class iterator {
+            /**
+             * The message returned to the user
+             */
+            Message _message;
+
+         public:
+            /**
+             * Constructor
+             * This iterator is constructed by MsgArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
+             * @see MsgArray3D::In::Operator()(size_type, size_type, size_type, size_type)
+             */
+            __device__ iterator(const Filter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+                : _message(parent, relative_x, relative_y, relative_z) {
+                // Increment to find first message
+                ++_message;
+            }
+            /**
+             * Moves to the next message
+             * (Prefix increment operator)
+             */
+            __device__ iterator& operator++() { ++_message;  return *this; }
+            /**
+             * Moves to the next message
+             * (Postfix increment operator, returns value prior to increment)
+             */
+            __device__ iterator operator++(int) {
+                iterator temp = *this;
+                ++* this;
+                return temp;
+            }
+            /**
+             * Equality operator
+             * Compares message
+             */
+            __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+            /**
+             * Inequality operator
+             * Compares message
+             */
+            __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message& operator*() { return _message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message* operator->() { return &_message; }
+        };
+        /**
+         * Constructor, takes the search parameters required
+         * @param _metadata Pointer to message list metadata
+         * @param _combined_hash agentfn+message hash for accessing message data
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param z Search origin z coord
+         * @param _radius Search radius
+         */
+        inline __device__ Filter(const MetaData* _metadata, const detail::curve::Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius);
+        /**
+         * Returns an iterator to the start of the message list subset about the search origin
+         */
+        inline __device__ iterator begin(void) const {
+            // Bin before initial bin, as the constructor calls increment operator
+            return iterator(*this,  min_cell[0], min_cell[1], min_cell[2] - 1);
+        }
+        /**
+         * Returns an iterator to the position beyond the end of the message list subset
+         * @note This iterator is the same for all message list subsets
+         */
+        inline __device__ iterator end(void) const {
+            // Final bin, as the constructor calls increment operator
+            return iterator(*this, max_cell[0], max_cell[1], max_cell[2]);
+        }
+
+     private:
+        /**
+         * Search origin
+         */
+        size_type loc[3];
+        /**
+         * Min offset to be accessed (inclusive)
+         */
+        int min_cell[3];
+        /**
+         * Max offset to be accessed (inclusive)
+         */
+        int max_cell[3];
+        /**
+         * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+         */
+        const MetaData* metadata;
+        /**
+         * CURVE hash for accessing message data
+         * agent function hash + message hash
+         */
+        detail::curve::Curve::NamespaceHash combined_hash;
+    };
+    /**
      * Constructer
      * Initialises member variables
      * @param agentfn_hash Added to msg_hash to produce combined_hash
@@ -273,9 +475,10 @@ class MsgArray3D::In {
         , metadata(reinterpret_cast<const MetaData*>(_metadata))
     { }
     /**
-     * Returns a Filter object which provides access to message iterator
+     * Returns a WrapFilter object which provides access to message iterator
      * for iterating a subset of messages including those within the radius of the search origin
      * this excludes the message at the search origin
+     * The radius will wrap over environment bounds
      *
      * @param x Search origin x coord
      * @param y Search origin y coord
@@ -283,13 +486,57 @@ class MsgArray3D::In {
      * @param radius Search radius
      * @note radius 1 is 26 cells in 3x3x3
      * @note radius 2 is 124 cells in 5x5x5
-     * @note If radius is >= half of the array dimensions, cells will be doubly read
+     * @note radius which produce a message read dimension (radius*2 + 1) greater than one of the message list dimensions are unsupported
      * @note radius of 0 is unsupported
+     * @note The location [x, y, z] must be within the bounds of the message list
      */
-    inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
+    inline __device__ WrapFilter wrap(const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
-            DTHROW("%llu is not a valid radius for accessing Array3D message lists.\n", radius);
+            DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
+        } else if ((radius * 2) + 1 > metadata->dimensions[0] ||
+                   (radius * 2) + 1 > metadata->dimensions[1] ||
+                   (radius * 2) + 1 > metadata->dimensions[2]) {
+            unsigned int min_r = metadata->dimensions[0] < metadata->dimensions[1] ? metadata->dimensions[0] : metadata->dimensions[1];
+            min_r = min_r < metadata->dimensions[2] ? min_r : metadata->dimensions[2];
+            min_r = min_r % 2 == 0 ? min_r - 2: min_r - 1;
+            min_r /= 2;
+            DTHROW("%u is not a valid radius for accessing Array3D message lists, as the diameter of messages accessed exceeds one or more of the message list dimensions (%u, %u, %u)."
+            " Maximum supported radius for this message list is %u.\n",
+            radius, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2], min_r);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1] ||
+                   z >= metadata->dimensions[2]) {
+            DTHROW("(%u, %u, %u) is not a valid position for iterating an Array3D message list of dimensions (%u, %u, %u), location must be within bounds.",
+                x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
+        }
+#endif
+        return WrapFilter(metadata, combined_hash, x, y, z, radius);
+    }
+    /**
+     * Returns a Filter object which provides access to message iterator
+     * for iterating a subset of messages including those within the radius of the search origin
+     * this excludes the message at the search origin
+     * The radius will not wrap over environment bounds
+     *
+     * @param x Search origin x coord
+     * @param y Search origin y coord
+     * @param z Search origin y coord
+     * @param radius Search radius
+     * @note radius 1 is 26 cells in 3x3x3
+     * @note radius 2 is 124 cells in 5x5x5
+     * @note radius of 0 is unsupported
+     * @note The location [x, y, z] must be within the bounds of the message list
+     */
+    inline __device__ Filter operator()(const size_type& x, const size_type& y, const size_type& z, const size_type& radius = 1) const {
+#if !defined(SEATBELTS) || SEATBELTS
+        if (radius == 0) {
+            DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1] ||
+                   z >= metadata->dimensions[2]) {
+            DTHROW("(%u, %u, %u) is not a valid position for iterating an Array3D message list of dimensions (%u, %u, %u), location must be within bounds.",
+                x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
         }
 #endif
         return Filter(metadata, combined_hash, x, y, z, radius);
@@ -407,6 +654,18 @@ __device__ T MsgArray3D::In::Message::getVariable(const char(&variable_name)[N])
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
+__device__ T MsgArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, unsigned int N>
 __device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -455,7 +714,7 @@ __device__ inline void MsgArray3D::Out::setIndex(const size_type &x, const size_
     // Set scan flag incase the message is optional
     this->scan_flag[index] = 1;
 }
-__device__ inline MsgArray3D::In::Filter::Filter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
+__device__ inline MsgArray3D::In::WrapFilter::WrapFilter(const MetaData *_metadata, const detail::curve::Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
     : radius(_radius)
     , metadata(_metadata)
     , combined_hash(_combined_hash) {
@@ -463,7 +722,7 @@ __device__ inline MsgArray3D::In::Filter::Filter(const MetaData *_metadata, cons
     loc[1] = y;
     loc[2] = z;
 }
-__device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Message::operator++() {
+__device__ inline MsgArray3D::In::WrapFilter::Message& MsgArray3D::In::WrapFilter::Message::operator++() {
     if (relative_cell[2] >= static_cast<int>(_parent.radius)) {
         relative_cell[2] = -static_cast<int>(_parent.radius);
         if (relative_cell[1] >= static_cast<int>(_parent.radius)) {
@@ -487,6 +746,51 @@ __device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Messa
     index_1d = their_z * this->_parent.metadata->dimensions[0] * this->_parent.metadata->dimensions[1] +
                their_y * this->_parent.metadata->dimensions[0] +
                their_x;
+    return *this;
+}
+__device__ inline MsgArray3D::In::Filter::Filter(const MetaData* _metadata, const detail::curve::Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius)
+    : metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    loc[0] = x;
+    loc[1] = y;
+    loc[2] = z;
+    min_cell[0] = static_cast<int>(x) - static_cast<int>(_radius) < 0 ? -static_cast<int>(x) : - static_cast<int>(_radius);
+    min_cell[1] = static_cast<int>(y) - static_cast<int>(_radius) < 0 ? -static_cast<int>(y) : - static_cast<int>(_radius);
+    min_cell[2] = static_cast<int>(z) - static_cast<int>(_radius) < 0 ? -static_cast<int>(z) : - static_cast<int>(_radius);
+    max_cell[0] = x + _radius >= _metadata->dimensions[0] ? static_cast<int>(_metadata->dimensions[0]) - 1 - static_cast<int>(x) : static_cast<int>(_radius);
+    max_cell[1] = y + _radius >= _metadata->dimensions[1] ? static_cast<int>(_metadata->dimensions[1]) - 1 - static_cast<int>(y) : static_cast<int>(_radius);
+    max_cell[2] = z + _radius >= _metadata->dimensions[2] ? static_cast<int>(_metadata->dimensions[2]) - 1 - static_cast<int>(z) : static_cast<int>(_radius);
+}
+__device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Message::operator++() {
+    if (relative_cell[2] >= _parent.max_cell[2]) {
+        relative_cell[2] = _parent.min_cell[2];
+        if (relative_cell[1] >= _parent.max_cell[1]) {
+            relative_cell[1] = _parent.min_cell[1];
+            relative_cell[0]++;
+        } else {
+            relative_cell[1]++;
+        }
+    } else {
+        relative_cell[2]++;
+    }
+    // Skip origin cell
+    if (relative_cell[0] == 0 && relative_cell[1] == 0 && relative_cell[2] == 0) {
+        if (relative_cell[2] >= _parent.max_cell[2]) {
+            relative_cell[2] = _parent.min_cell[2];
+            if (relative_cell[1] >= _parent.max_cell[1]) {
+                relative_cell[1] = _parent.min_cell[1];
+                relative_cell[0]++;
+            } else {
+                relative_cell[1]++;
+            }
+        } else {
+            relative_cell[2]++;
+        }
+    }
+    // Solve to 1 dimensional bin index
+    index_1d = (this->_parent.loc[2] + relative_cell[2]) * this->_parent.metadata->dimensions[0] * this->_parent.metadata->dimensions[1] +
+               (this->_parent.loc[1] + relative_cell[1]) * this->_parent.metadata->dimensions[0] +
+               (this->_parent.loc[0] + relative_cell[0]);
     return *this;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,9 +117,6 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/test_namespaces/test_rtc_namespaces.cu
 )
 SET(DEV_TEST_CASE_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_2d.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_3d.cu
 )
 SET(OTHER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/host_reductions_common.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,9 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/test_namespaces/test_rtc_namespaces.cu
 )
 SET(DEV_TEST_CASE_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_2d.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_3d.cu
 )
 SET(OTHER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/host_reductions_common.h

--- a/tests/swig/python/runtime/messaging/test_array.py
+++ b/tests/swig/python/runtime/messaging/test_array.py
@@ -66,7 +66,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, flamegpu::MsgArray, flamegpu::MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(my_index);
+    auto filter = FLAMEGPU->message_in.wrap(my_index);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -1; i <= 1; ++i) {
@@ -79,8 +79,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, flamegpu::MsgArray, flamegpu::MsgNone) {
             ++msg;
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return flamegpu::ALIVE;
 }
@@ -91,7 +89,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, flamegpu::MsgArray, flamegpu::MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(my_index, 2);
+    auto filter = FLAMEGPU->message_in.wrap(my_index, 2);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -2; i <= 2; ++i) {
@@ -104,8 +102,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, flamegpu::MsgArray, flamegpu::MsgNone) {
             ++msg;
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return flamegpu::ALIVE;
 }
@@ -214,7 +210,7 @@ class TestMessage_Array(TestCase):
             assert index * 3 == message_read
         
 
-    def test_Moore1(self): 
+    def test_Moore1W(self): 
         m = pyflamegpu.ModelDescription(MODEL_NAME)
         msg = m.newMessageArray(MESSAGE_NAME)
         msg.setLength(AGENT_COUNT)
@@ -244,10 +240,10 @@ class TestMessage_Array(TestCase):
         # Validate each agent has read 8 correct messages
         for ai in pop:
             message_read = ai.getVariableUInt("message_read")
-            assert 3 == message_read
+            assert 2 == message_read
         
 
-    def test_Moore2(self): 
+    def test_Moore2W(self): 
         m = pyflamegpu.ModelDescription(MODEL_NAME)
         msg = m.newMessageArray(MESSAGE_NAME)
         msg.setLength(AGENT_COUNT)
@@ -277,7 +273,7 @@ class TestMessage_Array(TestCase):
         # Validate each agent has read 8 correct messages
         for ai in pop:
             message_read = ai.getVariableUInt("message_read")
-            assert 5 == message_read
+            assert 4 == message_read
         
 
     # Exception tests

--- a/tests/swig/python/runtime/messaging/test_array_2d.py
+++ b/tests/swig/python/runtime/messaging/test_array_2d.py
@@ -80,7 +80,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, flamegpu::MsgArray2D, flamegpu::MsgNone) {
     const unsigned int index_y = my_index / 12;
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(index_x, index_y);
+    auto filter = FLAMEGPU->message_in.wrap(index_x, index_y);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -1; i <= 1; ++i) {
@@ -96,8 +96,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, flamegpu::MsgArray2D, flamegpu::MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return flamegpu::ALIVE;
 }
@@ -110,7 +108,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, flamegpu::MsgArray2D, flamegpu::MsgNone) {
     const unsigned int index_y = my_index / 12;
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(index_x, index_y, 2);
+    auto filter = FLAMEGPU->message_in.wrap(index_x, index_y, 2);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -2; i <= 2; ++i) {
@@ -126,8 +124,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, flamegpu::MsgArray2D, flamegpu::MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return flamegpu::ALIVE;
 }
@@ -236,7 +232,7 @@ class TestMessage_Array2D(TestCase):
             assert index * 3 == message_read
         
 
-    def test_Moore1(self): 
+    def test_Moore1W(self): 
         m = pyflamegpu.ModelDescription(MODEL_NAME)
         msg = m.newMessageArray2D(MESSAGE_NAME)
         msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1)
@@ -266,10 +262,10 @@ class TestMessage_Array2D(TestCase):
         # Validate each agent has read 8 correct messages
         for ai in pop:
             message_read = ai.getVariableUInt("message_read")
-            assert 9 == message_read
+            assert 8 == message_read
         
 
-    def test_Moore2(self): 
+    def test_Moore2W(self): 
         m = pyflamegpu.ModelDescription(MODEL_NAME)
         msg = m.newMessageArray2D(MESSAGE_NAME)
         msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1)
@@ -299,7 +295,7 @@ class TestMessage_Array2D(TestCase):
         # Validate each agent has read 8 correct messages
         for ai in pop:
             message_read = ai.getVariableUInt("message_read")
-            assert 25 == message_read
+            assert 24 == message_read
         
 
     # Exception tests

--- a/tests/swig/python/runtime/messaging/test_array_3d.py
+++ b/tests/swig/python/runtime/messaging/test_array_3d.py
@@ -86,7 +86,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, flamegpu::MsgArray3D, flamegpu::MsgNone) {
     const unsigned int index_z = my_index / ((6) * (6 + 1));
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(index_x, index_y, index_z);
+    auto filter = FLAMEGPU->message_in.wrap(index_x, index_y, index_z);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -1; i <= 1; ++i) {
@@ -105,8 +105,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, flamegpu::MsgArray3D, flamegpu::MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return flamegpu::ALIVE;
 }
@@ -120,7 +118,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, flamegpu::MsgArray3D, flamegpu::MsgNone) {
     const unsigned int index_z = my_index / ((6) * (6 + 1));
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(index_x, index_y, index_z, 2);
+    auto filter = FLAMEGPU->message_in.wrap(index_x, index_y, index_z, 2);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -2; i <= 2; ++i) {
@@ -139,8 +137,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, flamegpu::MsgArray3D, flamegpu::MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return flamegpu::ALIVE;
 }
@@ -250,7 +246,7 @@ class TestMessage_Array3D(TestCase):
             assert index * 3 == message_read
         
 
-    def test_Moore1(self): 
+    def test_Moore1W(self): 
         m = pyflamegpu.ModelDescription(MODEL_NAME)
         msg = m.newMessageArray3D(MESSAGE_NAME)
         msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2)
@@ -280,10 +276,10 @@ class TestMessage_Array3D(TestCase):
         # Validate each agent has read 8 correct messages
         for ai in pop:
             message_read = ai.getVariableUInt("message_read")
-            assert 27 == message_read
+            assert 26 == message_read
         
 
-    def test_Moore2(self): 
+    def test_Moore2W(self): 
         m = pyflamegpu.ModelDescription(MODEL_NAME)
         msg = m.newMessageArray3D(MESSAGE_NAME)
         msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT + 1, CBRT_AGENT_COUNT + 2)
@@ -313,7 +309,7 @@ class TestMessage_Array3D(TestCase):
         # Validate each agent has read 8 correct messages
         for ai in pop:
             message_read = ai.getVariableUInt("message_read")
-            assert 125 == message_read
+            assert 124 == message_read
         
 
     # Exception tests

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -387,15 +387,15 @@ TEST(TestMessage_Array, ReadEmpty) {
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsX, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapOutOfBoundsX, MsgArray, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(dAGENT_COUNT)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array, MooreW_InitOutOfBoundsX) {
+TEST(TestMessage_Array, MooreWrap_InitOutOfBoundsX) {
 #else
-TEST(TestMessage_Array, DISABLED_MooreW_InitOutOfBoundsX) {
+TEST(TestMessage_Array, DISABLED_MooreWrap_InitOutOfBoundsX) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
@@ -407,7 +407,7 @@ TEST(TestMessage_Array, DISABLED_MooreW_InitOutOfBoundsX) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsX);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapOutOfBoundsX);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -427,15 +427,15 @@ TEST(TestMessage_Array, DISABLED_MooreW_InitOutOfBoundsX) {
     EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius1, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapBadRadius1, MsgArray, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(0, 0)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array, MooreW_BadRadius1) {
+TEST(TestMessage_Array, MooreWrap_BadRadius1) {
 #else
-TEST(TestMessage_Array, DISABLED_MooreW_BadRadius1) {
+TEST(TestMessage_Array, DISABLED_MooreWrap_BadRadius1) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
@@ -447,7 +447,7 @@ TEST(TestMessage_Array, DISABLED_MooreW_BadRadius1) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius1);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapBadRadius1);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -467,15 +467,15 @@ TEST(TestMessage_Array, DISABLED_MooreW_BadRadius1) {
     EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius2, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapBadRadius2, MsgArray, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(0, 64)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array, MooreW_BadRadius2) {
+TEST(TestMessage_Array, MooreWrap_BadRadius2) {
 #else
-TEST(TestMessage_Array, DISABLED_MooreW_BadRadius2) {
+TEST(TestMessage_Array, DISABLED_MooreWrap_BadRadius2) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
@@ -487,7 +487,7 @@ TEST(TestMessage_Array, DISABLED_MooreW_BadRadius2) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius2);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapBadRadius2);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -598,7 +598,7 @@ FLAMEGPU_AGENT_FUNCTION(OutSimpleX, MsgNone, MsgArray) {
     FLAMEGPU->message_out.setIndex(x);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreWTestXC, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreWrapTestXC, MsgArray, MsgNone) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
     const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
@@ -612,7 +612,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreWTestXC, MsgArray, MsgNone) {
     return ALIVE;
 }
 
-void test_mooorew_comradius(
+void test_moore_wrap_comradius(
     const unsigned int GRID_WIDTH,
     const unsigned int COMRADIUS
     ) {
@@ -637,7 +637,7 @@ void test_mooorew_comradius(
     // Define the function and layers.
     AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleX", OutSimpleX);
     outputFunction.setMessageOutput(message);
-    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWTestXC", MooreWTestXC);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWrapTestXC", MooreWrapTestXC);
     inputFunction.setMessageInput(message);
     model.newLayer().addAgentFunction(outputFunction);
     LayerDescription &li = model.newLayer();
@@ -678,39 +678,39 @@ void test_mooorew_comradius(
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array, MooreWX1R1) {
-    test_mooorew_comradius(1, 1);
+TEST(TestMessage_Array, MooreWrapX1R1) {
+    test_moore_wrap_comradius(1, 1);
 }
-TEST(TestMessage_Array, MooreWX2R1) {
-    test_mooorew_comradius(2, 1);
+TEST(TestMessage_Array, MooreWrapX2R1) {
+    test_moore_wrap_comradius(2, 1);
 }
-TEST(TestMessage_Array, MooreWX3R1) {
-    test_mooorew_comradius(3, 1);
+TEST(TestMessage_Array, MooreWrapX3R1) {
+    test_moore_wrap_comradius(3, 1);
 }
-TEST(TestMessage_Array, MooreWX4R1) {
-    test_mooorew_comradius(4, 1);
+TEST(TestMessage_Array, MooreWrapX4R1) {
+    test_moore_wrap_comradius(4, 1);
 }
 
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array, MooreWX1R2) {
-    test_mooorew_comradius(1, 2);
+TEST(TestMessage_Array, MooreWrapX1R2) {
+    test_moore_wrap_comradius(1, 2);
 }
-TEST(TestMessage_Array, MooreWX2R2) {
-    test_mooorew_comradius(2, 2);
+TEST(TestMessage_Array, MooreWrapX2R2) {
+    test_moore_wrap_comradius(2, 2);
 }
-TEST(TestMessage_Array, MooreWX3R2) {
-    test_mooorew_comradius(3, 2);
+TEST(TestMessage_Array, MooreWrapX3R2) {
+    test_moore_wrap_comradius(3, 2);
 }
-TEST(TestMessage_Array, MooreWX4R2) {
-    test_mooorew_comradius(4, 2);
+TEST(TestMessage_Array, MooreWrapX4R2) {
+    test_moore_wrap_comradius(4, 2);
 }
-TEST(TestMessage_Array, MooreWX5R2) {
-    test_mooorew_comradius(5, 2);
+TEST(TestMessage_Array, MooreWrapX5R2) {
+    test_moore_wrap_comradius(5, 2);
 }
-TEST(TestMessage_Array, MooreWX6R2) {
-    test_mooorew_comradius(6, 2);
+TEST(TestMessage_Array, MooreWrapX6R2) {
+    test_moore_wrap_comradius(6, 2);
 }
 
 FLAMEGPU_AGENT_FUNCTION(MooreTestXC, MsgArray, MsgNone) {

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -675,41 +675,21 @@ void test_moore_wrap_comradius(
 #endif
     }
 }
-// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array, MooreWrapX1R1) {
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with wrapping.
+TEST(TestMessage_Array, MooreWrapR1) {
     test_moore_wrap_comradius(1, 1);
-}
-TEST(TestMessage_Array, MooreWrapX2R1) {
     test_moore_wrap_comradius(2, 1);
-}
-TEST(TestMessage_Array, MooreWrapX3R1) {
     test_moore_wrap_comradius(3, 1);
-}
-TEST(TestMessage_Array, MooreWrapX4R1) {
     test_moore_wrap_comradius(4, 1);
 }
 
-// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array, MooreWrapX1R2) {
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case, with wrapped communication.
+TEST(TestMessage_Array, MooreWrapR2) {
     test_moore_wrap_comradius(1, 2);
-}
-TEST(TestMessage_Array, MooreWrapX2R2) {
     test_moore_wrap_comradius(2, 2);
-}
-TEST(TestMessage_Array, MooreWrapX3R2) {
     test_moore_wrap_comradius(3, 2);
-}
-TEST(TestMessage_Array, MooreWrapX4R2) {
     test_moore_wrap_comradius(4, 2);
-}
-TEST(TestMessage_Array, MooreWrapX5R2) {
     test_moore_wrap_comradius(5, 2);
-}
-TEST(TestMessage_Array, MooreWrapX6R2) {
     test_moore_wrap_comradius(6, 2);
 }
 
@@ -787,40 +767,20 @@ void test_mooore_comradius(
     ASSERT_EQ(right_count, population.size());
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array, MooreX1R1) {
+TEST(TestMessage_Array, MooreR1) {
     test_mooore_comradius(1, 1);
-}
-TEST(TestMessage_Array, MooreX2R1) {
     test_mooore_comradius(2, 1);
-}
-TEST(TestMessage_Array, MooreX3R1) {
     test_mooore_comradius(3, 1);
-}
-TEST(TestMessage_Array, MooreX4R1) {
     test_mooore_comradius(4, 1);
 }
 
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array, MooreX1R2) {
+TEST(TestMessage_Array, MooreR2) {
     test_mooore_comradius(1, 2);
-}
-TEST(TestMessage_Array, MooreX2R2) {
     test_mooore_comradius(2, 2);
-}
-TEST(TestMessage_Array, MooreX3R2) {
     test_mooore_comradius(3, 2);
-}
-TEST(TestMessage_Array, MooreX4R2) {
     test_mooore_comradius(4, 2);
-}
-TEST(TestMessage_Array, MooreX5R2) {
     test_mooore_comradius(5, 2);
-}
-TEST(TestMessage_Array, MooreX6R2) {
     test_mooore_comradius(6, 2);
 }
 

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -201,8 +201,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1W, MsgArray, MsgNone) {
             ++msg;
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
@@ -223,8 +221,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2W, MsgArray, MsgNone) {
             ++msg;
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
@@ -258,7 +254,7 @@ TEST(TestMessage_Array, Moore1W) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(3u, message_read);
+        EXPECT_EQ(2u, message_read);
     }
 }
 TEST(TestMessage_Array, Moore2W) {
@@ -291,7 +287,7 @@ TEST(TestMessage_Array, Moore2W) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(5u, message_read);
+        EXPECT_EQ(4u, message_read);
     }
 }
 // Exception tests

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -16,6 +16,7 @@ namespace test_message_array {
     const char *IN_LAYER_NAME = "InLayer";
     const char *OUT_LAYER_NAME = "OutLayer";
     const unsigned int AGENT_COUNT = 128;
+    __device__ const unsigned int dAGENT_COUNT = 128;
 FLAMEGPU_AGENT_FUNCTION(OutFunction, MsgNone, MsgArray) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
     FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
@@ -183,11 +184,11 @@ FLAMEGPU_AGENT_FUNCTION(OutSimple, MsgNone, MsgArray) {
     FLAMEGPU->message_out.setIndex(index);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreTest1W, MsgArray, MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(my_index);
+    auto filter = FLAMEGPU->message_in.wrap(my_index);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -1; i <= 1; ++i) {
@@ -205,11 +206,11 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray, MsgNone) {
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreTest2W, MsgArray, MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(my_index, 2);
+    auto filter = FLAMEGPU->message_in.wrap(my_index, 2);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -2; i <= 2; ++i) {
@@ -227,7 +228,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray, MsgNone) {
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
-TEST(TestMessage_Array, Moore1) {
+TEST(TestMessage_Array, Moore1W) {
     ModelDescription m(MODEL_NAME);
     MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
     msg.setLength(AGENT_COUNT);
@@ -236,7 +237,7 @@ TEST(TestMessage_Array, Moore1) {
     a.newVariable<unsigned int>("message_read", UINT_MAX);
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1W);
     fi.setMessageInput(msg);
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -260,7 +261,7 @@ TEST(TestMessage_Array, Moore1) {
         EXPECT_EQ(3u, message_read);
     }
 }
-TEST(TestMessage_Array, Moore2) {
+TEST(TestMessage_Array, Moore2W) {
     ModelDescription m(MODEL_NAME);
     MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
     msg.setLength(AGENT_COUNT);
@@ -269,7 +270,7 @@ TEST(TestMessage_Array, Moore2) {
     a.newVariable<unsigned int>("message_read", UINT_MAX);
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2W);
     fi.setMessageInput(msg);
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -304,8 +305,6 @@ TEST(TestMessage_Array, DISABLED_DuplicateOutputException) {
     msg.setLength(AGENT_COUNT);
     msg.newVariable<unsigned int>("index_times_3");
     AgentDescription &a = m.newAgent(AGENT_NAME);
-    a.newVariable<unsigned int>("index");
-    a.newVariable<unsigned int>("message_read", UINT_MAX);
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutBad);
     fo.setMessageOutput(msg);
@@ -327,9 +326,7 @@ TEST(TestMessage_Array, DISABLED_DuplicateOutputException) {
     AgentVector pop(a, AGENT_COUNT);
     for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
         AgentVector::Agent ai = pop[i];
-        ai.setVariable<unsigned int>("index", i);
-        ai.setVariable<unsigned int>("message_read", UINT_MAX);
-        ai.setVariable<unsigned int>("message_write", numbers[i]);
+        ai.setVariable<unsigned int>("message_write", i);  // numbers[i]
     }
     // Set pop in model
     CUDASimulation c(m);
@@ -389,6 +386,206 @@ TEST(TestMessage_Array, ReadEmpty) {
     auto ai = pop_out[0];
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
 }
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsX, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(dAGENT_COUNT)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, MooreW_InitOutOfBoundsX) {
+#else
+TEST(TestMessage_Array, DISABLED_MooreW_InitOutOfBoundsX) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsX);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius1, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, MooreW_BadRadius1) {
+#else
+TEST(TestMessage_Array, DISABLED_MooreW_BadRadius1) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius1);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius2, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, 64)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, MooreW_BadRadius2) {
+#else
+TEST(TestMessage_Array, DISABLED_MooreW_BadRadius2) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius2);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreOutOfBoundsX, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(dAGENT_COUNT)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, Moore_InitOutOfBoundsX) {
+#else
+TEST(TestMessage_Array, DISABLED_Moore_InitOutOfBoundsX) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreOutOfBoundsX);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreBadRadius, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(0, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, Moore_BadRadius) {
+#else
+TEST(TestMessage_Array, DISABLED_Moore_BadRadius) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreBadRadius);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
 
 /*
  * Test for fixed size grids with various com radii to check edge cases + expected cases.
@@ -401,6 +598,121 @@ FLAMEGPU_AGENT_FUNCTION(OutSimpleX, MsgNone, MsgArray) {
     FLAMEGPU->message_out.setIndex(x);
     return ALIVE;
 }
+FLAMEGPU_AGENT_FUNCTION(MooreWTestXC, MsgArray, MsgNone) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
+    // Iterate message list counting how many messages were read
+    unsigned int count = 0;
+    for (const auto &message : FLAMEGPU->message_in.wrap(x, COMRADIUS)) {
+        // @todo - check its the correct messages?
+        count++;
+    }
+    FLAMEGPU->setVariable<unsigned int>("message_read", count);
+    return ALIVE;
+}
+
+void test_mooorew_comradius(
+    const unsigned int GRID_WIDTH,
+    const unsigned int COMRADIUS
+    ) {
+    // Calc the population
+    const unsigned int agentCount = GRID_WIDTH;
+
+    // Define the model
+    ModelDescription model("MooreXR");
+
+    // Use an env var for the communication radius to use, rather than a __device__ or a #define.
+    EnvironmentDescription &env = model.Environment();
+    env.newProperty<unsigned int>("COMRADIUS", COMRADIUS);
+
+    // Define the message
+    MsgArray::Description &message = model.newMessage<MsgArray>(MESSAGE_NAME);
+    message.newVariable<unsigned int>("index");
+    message.setLength(GRID_WIDTH);
+    AgentDescription &agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<unsigned int>("index");
+    agent.newVariable<unsigned int>("x");
+    agent.newVariable<unsigned int>("message_read", UINT_MAX);
+    // Define the function and layers.
+    AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleX", OutSimpleX);
+    outputFunction.setMessageOutput(message);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWTestXC", MooreWTestXC);
+    inputFunction.setMessageInput(message);
+    model.newLayer().addAgentFunction(outputFunction);
+    LayerDescription &li = model.newLayer();
+    li.addAgentFunction(inputFunction);
+    // Assign the numbers in shuffled order to agents
+    AgentVector population(agent, agentCount);
+    for (unsigned int x = 0; x < GRID_WIDTH; x++) {
+        unsigned int idx = x;
+        AgentVector::Agent instance = population[idx];
+        instance.setVariable<unsigned int>("index", idx);
+        instance.setVariable<unsigned int>("x", x);
+        instance.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDASimulation simulation(model);
+    simulation.setPopulationData(population);
+
+    if ((COMRADIUS * 2) + 1 <= GRID_WIDTH) {
+        simulation.step();
+        simulation.getPopulationData(population);
+        // Validate each agent has read correct messages
+
+        // Calc the expected number of messages. This depoends on comm radius for wrapped moore neighbourhood
+        const unsigned int expected_count = COMRADIUS * 2;
+
+        for (AgentVector::Agent instance : population) {
+            const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
+            ASSERT_EQ(expected_count, message_read);
+        }
+    } else {
+        // If the comradius would lead to double message reads, a device error is thrown when SEATBELTS is enabled
+        // Behaviour is otherwise undefined
+#if !defined(SEATBELTS) || SEATBELTS
+        EXPECT_THROW(simulation.step(), flamegpu::exception::DeviceError);
+#endif
+    }
+}
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array, MooreWX1R1) {
+    test_mooorew_comradius(1, 1);
+}
+TEST(TestMessage_Array, MooreWX2R1) {
+    test_mooorew_comradius(2, 1);
+}
+TEST(TestMessage_Array, MooreWX3R1) {
+    test_mooorew_comradius(3, 1);
+}
+TEST(TestMessage_Array, MooreWX4R1) {
+    test_mooorew_comradius(4, 1);
+}
+
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array, MooreWX1R2) {
+    test_mooorew_comradius(1, 2);
+}
+TEST(TestMessage_Array, MooreWX2R2) {
+    test_mooorew_comradius(2, 2);
+}
+TEST(TestMessage_Array, MooreWX3R2) {
+    test_mooorew_comradius(3, 2);
+}
+TEST(TestMessage_Array, MooreWX4R2) {
+    test_mooorew_comradius(4, 2);
+}
+TEST(TestMessage_Array, MooreWX5R2) {
+    test_mooorew_comradius(5, 2);
+}
+TEST(TestMessage_Array, MooreWX6R2) {
+    test_mooorew_comradius(6, 2);
+}
+
 FLAMEGPU_AGENT_FUNCTION(MooreTestXC, MsgArray, MsgNone) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -421,11 +733,6 @@ void test_mooore_comradius(
     ) {
     // Calc the population
     const unsigned int agentCount = GRID_WIDTH;
-    // Some debug logging. @todo
-    /* printf("GRID_WIDTH %u\n", GRID_WIDTH);
-    printf("GRID_HEIGHT %u\n", GRID_HEIGHT);
-    printf("COMRADIUS %u\n", COMRADIUS);
-    printf("agentCount %u\n", agentCount); */
 
     // Define the model
     ModelDescription model("MooreXR");
@@ -464,34 +771,20 @@ void test_mooore_comradius(
     simulation.setPopulationData(population);
     simulation.step();
     simulation.getPopulationData(population);
-    // Validate each agent has read correct messages
-
-    // Calc the expected number of messages. This depoends on the env dims and the comm radius.
-    // Radius 0 is not supported, and currently the centre cell is not returned for other radii (so usually -1).
-    // If one of the environemnt dimensions is too small, < 2 * radius + 1, then either fewer messages should be read, or messages will be re-read.
-    // In this case, the centre cell may / is currently also read.
-
-    // const unsigned int nowrapExpectedCount = (2 * COMRADIUS) + 1 - 1;
-    // If any dim is less than 2 * rad + 1, then there are fewere unique messages to be read, and the center will be re-read.
-    const bool xFewerReads = (2 * COMRADIUS) + 1 > GRID_WIDTH;
-    const unsigned int xReadRange = !xFewerReads ? (2 * COMRADIUS) + 1 : GRID_WIDTH;
-    // @todo - verify if the self message should ever be returned, even when wrapped. Can always -1 if it should never be read.
-    const unsigned int selfRead = xFewerReads ? 0 : 1;
-    const unsigned int expected_count = (xReadRange) - selfRead;
-
-    /*
-    // @todo 
-    printf("xFewerReads %d\n", xFewerReads);
-    printf("yFewerReads %d\n", yFewerReads);
-    printf("xReadRange %u\n", xReadRange);
-    printf("yReadRange %u\n", yReadRange);
-    printf("selfRead %u\n", selfRead);
-    printf("expected_count %u\n", expected_count); */
-
+    unsigned int right_count = 0;
+    // Validate each agent has read correct number of messages
     for (AgentVector::Agent instance : population) {
+        const unsigned int x = instance.getVariable<unsigned int>("x");
         const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
-        ASSERT_EQ(expected_count, message_read);
+
+        unsigned int expected_read = 1;
+        expected_read *= (std::min<int>(static_cast<int>(x + COMRADIUS), static_cast<int>(GRID_WIDTH) - 1) - std::max<int>(static_cast<int>(x) - static_cast<int>(COMRADIUS), 0) + 1);
+        expected_read--;
+        // ASSERT_EQ(message_read, expected_read);
+        if (message_read == expected_read)
+            right_count++;
     }
+    ASSERT_EQ(right_count, population.size());
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -218,8 +218,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1W, MsgArray2D, MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
@@ -245,8 +243,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2W, MsgArray2D, MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
@@ -280,7 +276,7 @@ TEST(TestMessage_Array2D, Moore1W) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(9u, message_read);
+        EXPECT_EQ(8u, message_read);
     }
 }
 TEST(TestMessage_Array2D, Moore2W) {
@@ -313,7 +309,7 @@ TEST(TestMessage_Array2D, Moore2W) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(25u, message_read);
+        EXPECT_EQ(24u, message_read);
     }
 }
 

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -150,7 +150,7 @@ TEST(TestMessage_Array2D, Optional) {
 }
 
 // Test optional message output, wehre no messages are output.
-TEST(TestMessage_Array3D, OptionalNone) {
+TEST(TestMessage_Array2D, OptionalNone) {
     ModelDescription m(MODEL_NAME);
     MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
     msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
@@ -415,6 +415,179 @@ TEST(TestMessage_Array2D, ReadEmpty) {
     EXPECT_EQ(pop_out.size(), 1u);
     auto ai = pop_out[0];
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
+}
+
+/*
+ * Test for fixed size grids with various com radii to check edge cases + expected cases.
+ * 3x3x3 issue highlighted by see https://github.com/FLAMEGPU/FLAMEGPU2/issues/547
+ */
+FLAMEGPU_AGENT_FUNCTION(OutSimpleXY, MsgNone, MsgArray2D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
+    FLAMEGPU->message_out.setVariable("index", index);
+    FLAMEGPU->message_out.setIndex(x, y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTestXYC, MsgArray2D, MsgNone) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
+    const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
+    // Iterate message list counting how many messages were read.
+    unsigned int count = 0;
+    for (const auto &message : FLAMEGPU->message_in(x, y, COMRADIUS)) {
+        // @todo - check its the correct messages?
+        count++;
+    }
+    FLAMEGPU->setVariable<unsigned int>("message_read", count);
+    return ALIVE;
+}
+
+void test_mooore_comradius(
+    const unsigned int GRID_WIDTH,
+    const unsigned int GRID_HEIGHT,
+    const unsigned int COMRADIUS
+    ) {
+    // Calc the population
+    const unsigned int agentCount = GRID_WIDTH * GRID_HEIGHT;
+    // Some debug logging. @todo
+    /* printf("GRID_WIDTH %u\n", GRID_WIDTH);
+    printf("GRID_HEIGHT %u\n", GRID_HEIGHT);
+    printf("COMRADIUS %u\n", COMRADIUS);
+    printf("agentCount %u\n", agentCount); */
+
+    // Define the model
+    ModelDescription model("MooreXRC");
+
+    // Use an env var for the communication radius to use, rather than a __device__ or a #define.
+    EnvironmentDescription &env = model.Environment();
+    env.newProperty<unsigned int>("COMRADIUS", COMRADIUS);
+
+    // Define the message
+    MsgArray2D::Description &message = model.newMessage<MsgArray2D>(MESSAGE_NAME);
+    message.newVariable<unsigned int>("index");
+    message.setDimensions(GRID_WIDTH, GRID_HEIGHT);
+    AgentDescription &agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<unsigned int>("index");
+    agent.newVariable<unsigned int>("x");
+    agent.newVariable<unsigned int>("y");
+    agent.newVariable<unsigned int>("message_read", UINT_MAX);
+    // Define the function and layers.
+    AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleXY", OutSimpleXY);
+    outputFunction.setMessageOutput(message);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreTestXYC", MooreTestXYC);
+    inputFunction.setMessageInput(message);
+    model.newLayer().addAgentFunction(outputFunction);
+    LayerDescription &li = model.newLayer();
+    li.addAgentFunction(inputFunction);
+    // Assign the numbers in shuffled order to agents
+    AgentVector population(agent, agentCount);
+    for (unsigned int x = 0; x < GRID_WIDTH; x++) {
+        for (unsigned int y = 0; y < GRID_HEIGHT; y++) {
+            unsigned int idx = (x * GRID_HEIGHT) + y;
+            AgentVector::Agent instance = population[idx];
+            instance.setVariable<unsigned int>("index", idx);
+            instance.setVariable<unsigned int>("x", x);
+            instance.setVariable<unsigned int>("y", y);
+            instance.setVariable<unsigned int>("message_read", UINT_MAX);
+        }
+    }
+    // Set pop in model
+    CUDASimulation simulation(model);
+    simulation.setPopulationData(population);
+    simulation.step();
+    simulation.getPopulationData(population);
+    // Validate each agent has read correct messages
+    // Calc the expected number of messages. This depoends on the env dims and the comm radius.
+    // Radius 0 is not supported, and currently the centre cell is not returned for other radii (so usually -1).
+    // If one of the environemnt dimensions is too small, < 2 * radius + 1, then either fewer messages should be read, or messages will be re-read.
+    // In this case, the centre cell may / is currently also read.
+
+    // const unsigned int nowrapExpectedCount = pow((2 * COMRADIUS) + 1, 2) - 1;
+    // If any dim is less than 2 * rad + 1, then there are fewere unique messages to be read, and the center will be re-read.
+    const bool xFewerReads = (2 * COMRADIUS) + 1 > GRID_WIDTH;
+    const bool yFewerReads = (2 * COMRADIUS) + 1 > GRID_HEIGHT;
+    const unsigned int xReadRange = !xFewerReads ? (2 * COMRADIUS) + 1 : GRID_WIDTH;
+    const unsigned int yReadRange = !yFewerReads ? (2 * COMRADIUS) + 1 : GRID_HEIGHT;
+    // @todo - verify if the self message should ever be returned, even when wrapped. Can always -1 if it should never be read.
+    const unsigned int selfRead = xFewerReads || yFewerReads ? 0 : 1;
+    const unsigned int expected_count = (xReadRange * yReadRange) - selfRead;
+
+    /*
+    // @todo 
+    printf("xFewerReads %d\n", xFewerReads);
+    printf("yFewerReads %d\n", yFewerReads);
+    printf("xReadRange %u\n", xReadRange);
+    printf("yReadRange %u\n", yReadRange);
+    printf("selfRead %u\n", selfRead);
+    printf("expected_count %u\n", expected_count); */
+
+    for (AgentVector::Agent instance : population) {
+        const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
+        ASSERT_EQ(expected_count, message_read);
+    }
+}
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array2D, MooreX1Y1R1) {
+    test_mooore_comradius(1, 1, 1);
+}
+TEST(TestMessage_Array2D, MooreX2Y2R1) {
+    test_mooore_comradius(2, 2, 1);
+}
+TEST(TestMessage_Array2D, MooreX3Y3R1) {
+    test_mooore_comradius(3, 3, 1);
+}
+TEST(TestMessage_Array2D, MooreX4Y4R1) {
+    test_mooore_comradius(4, 4, 1);
+}
+TEST(TestMessage_Array2D, MooreX2Y1R1) {
+    test_mooore_comradius(2, 1, 1);
+}
+TEST(TestMessage_Array2D, MooreX3Y1R1) {
+    test_mooore_comradius(3, 1, 1);
+}
+TEST(TestMessage_Array2D, MooreX4Y1R1) {
+    test_mooore_comradius(4, 1, 1);
+}
+
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array2D, MooreX1Y1R2) {
+    test_mooore_comradius(1, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreX2Y2R2) {
+    test_mooore_comradius(2, 2, 2);
+}
+TEST(TestMessage_Array2D, MooreX3Y3R2) {
+    test_mooore_comradius(3, 3, 2);
+}
+TEST(TestMessage_Array2D, MooreX4Y4R2) {
+    test_mooore_comradius(4, 4, 2);
+}
+TEST(TestMessage_Array2D, MooreX5Y5R2) {
+    test_mooore_comradius(5, 5, 2);
+}
+TEST(TestMessage_Array2D, MooreX6Y6R2) {
+    test_mooore_comradius(6, 6, 2);
+}
+TEST(TestMessage_Array2D, MooreX2Y1R2) {
+    test_mooore_comradius(2, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreX3Y1R2) {
+    test_mooore_comradius(3, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreX4Y1R2) {
+    test_mooore_comradius(4, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreX5Y1R2) {
+    test_mooore_comradius(5, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreX6Y1R2) {
+    test_mooore_comradius(6, 1, 2);
 }
 
 }  // namespace test_message_array_2d

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -721,7 +721,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreWTestXYC, MsgArray2D, MsgNone) {
     return ALIVE;
 }
 
-void test_mooorew_comradius(
+void test_moore_wrap_comradius(
     const unsigned int GRID_WIDTH,
     const unsigned int GRID_HEIGHT,
     const unsigned int COMRADIUS
@@ -793,63 +793,63 @@ void test_mooorew_comradius(
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array2D, MooreWX1Y1R1) {
-    test_mooorew_comradius(1, 1, 1);
+TEST(TestMessage_Array2D, MooreWrapX1Y1R1) {
+    test_moore_wrap_comradius(1, 1, 1);
 }
-TEST(TestMessage_Array2D, MooreWX2Y2R1) {
-    test_mooorew_comradius(2, 2, 1);
+TEST(TestMessage_Array2D, MooreWrapX2Y2R1) {
+    test_moore_wrap_comradius(2, 2, 1);
 }
-TEST(TestMessage_Array2D, MooreWX3Y3R1) {
-    test_mooorew_comradius(3, 3, 1);
+TEST(TestMessage_Array2D, MooreWrapX3Y3R1) {
+    test_moore_wrap_comradius(3, 3, 1);
 }
-TEST(TestMessage_Array2D, MooreWX4Y4R1) {
-    test_mooorew_comradius(4, 4, 1);
+TEST(TestMessage_Array2D, MooreWrapX4Y4R1) {
+    test_moore_wrap_comradius(4, 4, 1);
 }
-TEST(TestMessage_Array2D, MooreWX2Y1R1) {
-    test_mooorew_comradius(2, 1, 1);
+TEST(TestMessage_Array2D, MooreWrapX2Y1R1) {
+    test_moore_wrap_comradius(2, 1, 1);
 }
-TEST(TestMessage_Array2D, MooreWX3Y1R1) {
-    test_mooorew_comradius(3, 1, 1);
+TEST(TestMessage_Array2D, MooreWrapX3Y1R1) {
+    test_moore_wrap_comradius(3, 1, 1);
 }
-TEST(TestMessage_Array2D, MooreWX4Y1R1) {
-    test_mooorew_comradius(4, 1, 1);
+TEST(TestMessage_Array2D, MooreWrapX4Y1R1) {
+    test_moore_wrap_comradius(4, 1, 1);
 }
 
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array2D, MooreWX1Y1R2) {
-    test_mooorew_comradius(1, 1, 2);
+TEST(TestMessage_Array2D, MooreWrapX1Y1R2) {
+    test_moore_wrap_comradius(1, 1, 2);
 }
-TEST(TestMessage_Array2D, MooreWX2Y2R2) {
-    test_mooorew_comradius(2, 2, 2);
+TEST(TestMessage_Array2D, MooreWrapX2Y2R2) {
+    test_moore_wrap_comradius(2, 2, 2);
 }
-TEST(TestMessage_Array2D, MooreWX3Y3R2) {
-    test_mooorew_comradius(3, 3, 2);
+TEST(TestMessage_Array2D, MooreWrapX3Y3R2) {
+    test_moore_wrap_comradius(3, 3, 2);
 }
-TEST(TestMessage_Array2D, MooreWX4Y4R2) {
-    test_mooorew_comradius(4, 4, 2);
+TEST(TestMessage_Array2D, MooreWrapX4Y4R2) {
+    test_moore_wrap_comradius(4, 4, 2);
 }
-TEST(TestMessage_Array2D, MooreWX5Y5R2) {
-    test_mooorew_comradius(5, 5, 2);
+TEST(TestMessage_Array2D, MooreWrapX5Y5R2) {
+    test_moore_wrap_comradius(5, 5, 2);
 }
-TEST(TestMessage_Array2D, MooreWX6Y6R2) {
-    test_mooorew_comradius(6, 6, 2);
+TEST(TestMessage_Array2D, MooreWrapX6Y6R2) {
+    test_moore_wrap_comradius(6, 6, 2);
 }
-TEST(TestMessage_Array2D, MooreWX2Y1R2) {
-    test_mooorew_comradius(2, 1, 2);
+TEST(TestMessage_Array2D, MooreWrapX2Y1R2) {
+    test_moore_wrap_comradius(2, 1, 2);
 }
-TEST(TestMessage_Array2D, MooreWX3Y1R2) {
-    test_mooorew_comradius(3, 1, 2);
+TEST(TestMessage_Array2D, MooreWrapX3Y1R2) {
+    test_moore_wrap_comradius(3, 1, 2);
 }
-TEST(TestMessage_Array2D, MooreWX4Y1R2) {
-    test_mooorew_comradius(4, 1, 2);
+TEST(TestMessage_Array2D, MooreWrapX4Y1R2) {
+    test_moore_wrap_comradius(4, 1, 2);
 }
-TEST(TestMessage_Array2D, MooreWX5Y1R2) {
-    test_mooorew_comradius(5, 1, 2);
+TEST(TestMessage_Array2D, MooreWrapX5Y1R2) {
+    test_moore_wrap_comradius(5, 1, 2);
 }
-TEST(TestMessage_Array2D, MooreWX6Y1R2) {
-    test_mooorew_comradius(6, 1, 2);
+TEST(TestMessage_Array2D, MooreWrapX6Y1R2) {
+    test_moore_wrap_comradius(6, 1, 2);
 }
 
 FLAMEGPU_AGENT_FUNCTION(MooreTestXYC, MsgArray2D, MsgNone) {

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -196,13 +196,13 @@ FLAMEGPU_AGENT_FUNCTION(OutSimple, MsgNone, MsgArray2D) {
     FLAMEGPU->message_out.setIndex(index_x, index_y);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray2D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreTest1W, MsgArray2D, MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int index_x = my_index % dSQRT_AGENT_COUNT;
     const unsigned int index_y = my_index / dSQRT_AGENT_COUNT;
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(index_x, index_y);
+    auto filter = FLAMEGPU->message_in.wrap(index_x, index_y);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -1; i <= 1; ++i) {
@@ -223,13 +223,13 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray2D, MsgNone) {
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray2D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreTest2W, MsgArray2D, MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int index_x = my_index % dSQRT_AGENT_COUNT;
     const unsigned int index_y = my_index / dSQRT_AGENT_COUNT;
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(index_x, index_y, 2);
+    auto filter = FLAMEGPU->message_in.wrap(index_x, index_y, 2);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -2; i <= 2; ++i) {
@@ -250,7 +250,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray2D, MsgNone) {
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
-TEST(TestMessage_Array2D, Moore1) {
+TEST(TestMessage_Array2D, Moore1W) {
     ModelDescription m(MODEL_NAME);
     MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
     msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
@@ -259,7 +259,7 @@ TEST(TestMessage_Array2D, Moore1) {
     a.newVariable<unsigned int>("message_read", UINT_MAX);
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1W);
     fi.setMessageInput(msg);
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -283,7 +283,7 @@ TEST(TestMessage_Array2D, Moore1) {
         EXPECT_EQ(9u, message_read);
     }
 }
-TEST(TestMessage_Array2D, Moore2) {
+TEST(TestMessage_Array2D, Moore2W) {
     ModelDescription m(MODEL_NAME);
     MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
     msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
@@ -292,7 +292,7 @@ TEST(TestMessage_Array2D, Moore2) {
     a.newVariable<unsigned int>("message_read", UINT_MAX);
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2W);
     fi.setMessageInput(msg);
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -328,8 +328,6 @@ TEST(TestMessage_Array2D, DISABLED_DuplicateOutputException) {
     msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
     msg.newVariable<unsigned int>("index_times_3");
     AgentDescription &a = m.newAgent(AGENT_NAME);
-    a.newVariable<unsigned int>("index");
-    a.newVariable<unsigned int>("message_read", UINT_MAX);
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutBad);
     fo.setMessageOutput(msg);
@@ -351,9 +349,7 @@ TEST(TestMessage_Array2D, DISABLED_DuplicateOutputException) {
     AgentVector pop(a, AGENT_COUNT);
     for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
         AgentVector::Agent ai = pop[i];
-        ai.setVariable<unsigned int>("index", i);
-        ai.setVariable<unsigned int>("message_read", UINT_MAX);
-        ai.setVariable<unsigned int>("message_write", numbers[i]);
+        ai.setVariable<unsigned int>("message_write", i);  // numbers[i]
     }
     // Set pop in model
     CUDASimulation c(m);
@@ -416,6 +412,287 @@ TEST(TestMessage_Array2D, ReadEmpty) {
     auto ai = pop_out[0];
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
 }
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsX, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(dSQRT_AGENT_COUNT, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, MooreW_InitOutOfBoundsX) {
+#else
+TEST(TestMessage_Array2D, DISABLED_MooreW_InitOutOfBoundsX) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsX);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsY, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, dSQRT_AGENT_COUNT + 1, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, MooreW_InitOutOfBoundsY) {
+#else
+TEST(TestMessage_Array2D, DISABLED_MooreW_InitOutOfBoundsY) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsY);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius1, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, 0, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, MooreW_BadRadius1) {
+#else
+TEST(TestMessage_Array2D, DISABLED_MooreW_BadRadius1) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius1);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius2, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, 0, 6)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, MooreW_BadRadius2) {
+#else
+TEST(TestMessage_Array2D, DISABLED_MooreW_BadRadius2) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius2);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreOutOfBoundsX, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(dSQRT_AGENT_COUNT, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, Moore_InitOutOfBoundsX) {
+#else
+TEST(TestMessage_Array2D, DISABLED_Moore_InitOutOfBoundsX) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreOutOfBoundsX);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreOutOfBoundsY, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(0, dSQRT_AGENT_COUNT + 1)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, Moore_InitOutOfBoundsY) {
+#else
+TEST(TestMessage_Array2D, DISABLED_Moore_InitOutOfBoundsY) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreOutOfBoundsY);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreBadRadius, MsgArray2D, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(0, 0, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, Moore_BadRadius) {
+#else
+TEST(TestMessage_Array2D, DISABLED_Moore_BadRadius) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT + 1);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreBadRadius);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
+}
+
 
 /*
  * Test for fixed size grids with various com radii to check edge cases + expected cases.
@@ -429,6 +706,152 @@ FLAMEGPU_AGENT_FUNCTION(OutSimpleXY, MsgNone, MsgArray2D) {
     FLAMEGPU->message_out.setIndex(x, y);
     return ALIVE;
 }
+FLAMEGPU_AGENT_FUNCTION(MooreWTestXYC, MsgArray2D, MsgNone) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
+    const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
+    // Iterate message list counting how many messages were read.
+    unsigned int count = 0;
+    for (const auto &message : FLAMEGPU->message_in.wrap(x, y, COMRADIUS)) {
+        // @todo - check its the correct messages?
+        count++;
+    }
+    FLAMEGPU->setVariable<unsigned int>("message_read", count);
+    return ALIVE;
+}
+
+void test_mooorew_comradius(
+    const unsigned int GRID_WIDTH,
+    const unsigned int GRID_HEIGHT,
+    const unsigned int COMRADIUS
+    ) {
+    // Calc the population
+    const unsigned int agentCount = GRID_WIDTH * GRID_HEIGHT;
+
+    // Define the model
+    ModelDescription model("MooreXRC");
+
+    // Use an env var for the communication radius to use, rather than a __device__ or a #define.
+    EnvironmentDescription &env = model.Environment();
+    env.newProperty<unsigned int>("COMRADIUS", COMRADIUS);
+
+    // Define the message
+    MsgArray2D::Description &message = model.newMessage<MsgArray2D>(MESSAGE_NAME);
+    message.newVariable<unsigned int>("index");
+    message.setDimensions(GRID_WIDTH, GRID_HEIGHT);
+    AgentDescription &agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<unsigned int>("index");
+    agent.newVariable<unsigned int>("x");
+    agent.newVariable<unsigned int>("y");
+    agent.newVariable<unsigned int>("message_read", UINT_MAX);
+    // Define the function and layers.
+    AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleXY", OutSimpleXY);
+    outputFunction.setMessageOutput(message);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWTestXYC", MooreWTestXYC);
+    inputFunction.setMessageInput(message);
+    model.newLayer().addAgentFunction(outputFunction);
+    LayerDescription &li = model.newLayer();
+    li.addAgentFunction(inputFunction);
+    // Assign the numbers in shuffled order to agents
+    AgentVector population(agent, agentCount);
+    for (unsigned int x = 0; x < GRID_WIDTH; x++) {
+        for (unsigned int y = 0; y < GRID_HEIGHT; y++) {
+            unsigned int idx = (x * GRID_HEIGHT) + y;
+            AgentVector::Agent instance = population[idx];
+            instance.setVariable<unsigned int>("index", idx);
+            instance.setVariable<unsigned int>("x", x);
+            instance.setVariable<unsigned int>("y", y);
+            instance.setVariable<unsigned int>("message_read", UINT_MAX);
+        }
+    }
+    // Set pop in model
+    CUDASimulation simulation(model);
+    simulation.setPopulationData(population);
+
+    if ((COMRADIUS * 2) + 1 <= GRID_WIDTH &&
+        (COMRADIUS * 2) + 1 <= GRID_HEIGHT) {
+        simulation.step();
+        simulation.getPopulationData(population);
+        // Validate each agent has read correct messages
+
+        // Calc the expected number of messages. This depoends on comm radius for wrapped moore neighbourhood
+        const unsigned int expected_count = static_cast<unsigned int>(pow((COMRADIUS * 2) + 1, 2)) - 1;
+
+        for (AgentVector::Agent instance : population) {
+            const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
+            ASSERT_EQ(expected_count, message_read);
+        }
+    } else {
+        // If the comradius would lead to double message reads, a device error is thrown when SEATBELTS is enabled
+        // Behaviour is otherwise undefined
+#if !defined(SEATBELTS) || SEATBELTS
+        EXPECT_THROW(simulation.step(), flamegpu::exception::DeviceError);
+#endif
+    }
+}
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array2D, MooreWX1Y1R1) {
+    test_mooorew_comradius(1, 1, 1);
+}
+TEST(TestMessage_Array2D, MooreWX2Y2R1) {
+    test_mooorew_comradius(2, 2, 1);
+}
+TEST(TestMessage_Array2D, MooreWX3Y3R1) {
+    test_mooorew_comradius(3, 3, 1);
+}
+TEST(TestMessage_Array2D, MooreWX4Y4R1) {
+    test_mooorew_comradius(4, 4, 1);
+}
+TEST(TestMessage_Array2D, MooreWX2Y1R1) {
+    test_mooorew_comradius(2, 1, 1);
+}
+TEST(TestMessage_Array2D, MooreWX3Y1R1) {
+    test_mooorew_comradius(3, 1, 1);
+}
+TEST(TestMessage_Array2D, MooreWX4Y1R1) {
+    test_mooorew_comradius(4, 1, 1);
+}
+
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array2D, MooreWX1Y1R2) {
+    test_mooorew_comradius(1, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreWX2Y2R2) {
+    test_mooorew_comradius(2, 2, 2);
+}
+TEST(TestMessage_Array2D, MooreWX3Y3R2) {
+    test_mooorew_comradius(3, 3, 2);
+}
+TEST(TestMessage_Array2D, MooreWX4Y4R2) {
+    test_mooorew_comradius(4, 4, 2);
+}
+TEST(TestMessage_Array2D, MooreWX5Y5R2) {
+    test_mooorew_comradius(5, 5, 2);
+}
+TEST(TestMessage_Array2D, MooreWX6Y6R2) {
+    test_mooorew_comradius(6, 6, 2);
+}
+TEST(TestMessage_Array2D, MooreWX2Y1R2) {
+    test_mooorew_comradius(2, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreWX3Y1R2) {
+    test_mooorew_comradius(3, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreWX4Y1R2) {
+    test_mooorew_comradius(4, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreWX5Y1R2) {
+    test_mooorew_comradius(5, 1, 2);
+}
+TEST(TestMessage_Array2D, MooreWX6Y1R2) {
+    test_mooorew_comradius(6, 1, 2);
+}
+
 FLAMEGPU_AGENT_FUNCTION(MooreTestXYC, MsgArray2D, MsgNone) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -451,11 +874,6 @@ void test_mooore_comradius(
     ) {
     // Calc the population
     const unsigned int agentCount = GRID_WIDTH * GRID_HEIGHT;
-    // Some debug logging. @todo
-    /* printf("GRID_WIDTH %u\n", GRID_WIDTH);
-    printf("GRID_HEIGHT %u\n", GRID_HEIGHT);
-    printf("COMRADIUS %u\n", COMRADIUS);
-    printf("agentCount %u\n", agentCount); */
 
     // Define the model
     ModelDescription model("MooreXRC");
@@ -498,35 +916,22 @@ void test_mooore_comradius(
     simulation.setPopulationData(population);
     simulation.step();
     simulation.getPopulationData(population);
-    // Validate each agent has read correct messages
-    // Calc the expected number of messages. This depoends on the env dims and the comm radius.
-    // Radius 0 is not supported, and currently the centre cell is not returned for other radii (so usually -1).
-    // If one of the environemnt dimensions is too small, < 2 * radius + 1, then either fewer messages should be read, or messages will be re-read.
-    // In this case, the centre cell may / is currently also read.
-
-    // const unsigned int nowrapExpectedCount = pow((2 * COMRADIUS) + 1, 2) - 1;
-    // If any dim is less than 2 * rad + 1, then there are fewere unique messages to be read, and the center will be re-read.
-    const bool xFewerReads = (2 * COMRADIUS) + 1 > GRID_WIDTH;
-    const bool yFewerReads = (2 * COMRADIUS) + 1 > GRID_HEIGHT;
-    const unsigned int xReadRange = !xFewerReads ? (2 * COMRADIUS) + 1 : GRID_WIDTH;
-    const unsigned int yReadRange = !yFewerReads ? (2 * COMRADIUS) + 1 : GRID_HEIGHT;
-    // @todo - verify if the self message should ever be returned, even when wrapped. Can always -1 if it should never be read.
-    const unsigned int selfRead = xFewerReads || yFewerReads ? 0 : 1;
-    const unsigned int expected_count = (xReadRange * yReadRange) - selfRead;
-
-    /*
-    // @todo 
-    printf("xFewerReads %d\n", xFewerReads);
-    printf("yFewerReads %d\n", yFewerReads);
-    printf("xReadRange %u\n", xReadRange);
-    printf("yReadRange %u\n", yReadRange);
-    printf("selfRead %u\n", selfRead);
-    printf("expected_count %u\n", expected_count); */
-
+    unsigned int right_count = 0;
+    // Validate each agent has read correct number of messages
     for (AgentVector::Agent instance : population) {
+        const unsigned int x = instance.getVariable<unsigned int>("x");
+        const unsigned int y = instance.getVariable<unsigned int>("y");
         const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
-        ASSERT_EQ(expected_count, message_read);
+
+        unsigned int expected_read = 1;
+        expected_read *= (std::min<int>(static_cast<int>(x + COMRADIUS), static_cast<int>(GRID_WIDTH) - 1) - std::max<int>(static_cast<int>(x) - static_cast<int>(COMRADIUS), 0) + 1);
+        expected_read *= (std::min<int>(static_cast<int>(y + COMRADIUS), static_cast<int>(GRID_HEIGHT) - 1) - std::max<int>(static_cast<int>(y) - static_cast<int>(COMRADIUS), 0) + 1);
+        expected_read--;
+        // ASSERT_EQ(message_read, expected_read);
+        if (message_read == expected_read)
+            right_count++;
     }
+    ASSERT_EQ(right_count, population.size());
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -790,65 +790,35 @@ void test_moore_wrap_comradius(
 #endif
     }
 }
-// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array2D, MooreWrapX1Y1R1) {
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with wrapping
+TEST(TestMessage_Array2D, MooreWrapR1) {
     test_moore_wrap_comradius(1, 1, 1);
-}
-TEST(TestMessage_Array2D, MooreWrapX2Y2R1) {
     test_moore_wrap_comradius(2, 2, 1);
-}
-TEST(TestMessage_Array2D, MooreWrapX3Y3R1) {
     test_moore_wrap_comradius(3, 3, 1);
-}
-TEST(TestMessage_Array2D, MooreWrapX4Y4R1) {
     test_moore_wrap_comradius(4, 4, 1);
 }
-TEST(TestMessage_Array2D, MooreWrapX2Y1R1) {
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with wrapping and non-uniform dimensions
+TEST(TestMessage_Array2D, MooreWrapR1NonUniform) {
     test_moore_wrap_comradius(2, 1, 1);
-}
-TEST(TestMessage_Array2D, MooreWrapX3Y1R1) {
     test_moore_wrap_comradius(3, 1, 1);
-}
-TEST(TestMessage_Array2D, MooreWrapX4Y1R1) {
     test_moore_wrap_comradius(4, 1, 1);
 }
 
-// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array2D, MooreWrapX1Y1R2) {
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case, with wrapping
+TEST(TestMessage_Array2D, MooreWrapR2) {
     test_moore_wrap_comradius(1, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX2Y2R2) {
     test_moore_wrap_comradius(2, 2, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX3Y3R2) {
     test_moore_wrap_comradius(3, 3, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX4Y4R2) {
     test_moore_wrap_comradius(4, 4, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX5Y5R2) {
     test_moore_wrap_comradius(5, 5, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX6Y6R2) {
     test_moore_wrap_comradius(6, 6, 2);
 }
-TEST(TestMessage_Array2D, MooreWrapX2Y1R2) {
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case, with wrapping and non-uniform dimensions
+TEST(TestMessage_Array2D, MooreWrapR2NonUniform) {
     test_moore_wrap_comradius(2, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX3Y1R2) {
     test_moore_wrap_comradius(3, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX4Y1R2) {
     test_moore_wrap_comradius(4, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX5Y1R2) {
     test_moore_wrap_comradius(5, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreWrapX6Y1R2) {
     test_moore_wrap_comradius(6, 1, 2);
 }
 
@@ -934,64 +904,34 @@ void test_mooore_comradius(
     ASSERT_EQ(right_count, population.size());
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array2D, MooreX1Y1R1) {
+TEST(TestMessage_Array2D, MooreR1) {
     test_mooore_comradius(1, 1, 1);
-}
-TEST(TestMessage_Array2D, MooreX2Y2R1) {
     test_mooore_comradius(2, 2, 1);
-}
-TEST(TestMessage_Array2D, MooreX3Y3R1) {
     test_mooore_comradius(3, 3, 1);
-}
-TEST(TestMessage_Array2D, MooreX4Y4R1) {
     test_mooore_comradius(4, 4, 1);
 }
-TEST(TestMessage_Array2D, MooreX2Y1R1) {
+// Test a range of environment sizes for comradius of 1, with non-uniform dimensions
+TEST(TestMessage_Array2D, MooreR1NonUnifiorm) {
     test_mooore_comradius(2, 1, 1);
-}
-TEST(TestMessage_Array2D, MooreX3Y1R1) {
     test_mooore_comradius(3, 1, 1);
-}
-TEST(TestMessage_Array2D, MooreX4Y1R1) {
     test_mooore_comradius(4, 1, 1);
 }
 
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array2D, MooreX1Y1R2) {
+TEST(TestMessage_Array2D, MooreR2) {
     test_mooore_comradius(1, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreX2Y2R2) {
     test_mooore_comradius(2, 2, 2);
-}
-TEST(TestMessage_Array2D, MooreX3Y3R2) {
     test_mooore_comradius(3, 3, 2);
-}
-TEST(TestMessage_Array2D, MooreX4Y4R2) {
     test_mooore_comradius(4, 4, 2);
-}
-TEST(TestMessage_Array2D, MooreX5Y5R2) {
     test_mooore_comradius(5, 5, 2);
-}
-TEST(TestMessage_Array2D, MooreX6Y6R2) {
     test_mooore_comradius(6, 6, 2);
 }
-TEST(TestMessage_Array2D, MooreX2Y1R2) {
+// Test a range of environment sizes for comradius of 2, with non uniform dimensions
+TEST(TestMessage_Array2D, MooreR2NonUniform) {
     test_mooore_comradius(2, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreX3Y1R2) {
     test_mooore_comradius(3, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreX4Y1R2) {
     test_mooore_comradius(4, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreX5Y1R2) {
     test_mooore_comradius(5, 1, 2);
-}
-TEST(TestMessage_Array2D, MooreX6Y1R2) {
     test_mooore_comradius(6, 1, 2);
 }
 

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -292,7 +292,7 @@ TEST(TestMessage_Array3D, Moore1) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(27u, message_read);
+        EXPECT_EQ(27u, message_read);  // @todo This actually should be 26?
     }
 }
 TEST(TestMessage_Array3D, Moore2) {
@@ -325,7 +325,7 @@ TEST(TestMessage_Array3D, Moore2) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(125u, message_read);
+        EXPECT_EQ(125u, message_read);  // @todo - 124?
     }
 }
 
@@ -429,6 +429,218 @@ TEST(TestMessage_Array3D, ReadEmpty) {
     EXPECT_EQ(pop_out.size(), 1u);
     auto ai = pop_out[0];
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
+}
+
+/*
+ * Test for fixed size grids with various com radii to check edge cases + expected cases.
+ * 3x3x3 issue highlighted by see https://github.com/FLAMEGPU/FLAMEGPU2/issues/547
+ */
+FLAMEGPU_AGENT_FUNCTION(OutSimpleXYZ, MsgNone, MsgArray3D) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int>("z");
+    FLAMEGPU->message_out.setVariable("index", index);
+    FLAMEGPU->message_out.setIndex(x, y, z);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(MooreTestXYZC, MsgArray3D, MsgNone) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int>("z");
+    const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
+    // Iterate message list counting how many messages were read.
+    unsigned int count = 0;
+    for (const auto &message : FLAMEGPU->message_in(x, y, z, COMRADIUS)) {
+        // @todo - check its the correct messages?
+        /* if(index == 0){
+            printf("message from %u: %u %u %u\n", message.getVariable<unsigned int>("index"), message.getX(), message.getY(), message.getZ());
+        } */
+        count++;
+    }
+    FLAMEGPU->setVariable<unsigned int>("message_read", count);
+    return ALIVE;
+}
+
+void test_mooore_comradius(
+    const unsigned int GRID_WIDTH,
+    const unsigned int GRID_HEIGHT,
+    const unsigned int GRID_DEPTH,
+    const unsigned int COMRADIUS
+    ) {
+    // Calc the population
+    const unsigned int agentCount =  GRID_WIDTH * GRID_HEIGHT * GRID_DEPTH;
+    // Some debug logging. @todo
+    /* printf("GRID_WIDTH %u\n", GRID_WIDTH);
+    printf("GRID_HEIGHT %u\n", GRID_HEIGHT);
+    printf("GRID_DEPTH %u\n", GRID_DEPTH);
+    printf("COMRADIUS %u\n", COMRADIUS);
+    printf("agentCount %u\n", agentCount); */
+
+    // Define the model
+    ModelDescription model("MooreXYZC");
+
+    // Use an env var for the communication radius to use, rather than a __device__ or a #define.
+    EnvironmentDescription &env = model.Environment();
+    env.newProperty<unsigned int>("COMRADIUS", COMRADIUS);
+
+    // Define the message
+    MsgArray3D::Description &message = model.newMessage<MsgArray3D>(MESSAGE_NAME);
+    message.newVariable<unsigned int>("index");
+    message.setDimensions(GRID_WIDTH, GRID_HEIGHT, GRID_DEPTH);
+    AgentDescription &agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<unsigned int>("index");
+    agent.newVariable<unsigned int>("x");
+    agent.newVariable<unsigned int>("y");
+    agent.newVariable<unsigned int>("z");
+    agent.newVariable<unsigned int>("message_read", UINT_MAX);
+    // Define the function and layers.
+    AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleXYZ", OutSimpleXYZ);
+    outputFunction.setMessageOutput(message);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreTestXYZC", MooreTestXYZC);
+    inputFunction.setMessageInput(message);
+    model.newLayer().addAgentFunction(outputFunction);
+    LayerDescription &li = model.newLayer();
+    li.addAgentFunction(inputFunction);
+    // Assign the numbers in shuffled order to agents
+    AgentVector population(agent, agentCount);
+    for (unsigned int x = 0; x < GRID_WIDTH; x++) {
+        for (unsigned int y = 0; y < GRID_HEIGHT; y++) {
+            for (unsigned int z = 0; z < GRID_DEPTH; z++) {
+                unsigned int idx = (x * GRID_HEIGHT * GRID_DEPTH) + (y * GRID_DEPTH) + z;
+                AgentVector::Agent instance = population[idx];
+                instance.setVariable<unsigned int>("index", idx);
+                instance.setVariable<unsigned int>("x", x);
+                instance.setVariable<unsigned int>("y", y);
+                instance.setVariable<unsigned int>("z", z);
+                instance.setVariable<unsigned int>("message_read", UINT_MAX);
+            }
+        }
+    }
+    // Set pop in model
+    CUDASimulation simulation(model);
+    simulation.setPopulationData(population);
+    simulation.step();
+    simulation.getPopulationData(population);
+    // Validate each agent has read correct messages
+
+    // Calc the expected number of messages. This depoends on the env dims and the comm radius.
+    // Radius 0 is not supported, and currently the centre cell is not returned for other radii (so usually -1).
+    // If one of the environemnt dimensions is too small, < 2 * radius + 1, then either fewer messages should be read, or messages will be re-read.
+    // In this case, the centre cell may / is currently also read.
+
+    // const unsigned int nowrapExpectedCount = pow((2 * COMRADIUS) + 1, 3) - 1;
+    // If any dim is less than 2 * rad + 1, then there are fewere unique messages to be read, and the center will be re-read.
+    const bool xFewerReads = (2 * COMRADIUS) + 1 > GRID_WIDTH;
+    const bool yFewerReads = (2 * COMRADIUS) + 1 > GRID_HEIGHT;
+    const bool zFewerReads = (2 * COMRADIUS) + 1 > GRID_DEPTH;
+    const unsigned int xReadRange = !xFewerReads ? (2 * COMRADIUS) + 1 : GRID_WIDTH;
+    const unsigned int yReadRange = !yFewerReads ? (2 * COMRADIUS) + 1 : GRID_HEIGHT;
+    const unsigned int zReadRange = !zFewerReads ? (2 * COMRADIUS) + 1 : GRID_DEPTH;
+    // @todo - verify if the self message should ever be returned, even when wrapped. Can always -1 if it should never be read.
+    const unsigned int selfRead = xFewerReads || yFewerReads || zFewerReads ? 0 : 1;
+    const unsigned int expected_count = (xReadRange * yReadRange * zReadRange) - selfRead;
+
+    /*
+    // @todo 
+    printf("xFewerReads %d\n", xFewerReads);
+    printf("yFewerReads %d\n", yFewerReads);
+    printf("zFewerReads %d\n", zFewerReads);
+    printf("xReadRange %u\n", xReadRange);
+    printf("yReadRange %u\n", yReadRange);
+    printf("zReadRange %u\n", zReadRange);
+    printf("selfRead %u\n", selfRead);
+    printf("expected_count %u\n", expected_count); */
+
+    for (AgentVector::Agent instance : population) {
+        const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
+        ASSERT_EQ(expected_count, message_read);
+    }
+}
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array3D, MooreX1Y1Z1R1) {
+    test_mooore_comradius(1, 1, 1, 1);
+}
+TEST(TestMessage_Array3D, MooreX2Y2Z2R1) {
+    test_mooore_comradius(2, 2, 2, 1);
+}
+TEST(TestMessage_Array3D, MooreX3Y3Z3R1) {
+    test_mooore_comradius(3, 3, 3, 1);
+}
+TEST(TestMessage_Array3D, MooreX4Y4Z4R1) {
+    test_mooore_comradius(4, 4, 4, 1);
+}
+TEST(TestMessage_Array3D, MooreX2Y2Z1R1) {
+    test_mooore_comradius(2, 2, 1, 1);
+}
+TEST(TestMessage_Array3D, MooreX3Y3Z1R1) {
+    test_mooore_comradius(3, 3, 1, 1);
+}
+TEST(TestMessage_Array3D, MooreX4Y4Z1R1) {
+    test_mooore_comradius(4, 4, 1, 1);
+}
+TEST(TestMessage_Array3D, MooreX2Y1Z1R1) {
+    test_mooore_comradius(2, 1, 1, 1);
+}
+TEST(TestMessage_Array3D, MooreX3Y1Z1R1) {
+    test_mooore_comradius(3, 1, 1, 1);
+}
+TEST(TestMessage_Array3D, MooreX4Y1Z1R1) {
+    test_mooore_comradius(4, 1, 1, 1);
+}
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array3D, MooreXX1Y1Z1R2) {
+    test_mooore_comradius(1, 1, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX2Y2Z2R2) {
+    test_mooore_comradius(2, 2, 2, 2);
+}
+TEST(TestMessage_Array3D, MooreXX3Y3Z3R2) {
+    test_mooore_comradius(3, 3, 3, 2);
+}
+TEST(TestMessage_Array3D, MooreXX4Y4Z4R2) {
+    test_mooore_comradius(4, 4, 4, 2);
+}
+TEST(TestMessage_Array3D, MooreXX5Y5Z5R2) {
+    test_mooore_comradius(5, 5, 5, 2);
+}
+TEST(TestMessage_Array3D, MooreXX6Y6Z6R2) {
+    test_mooore_comradius(6, 6, 6, 2);
+}
+TEST(TestMessage_Array3D, MooreXX2Y2Z1R2) {
+    test_mooore_comradius(2, 2, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX3Y3Z1R2) {
+    test_mooore_comradius(3, 3, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX4Y4Z1R2) {
+    test_mooore_comradius(4, 4, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX5Y5Z1R2) {
+    test_mooore_comradius(5, 5, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX6Y6Z1R2) {
+    test_mooore_comradius(6, 6, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX2Y1Z1R2) {
+    test_mooore_comradius(2, 1, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX3Y1Z1R2) {
+    test_mooore_comradius(3, 1, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX4Y1Z1R2) {
+    test_mooore_comradius(4, 1, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX5Y1Z1R2) {
+    test_mooore_comradius(5, 1, 1, 2);
+}
+TEST(TestMessage_Array3D, MooreXX6Y1Z1R2) {
+    test_mooore_comradius(6, 1, 1, 2);
 }
 
 }  // namespace test_message_array_3d

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -427,15 +427,15 @@ TEST(TestMessage_Array3D, ReadEmpty) {
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsX, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapOutOfBoundsX, MsgArray3D, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(dCBRT_AGENT_COUNT, 0, 0)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array3D, MooreW_InitOutOfBoundsX) {
+TEST(TestMessage_Array3D, MooreWrap_InitOutOfBoundsX) {
 #else
-TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsX) {
+TEST(TestMessage_Array3D, DISABLED_MooreWrap_InitOutOfBoundsX) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
@@ -447,7 +447,7 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsX) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsX);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapOutOfBoundsX);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -467,15 +467,15 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsX) {
     EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsY, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapOutOfBoundsY, MsgArray3D, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(0, dCBRT_AGENT_COUNT + 1, 0)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array3D, MooreW_InitOutOfBoundsY) {
+TEST(TestMessage_Array3D, MooreWrap_InitOutOfBoundsY) {
 #else
-TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsY) {
+TEST(TestMessage_Array3D, DISABLED_MooreWrap_InitOutOfBoundsY) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
@@ -487,7 +487,7 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsY) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsY);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapOutOfBoundsY);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -507,15 +507,15 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsY) {
     EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsZ, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapOutOfBoundsZ, MsgArray3D, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(0, 0, dCBRT_AGENT_COUNT + 2)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array3D, MooreW_InitOutOfBoundsZ) {
+TEST(TestMessage_Array3D, MooreWrap_InitOutOfBoundsZ) {
 #else
-TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsZ) {
+TEST(TestMessage_Array3D, DISABLED_MooreWrap_InitOutOfBoundsZ) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
@@ -527,7 +527,7 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsZ) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsZ);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapOutOfBoundsZ);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -547,15 +547,15 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_InitOutOfBoundsZ) {
     EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius1, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapBadRadius1, MsgArray3D, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(0, 0, 0, 0)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array3D, MooreW_BadRadius1) {
+TEST(TestMessage_Array3D, MooreWrap_BadRadius1) {
 #else
-TEST(TestMessage_Array3D, DISABLED_MooreW_BadRadius1) {
+TEST(TestMessage_Array3D, DISABLED_MooreWrap_BadRadius1) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
@@ -567,7 +567,7 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_BadRadius1) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius1);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapBadRadius1);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -587,15 +587,15 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_BadRadius1) {
     EXPECT_THROW(c.step(), flamegpu::exception::DeviceError);
 }
 #if !defined(SEATBELTS) || SEATBELTS
-FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius2, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(InMooreWrapBadRadius2, MsgArray3D, MsgNone) {
     for (auto a : FLAMEGPU->message_in.wrap(0, 0, 0, 3)) {
         FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
     }
     return ALIVE;
 }
-TEST(TestMessage_Array3D, MooreW_BadRadius2) {
+TEST(TestMessage_Array3D, MooreWrap_BadRadius2) {
 #else
-TEST(TestMessage_Array3D, DISABLED_MooreW_BadRadius2) {
+TEST(TestMessage_Array3D, DISABLED_MooreWrap_BadRadius2) {
 #endif
     ModelDescription m(MODEL_NAME);
     MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
@@ -607,7 +607,7 @@ TEST(TestMessage_Array3D, DISABLED_MooreW_BadRadius2) {
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius2);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWrapBadRadius2);
     fi.setMessageInput(msg);
     LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -801,7 +801,7 @@ FLAMEGPU_AGENT_FUNCTION(OutSimpleXYZ, MsgNone, MsgArray3D) {
     FLAMEGPU->message_out.setIndex(x, y, z);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreWTestXYZC, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreWrapTestXYZC, MsgArray3D, MsgNone) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
     const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
@@ -817,7 +817,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreWTestXYZC, MsgArray3D, MsgNone) {
     return ALIVE;
 }
 
-void test_mooorew_comradius(
+void test_moore_wrapped_comradius(
     const unsigned int GRID_WIDTH,
     const unsigned int GRID_HEIGHT,
     const unsigned int GRID_DEPTH,
@@ -846,7 +846,7 @@ void test_mooorew_comradius(
     // Define the function and layers.
     AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleXYZ", OutSimpleXYZ);
     outputFunction.setMessageOutput(message);
-    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWTestXYZC", MooreWTestXYZC);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWrapTestXYZC", MooreWrapTestXYZC);
     inputFunction.setMessageInput(message);
     model.newLayer().addAgentFunction(outputFunction);
     LayerDescription &li = model.newLayer();
@@ -895,86 +895,86 @@ void test_mooorew_comradius(
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreWX1Y1Z1R1) {
-    test_mooorew_comradius(1, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX1Y1Z1R1) {
+    test_moore_wrapped_comradius(1, 1, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreWX2Y2Z2R1) {
-    test_mooorew_comradius(2, 2, 2, 1);
+TEST(TestMessage_Array3D, MooreWrapX2Y2Z2R1) {
+    test_moore_wrapped_comradius(2, 2, 2, 1);
 }
-TEST(TestMessage_Array3D, MooreWX3Y3Z3R1) {
-    test_mooorew_comradius(3, 3, 3, 1);
+TEST(TestMessage_Array3D, MooreWrapX3Y3Z3R1) {
+    test_moore_wrapped_comradius(3, 3, 3, 1);
 }
-TEST(TestMessage_Array3D, MooreWX4Y4Z4R1) {
-    test_mooorew_comradius(4, 4, 4, 1);
+TEST(TestMessage_Array3D, MooreWrapX4Y4Z4R1) {
+    test_moore_wrapped_comradius(4, 4, 4, 1);
 }
-TEST(TestMessage_Array3D, MooreWX2Y2Z1R1) {
-    test_mooorew_comradius(2, 2, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX2Y2Z1R1) {
+    test_moore_wrapped_comradius(2, 2, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreWX3Y3Z1R1) {
-    test_mooorew_comradius(3, 3, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX3Y3Z1R1) {
+    test_moore_wrapped_comradius(3, 3, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreWX4Y4Z1R1) {
-    test_mooorew_comradius(4, 4, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX4Y4Z1R1) {
+    test_moore_wrapped_comradius(4, 4, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreWX2Y1Z1R1) {
-    test_mooorew_comradius(2, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX2Y1Z1R1) {
+    test_moore_wrapped_comradius(2, 1, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreWX3Y1Z1R1) {
-    test_mooorew_comradius(3, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX3Y1Z1R1) {
+    test_moore_wrapped_comradius(3, 1, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreWX4Y1Z1R1) {
-    test_mooorew_comradius(4, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWrapX4Y1Z1R1) {
+    test_moore_wrapped_comradius(4, 1, 1, 1);
 }
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreWXX1Y1Z1R2) {
-    test_mooorew_comradius(1, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX1Y1Z1R2) {
+    test_moore_wrapped_comradius(1, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX2Y2Z2R2) {
-    test_mooorew_comradius(2, 2, 2, 2);
+TEST(TestMessage_Array3D, MooreWrapX2Y2Z2R2) {
+    test_moore_wrapped_comradius(2, 2, 2, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX3Y3Z3R2) {
-    test_mooorew_comradius(3, 3, 3, 2);
+TEST(TestMessage_Array3D, MooreWrapX3Y3Z3R2) {
+    test_moore_wrapped_comradius(3, 3, 3, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX4Y4Z4R2) {
-    test_mooorew_comradius(4, 4, 4, 2);
+TEST(TestMessage_Array3D, MooreWrapX4Y4Z4R2) {
+    test_moore_wrapped_comradius(4, 4, 4, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX5Y5Z5R2) {
-    test_mooorew_comradius(5, 5, 5, 2);
+TEST(TestMessage_Array3D, MooreWrapX5Y5Z5R2) {
+    test_moore_wrapped_comradius(5, 5, 5, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX6Y6Z6R2) {
-    test_mooorew_comradius(6, 6, 6, 2);
+TEST(TestMessage_Array3D, MooreWrapX6Y6Z6R2) {
+    test_moore_wrapped_comradius(6, 6, 6, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX2Y2Z1R2) {
-    test_mooorew_comradius(2, 2, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX2Y2Z1R2) {
+    test_moore_wrapped_comradius(2, 2, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX3Y3Z1R2) {
-    test_mooorew_comradius(3, 3, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX3Y3Z1R2) {
+    test_moore_wrapped_comradius(3, 3, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX4Y4Z1R2) {
-    test_mooorew_comradius(4, 4, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX4Y4Z1R2) {
+    test_moore_wrapped_comradius(4, 4, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX5Y5Z1R2) {
-    test_mooorew_comradius(5, 5, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX5Y5Z1R2) {
+    test_moore_wrapped_comradius(5, 5, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX6Y6Z1R2) {
-    test_mooorew_comradius(6, 6, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX6Y6Z1R2) {
+    test_moore_wrapped_comradius(6, 6, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX2Y1Z1R2) {
-    test_mooorew_comradius(2, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX2Y1Z1R2) {
+    test_moore_wrapped_comradius(2, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX3Y1Z1R2) {
-    test_mooorew_comradius(3, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX3Y1Z1R2) {
+    test_moore_wrapped_comradius(3, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX4Y1Z1R2) {
-    test_mooorew_comradius(4, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX4Y1Z1R2) {
+    test_moore_wrapped_comradius(4, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX5Y1Z1R2) {
-    test_mooorew_comradius(5, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX5Y1Z1R2) {
+    test_moore_wrapped_comradius(5, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreWXX6Y1Z1R2) {
-    test_mooorew_comradius(6, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWrapX6Y1Z1R2) {
+    test_moore_wrapped_comradius(6, 1, 1, 2);
 }
 
 FLAMEGPU_AGENT_FUNCTION(MooreTestXYZC, MsgArray3D, MsgNone) {
@@ -1101,52 +1101,52 @@ TEST(TestMessage_Array3D, MooreX4Y1Z1R1) {
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreXX1Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreX1Y1Z1R2) {
     test_mooore_comradius(1, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX2Y2Z2R2) {
+TEST(TestMessage_Array3D, MooreX2Y2Z2R2) {
     test_mooore_comradius(2, 2, 2, 2);
 }
-TEST(TestMessage_Array3D, MooreXX3Y3Z3R2) {
+TEST(TestMessage_Array3D, MooreX3Y3Z3R2) {
     test_mooore_comradius(3, 3, 3, 2);
 }
-TEST(TestMessage_Array3D, MooreXX4Y4Z4R2) {
+TEST(TestMessage_Array3D, MooreX4Y4Z4R2) {
     test_mooore_comradius(4, 4, 4, 2);
 }
-TEST(TestMessage_Array3D, MooreXX5Y5Z5R2) {
+TEST(TestMessage_Array3D, MooreX5Y5Z5R2) {
     test_mooore_comradius(5, 5, 5, 2);
 }
-TEST(TestMessage_Array3D, MooreXX6Y6Z6R2) {
+TEST(TestMessage_Array3D, MooreX6Y6Z6R2) {
     test_mooore_comradius(6, 6, 6, 2);
 }
-TEST(TestMessage_Array3D, MooreXX2Y2Z1R2) {
+TEST(TestMessage_Array3D, MooreX2Y2Z1R2) {
     test_mooore_comradius(2, 2, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX3Y3Z1R2) {
+TEST(TestMessage_Array3D, MooreX3Y3Z1R2) {
     test_mooore_comradius(3, 3, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX4Y4Z1R2) {
+TEST(TestMessage_Array3D, MooreX4Y4Z1R2) {
     test_mooore_comradius(4, 4, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX5Y5Z1R2) {
+TEST(TestMessage_Array3D, MooreX5Y5Z1R2) {
     test_mooore_comradius(5, 5, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX6Y6Z1R2) {
+TEST(TestMessage_Array3D, MooreX6Y6Z1R2) {
     test_mooore_comradius(6, 6, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX2Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreX2Y1Z1R2) {
     test_mooore_comradius(2, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX3Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreX3Y1Z1R2) {
     test_mooore_comradius(3, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX4Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreX4Y1Z1R2) {
     test_mooore_comradius(4, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX5Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreX5Y1Z1R2) {
     test_mooore_comradius(5, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX6Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreX6Y1Z1R2) {
     test_mooore_comradius(6, 1, 1, 2);
 }
 

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -892,88 +892,42 @@ void test_moore_wrapped_comradius(
 #endif
     }
 }
-// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreWrapX1Y1Z1R1) {
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with wrapping
+TEST(TestMessage_Array3D, MooreWrapR1) {
     test_moore_wrapped_comradius(1, 1, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX2Y2Z2R1) {
     test_moore_wrapped_comradius(2, 2, 2, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX3Y3Z3R1) {
     test_moore_wrapped_comradius(3, 3, 3, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX4Y4Z4R1) {
     test_moore_wrapped_comradius(4, 4, 4, 1);
 }
-TEST(TestMessage_Array3D, MooreWrapX2Y2Z1R1) {
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with wrapping and non uniform dimensions
+TEST(TestMessage_Array3D, MooreWrapR1NonUniform) {
     test_moore_wrapped_comradius(2, 2, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX3Y3Z1R1) {
     test_moore_wrapped_comradius(3, 3, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX4Y4Z1R1) {
     test_moore_wrapped_comradius(4, 4, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX2Y1Z1R1) {
     test_moore_wrapped_comradius(2, 1, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX3Y1Z1R1) {
     test_moore_wrapped_comradius(3, 1, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreWrapX4Y1Z1R1) {
     test_moore_wrapped_comradius(4, 1, 1, 1);
 }
-// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreWrapX1Y1Z1R2) {
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case, with wrapping
+TEST(TestMessage_Array3D, MooreWrapR2) {
     test_moore_wrapped_comradius(1, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX2Y2Z2R2) {
     test_moore_wrapped_comradius(2, 2, 2, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX3Y3Z3R2) {
     test_moore_wrapped_comradius(3, 3, 3, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX4Y4Z4R2) {
     test_moore_wrapped_comradius(4, 4, 4, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX5Y5Z5R2) {
     test_moore_wrapped_comradius(5, 5, 5, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX6Y6Z6R2) {
     test_moore_wrapped_comradius(6, 6, 6, 2);
 }
-TEST(TestMessage_Array3D, MooreWrapX2Y2Z1R2) {
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case, with wrapping and non-uniform dimensions
+TEST(TestMessage_Array3D, MooreWrapR2NonUniform) {
     test_moore_wrapped_comradius(2, 2, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX3Y3Z1R2) {
     test_moore_wrapped_comradius(3, 3, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX4Y4Z1R2) {
     test_moore_wrapped_comradius(4, 4, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX5Y5Z1R2) {
     test_moore_wrapped_comradius(5, 5, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX6Y6Z1R2) {
     test_moore_wrapped_comradius(6, 6, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX2Y1Z1R2) {
     test_moore_wrapped_comradius(2, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX3Y1Z1R2) {
     test_moore_wrapped_comradius(3, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX4Y1Z1R2) {
     test_moore_wrapped_comradius(4, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX5Y1Z1R2) {
     test_moore_wrapped_comradius(5, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreWrapX6Y1Z1R2) {
     test_moore_wrapped_comradius(6, 1, 1, 2);
 }
 
@@ -1066,87 +1020,41 @@ void test_mooore_comradius(
     ASSERT_EQ(right_count, population.size());
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreX1Y1Z1R1) {
+TEST(TestMessage_Array3D, MooreR1) {
     test_mooore_comradius(1, 1, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreX2Y2Z2R1) {
     test_mooore_comradius(2, 2, 2, 1);
-}
-TEST(TestMessage_Array3D, MooreX3Y3Z3R1) {
     test_mooore_comradius(3, 3, 3, 1);
-}
-TEST(TestMessage_Array3D, MooreX4Y4Z4R1) {
     test_mooore_comradius(4, 4, 4, 1);
 }
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with non-uniform dimensions
 TEST(TestMessage_Array3D, MooreX2Y2Z1R1) {
     test_mooore_comradius(2, 2, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreX3Y3Z1R1) {
     test_mooore_comradius(3, 3, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreX4Y4Z1R1) {
     test_mooore_comradius(4, 4, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreX2Y1Z1R1) {
     test_mooore_comradius(2, 1, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreX3Y1Z1R1) {
     test_mooore_comradius(3, 1, 1, 1);
-}
-TEST(TestMessage_Array3D, MooreX4Y1Z1R1) {
     test_mooore_comradius(4, 1, 1, 1);
 }
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
-// Also try non-uniform dimensions.
-// @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreX1Y1Z1R2) {
+TEST(TestMessage_Array3D, MooreR2) {
     test_mooore_comradius(1, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX2Y2Z2R2) {
     test_mooore_comradius(2, 2, 2, 2);
-}
-TEST(TestMessage_Array3D, MooreX3Y3Z3R2) {
     test_mooore_comradius(3, 3, 3, 2);
-}
-TEST(TestMessage_Array3D, MooreX4Y4Z4R2) {
     test_mooore_comradius(4, 4, 4, 2);
-}
-TEST(TestMessage_Array3D, MooreX5Y5Z5R2) {
     test_mooore_comradius(5, 5, 5, 2);
-}
-TEST(TestMessage_Array3D, MooreX6Y6Z6R2) {
     test_mooore_comradius(6, 6, 6, 2);
 }
-TEST(TestMessage_Array3D, MooreX2Y2Z1R2) {
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case, with non-uniform dimensions
+TEST(TestMessage_Array3D, MooreR2NonUniform) {
     test_mooore_comradius(2, 2, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX3Y3Z1R2) {
     test_mooore_comradius(3, 3, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX4Y4Z1R2) {
     test_mooore_comradius(4, 4, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX5Y5Z1R2) {
     test_mooore_comradius(5, 5, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX6Y6Z1R2) {
     test_mooore_comradius(6, 6, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX2Y1Z1R2) {
     test_mooore_comradius(2, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX3Y1Z1R2) {
     test_mooore_comradius(3, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX4Y1Z1R2) {
     test_mooore_comradius(4, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX5Y1Z1R2) {
     test_mooore_comradius(5, 1, 1, 2);
-}
-TEST(TestMessage_Array3D, MooreX6Y1Z1R2) {
     test_mooore_comradius(6, 1, 1, 2);
 }
 

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -226,8 +226,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1W, MsgArray3D, MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
@@ -257,8 +255,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2W, MsgArray3D, MsgNone) {
             }
         }
     }
-    if (msg == filter.end())
-        message_read++;
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
@@ -292,7 +288,7 @@ TEST(TestMessage_Array3D, Moore1W) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(27u, message_read);  // @todo This actually should be 26?
+        EXPECT_EQ(26u, message_read);
     }
 }
 TEST(TestMessage_Array3D, Moore2W) {
@@ -325,7 +321,7 @@ TEST(TestMessage_Array3D, Moore2W) {
     // Validate each agent has read 8 correct messages
     for (AgentVector::Agent ai : pop) {
         const unsigned int message_read = ai.getVariable<unsigned int>("message_read");
-        EXPECT_EQ(125u, message_read);  // @todo - 124?
+        EXPECT_EQ(124u, message_read);
     }
 }
 


### PR DESCRIPTION
Array messages are currently broken for combinations of dimensions and communication radii.

Closes #547, closes #548 and closes #552.

+ [x] Add new tests to detect errors
+ [x] Adjust old tests that `+1` to the number of read messages to expect the correct value
+ [x] Where the bounds are exactly correct for the communication radius (#547)
+ [x] Where the bounds are less than required for the communication radius, leading to reading of more messages than intended (#548)
+ [x] Adds wrapped array messaging (#552)
