### PR TITLE
Do not use GCC 10.3 on github actions

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-20.04
             cuda: "11.3"
             cuda_arch: "52"
-            gcc: 10
+            gcc: 9
           # 18.04 supports CUDA 10.0+ (gcc <=8), 11.0+ (gcc<=9), 11.1+ (gcc<=10)
           - os: ubuntu-18.04
             cuda: "10.0"


### PR DESCRIPTION
GCC 10.3.0 errors with an internal error when building FLAME GPU 2 with CUDA 11.3

For ubuntu x86 platforms, GCC 9.x is supported. 10.2 is supported for ARM/power systems.

See #575 