### PR TITLE
BugFix: DeviceAgentVector was not available via Python interface.

### DIFF
--- a/include/flamegpu/pop/DeviceAgentVector_impl.h
+++ b/include/flamegpu/pop/DeviceAgentVector_impl.h
@@ -29,6 +29,8 @@ struct NewAgentStorage;
  */
 class DeviceAgentVector_impl : protected AgentVector {
  public:
+    using AgentVector::Agent;
+    using AgentVector::CAgent;
     /**
      * Construct a DeviceAgentVector interface to the on-device data of cuda_agent
      * @param _cuda_agent CUDAAgent instance holding pointers to the desired agent data

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -366,48 +366,48 @@ namespace EnvironmentManager{
 %feature("valuewrapper") DeviceAgentVector;
 %include "flamegpu/runtime/HostAPI.h"
 %include "flamegpu/runtime/HostNewAgentAPI.h"
-%ignore DeviceAgentVector_t; // Not required, internal
-%ignore DeviceAgentVector_t::VariableBufferPair; // Not required, internal
+%ignore DeviceAgentVector_impl::VariableBufferPair; // Not required, internal
 // Disable functions which use C++ iterators/type_index
-%ignore DeviceAgentVector::const_iterator;
-%ignore DeviceAgentVector::const_reverse_iterator;
-%ignore DeviceAgentVector::iterator;
-%ignore DeviceAgentVector::const_iterator;
-%ignore DeviceAgentVector::reverse_iterator;
-%ignore DeviceAgentVector::const_reverse_iterator;
-%ignore DeviceAgentVector::begin;
-%ignore DeviceAgentVector::cbegin;
-%ignore DeviceAgentVector::end;
-%ignore DeviceAgentVector::cend;
-%ignore DeviceAgentVector::rbegin;
-%ignore DeviceAgentVector::crbegin;
-%ignore DeviceAgentVector::rend;
-%ignore DeviceAgentVector::crend;
-%ignore DeviceAgentVector::insert;
-%ignore DeviceAgentVector::erase;
-%ignore DeviceAgentVector::getVariableType;
-%ignore DeviceAgentVector::getVariableMetaData;
-%ignore DeviceAgentVector::data;
-%rename(insert) DeviceAgentVector::py_insert; 
-%rename(erase) DeviceAgentVector::py_erase; 
-// Extend DeviceAgentVector so that it is python iterable
-%extend DeviceAgentVector {
+%ignore DeviceAgentVector_impl::const_iterator;
+%ignore DeviceAgentVector_impl::const_reverse_iterator;
+%ignore DeviceAgentVector_impl::iterator;
+%ignore DeviceAgentVector_impl::const_iterator;
+%ignore DeviceAgentVector_impl::reverse_iterator;
+%ignore DeviceAgentVector_impl::const_reverse_iterator;
+%ignore DeviceAgentVector_impl::begin;
+%ignore DeviceAgentVector_impl::cbegin;
+%ignore DeviceAgentVector_impl::end;
+%ignore DeviceAgentVector_impl::cend;
+%ignore DeviceAgentVector_impl::rbegin;
+%ignore DeviceAgentVector_impl::crbegin;
+%ignore DeviceAgentVector_impl::rend;
+%ignore DeviceAgentVector_impl::crend;
+%ignore DeviceAgentVector_impl::insert;
+%ignore DeviceAgentVector_impl::erase;
+%ignore DeviceAgentVector_impl::getVariableType;
+%ignore DeviceAgentVector_impl::getVariableMetaData;
+%ignore DeviceAgentVector_impl::data;
+%rename(insert) DeviceAgentVector_impl::py_insert; 
+%rename(erase) DeviceAgentVector_impl::py_erase; 
+// Extend DeviceAgentVector_impl so that it is python iterable
+%extend DeviceAgentVector_impl {
 %pythoncode {
     def __iter__(self):
         return FLAMEGPUIterator(self)
     def __len__(self):
         return self.size()
 }
-    DeviceAgentVector::Agent DeviceAgentVector::__getitem__(const int &index) {
+    DeviceAgentVector_impl::Agent DeviceAgentVector_impl::__getitem__(const int &index) {
         if (index >= 0)
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
     }
-    void DeviceAgentVector::__setitem__(const size_type &index, const Agent &value) {
+    void DeviceAgentVector_impl::__setitem__(const size_type &index, const Agent &value) {
         $self->operator[](index).setData(value);
     }
 }
 %include "flamegpu/pop/DeviceAgentVector.h"
+%include "flamegpu/pop/DeviceAgentVector_impl.h"
 
 %include "flamegpu/runtime/HostAgentAPI.h"
 /* Extend HostAgentAPI to add a templated version of the sum function (with differing return type) with a different name so this can be instantiated */


### PR DESCRIPTION
This seems to be due to last minute changes in DAV, and lack of py tests.

Carlos needs this sharpish, so tests can come in a later PR/issue, as semi-busy with hack today.