### PR TITLE
Array message testing rob

### DIFF
--- a/include/flamegpu/runtime/messaging/Array/ArrayDevice.h
+++ b/include/flamegpu/runtime/messaging/Array/ArrayDevice.h
@@ -396,7 +396,7 @@ class MsgArray::In {
             return iterator(*this, max_cell);
         }
 
-      private:
+     private:
         /**
          * Search origin
          */

--- a/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array2D/Array2DDevice.h
@@ -65,7 +65,194 @@ class MsgArray2D::In {
     /**
      * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
      * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
-     * 
+     * The radius wraps the message list bounds
+     *
+     * @see MsgArray2D::In::wrap(size_type, size_type, size_type)
+     */
+    class WrapFilter {
+        /**
+         * Message has full access to WrapFilter, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class Message;
+
+     public:
+        /**
+         * Provides access to a specific message
+         * Returned by the iterator
+         * @see In::WrapFilter::iterator
+         */
+        class Message {
+            /**
+             * Paired WrapFilter class which created the iterator
+             */
+            const WrapFilter&_parent;
+            /**
+             * Relative position within the Moore neighbourhood
+             * This is initialised based on user provided radius
+             */
+            int relative_cell[2];
+            /**
+             * Index into memory of currently pointed message
+             */
+            size_type index_1d = 0;
+
+         public:
+            /**
+             * Constructs a message and directly initialises all of it's member variables
+             * @note See member variable documentation for their purposes
+             */
+            __device__ Message(const WrapFilter&parent, const int &relative_x, const int &relative_y)
+                : _parent(parent) {
+                relative_cell[0] = relative_x;
+                relative_cell[1] = relative_y;
+            }
+            /**
+             * Equality operator
+             * Compares all internal member vars for equality
+             * @note Does not compare _parent
+             */
+            __device__ bool operator==(const Message& rhs) const {
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1];
+                // && this->_parent.loc[0] == rhs._parent.loc[0]
+                // && this->_parent.loc[1] == rhs._parent.loc[1];
+            }
+            /**
+             * Inequality operator
+             * Returns inverse of equality operator
+             * @see operator==(const Message&)
+             */
+            __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+            /**
+             * Updates the message to return variables from the next cell in the Moore neighbourhood
+             * @return Returns itself
+             */
+            inline __device__ Message& operator++();
+            /**
+             * Returns x array index of message
+             */
+            __device__ size_type getX() const {
+                return (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+            }
+            /**
+             * Returns y array index of message
+             */
+            __device__ size_type getY() const {
+                return (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+            }
+            /**
+             * Returns the value for the current message attached to the named variable
+             * @param variable_name Name of the variable
+             * @tparam T type of the variable
+             * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+             * @return The specified variable, else 0x0 if an error occurs
+             */
+            template<typename T, unsigned int N>
+            __device__ T getVariable(const char(&variable_name)[N]) const;
+        };
+        /**
+         * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
+         */
+        class iterator {
+            /**
+             * The message returned to the user
+             */
+            Message _message;
+
+         public:
+            /**
+             * Constructor
+             * This iterator is constructed by MsgArray2D::In::WrapFilter::begin()(size_type, size_type, size_type)
+             * @see MsgArray2D::In::wrap(size_type, size_type, size_type)
+             */
+            __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y)
+                : _message(parent, relative_x, relative_y) {
+                // Increment to find first message
+                ++_message;
+            }
+            /**
+             * Moves to the next message
+             * (Prefix increment operator)
+             */
+            __device__ iterator& operator++() { ++_message;  return *this; }
+            /**
+             * Moves to the next message
+             * (Postfix increment operator, returns value prior to increment)
+             */
+            __device__ iterator operator++(int) {
+                iterator temp = *this;
+                ++*this;
+                return temp;
+            }
+            /**
+             * Equality operator
+             * Compares message
+             */
+            __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+            /**
+             * Inequality operator
+             * Compares message
+             */
+            __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message& operator*() { return _message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message* operator->() { return &_message; }
+        };
+        /**
+         * Constructor, takes the search parameters required
+         * @param _metadata Pointer to message list metadata
+         * @param _combined_hash agentfn+message hash for accessing message data
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param _radius Search radius
+         */
+        inline __device__ WrapFilter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius);
+        /**
+         * Returns an iterator to the start of the message list subset about the search origin
+         */
+        inline __device__ iterator begin(void) const {
+            // Bin before initial bin, as the constructor calls increment operator
+            return iterator(*this, -static_cast<int>(radius), -static_cast<int>(radius)-1);
+        }
+        /**
+         * Returns an iterator to the position beyond the end of the message list subset
+         * @note This iterator is the same for all message list subsets
+         */
+        inline __device__ iterator end(void) const {
+            // Final bin, as the constructor calls increment operator
+            return iterator(*this, radius, radius);
+        }
+
+     private:
+        /**
+         * Search origin
+         */
+        size_type loc[2];
+        /**
+         * Search radius
+         */
+        const size_type radius;
+        /**
+         * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+         */
+        const MetaData *metadata;
+        /**
+         * CURVE hash for accessing message data
+         * agent function hash + message hash
+         */
+        Curve::NamespaceHash combined_hash;
+    };
+    /**
+     * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
+     * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius does not wrap the message list bounds
+     *
      * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
      */
     class Filter {
@@ -112,9 +299,10 @@ class MsgArray2D::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->index_1d == rhs.index_1d
-                    && this->_parent.loc[0] == rhs._parent.loc[0]
-                    && this->_parent.loc[1] == rhs._parent.loc[1];
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1];
+                    // && this->_parent.loc[0] == rhs._parent.loc[0]
+                    // && this->_parent.loc[1] == rhs._parent.loc[1];
             }
             /**
              * Inequality operator
@@ -131,13 +319,13 @@ class MsgArray2D::In {
              * Returns x array index of message
              */
             __device__ size_type getX() const {
-                return (this->_parent.loc[0] + relative_cell[0] + this->_parent.metadata->dimensions[0]) % this->_parent.metadata->dimensions[0];
+                return this->_parent.loc[0] + relative_cell[0];
             }
             /**
              * Returns y array index of message
              */
             __device__ size_type getY() const {
-                return (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
+                return this->_parent.loc[1] + relative_cell[1];
             }
             /**
              * Returns the value for the current message attached to the named variable
@@ -203,7 +391,7 @@ class MsgArray2D::In {
             __device__ Message* operator->() { return &_message; }
         };
         /**
-         * Constructor, takes the search parameters requried
+         * Constructor, takes the search parameters required
          * @param _metadata Pointer to message list metadata
          * @param _combined_hash agentfn+message hash for accessing message data
          * @param x Search origin x coord
@@ -216,7 +404,7 @@ class MsgArray2D::In {
          */
         inline __device__ iterator begin(void) const {
             // Bin before initial bin, as the constructor calls increment operator
-            return iterator(*this, -static_cast<int>(radius), -static_cast<int>(radius)-1);
+            return iterator(*this, min_cell[0], min_cell[1] - 1);
         }
         /**
          * Returns an iterator to the position beyond the end of the message list subset
@@ -224,7 +412,7 @@ class MsgArray2D::In {
          */
         inline __device__ iterator end(void) const {
             // Final bin, as the constructor calls increment operator
-            return iterator(*this, radius, radius);
+            return iterator(*this, max_cell[0], max_cell[1]);
         }
 
      private:
@@ -232,6 +420,14 @@ class MsgArray2D::In {
          * Search origin
          */
         size_type loc[2];
+        /**
+         * Min offset to be accessed (inclusive)
+         */
+        int min_cell[2];
+        /**
+         * Max offset to be accessed (inclusive)
+         */
+        int max_cell[2];
         /**
          * Search radius
          */
@@ -261,19 +457,58 @@ class MsgArray2D::In {
      * Returns a Filter object which provides access to message iterator
      * for iterating a subset of messages including those within the radius of the search origin
      * this excludes the message at the search origin
+     * The radius will wrap over environment bounds
      *
      * @param x Search origin x coord
      * @param y Search origin y coord
      * @param radius Search radius
      * @note radius 1 is 8 cells in 3x3
      * @note radius 2 is 24 cells in 5x5
-     * @note If radius is >= half of the array dimensions, cells will be doubly read
+     * @note radius which produce a message read dimension (radius*2 + 1) greater than one of the message list dimensions are unsupported
      * @note radius of 0 is unsupported
+     * @note The location [x, y] must be within the bounds of the message list
+     */
+    inline __device__ WrapFilter wrap(const size_type & x, const size_type & y, const size_type & radius = 1) const {
+#if !defined(SEATBELTS) || SEATBELTS
+        if (radius == 0) {
+            DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
+        } else if ((radius * 2) + 1 > metadata->dimensions[0] ||
+                   (radius * 2) + 1 > metadata->dimensions[1]) {
+            unsigned int min_r = metadata->dimensions[0] < metadata->dimensions[1] ? metadata->dimensions[0] : metadata->dimensions[1];
+            min_r = min_r % 2 == 0 ? min_r - 2: min_r - 1;
+            min_r /= 2;
+            DTHROW("%u is not a valid radius for accessing Array2D message lists, as the diameter of messages accessed exceeds one or more of the message list dimensions (%u, %u)."
+            " Maximum supported radius for this message list is %u.\n",
+            radius, metadata->dimensions[0], metadata->dimensions[1], min_r);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1]) {
+            DTHROW("(%u, %u) is not a valid position for iterating an Array2D message list of dimensions (%u, %u), location must be within bounds.",
+                x, y, metadata->dimensions[0], metadata->dimensions[1]);
+        }
+#endif
+        return WrapFilter(metadata, combined_hash, x, y, radius);
+    }
+    /**
+     * Returns a Filter object which provides access to message iterator
+     * for iterating a subset of messages including those within the radius of the search origin
+     * this excludes the message at the search origin
+     *
+     * @param x Search origin x coord
+     * @param y Search origin y coord
+     * @param radius Search radius
+     * @note radius 1 is 8 cells in 3x3
+     * @note radius 2 is 24 cells in 5x5
+     * @note radius of 0 is unsupported
+     * @note The location [x, y] must be within the bounds of the message list
      */
     inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
-            DTHROW("%llu is not a valid radius for accessing Array2D message lists.\n", radius);
+            DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1]) {
+            DTHROW("(%u, %u) is not a valid position for iterating an Array2D message list of dimensions (%u, %u), location must be within bounds.",
+                x, y, metadata->dimensions[0], metadata->dimensions[1]);
         }
 #endif
         return Filter(metadata, combined_hash, x, y, radius);
@@ -386,6 +621,18 @@ __device__ T MsgArray2D::In::Message::getVariable(const char(&variable_name)[N])
     return Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
+__device__ T MsgArray2D::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array2D message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, unsigned int N>
 __device__ T MsgArray2D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -432,14 +679,14 @@ __device__ void MsgArray2D::Out::setIndex(const size_type &x, const size_type &y
     // Set scan flag incase the message is optional
     this->scan_flag[index] = 1;
 }
-__device__ MsgArray2D::In::Filter::Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius)
+__device__ MsgArray2D::In::WrapFilter::WrapFilter(const MetaData* _metadata, const Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& y, const size_type& _radius)
     : radius(_radius)
     , metadata(_metadata)
     , combined_hash(_combined_hash) {
     loc[0] = x;
     loc[1] = y;
 }
-__device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::operator++() {
+__device__ MsgArray2D::In::WrapFilter::Message& MsgArray2D::In::WrapFilter::Message::operator++() {
     if (relative_cell[1] >= static_cast<int>(_parent.radius)) {
         relative_cell[1] = -static_cast<int>(_parent.radius);
         relative_cell[0]++;
@@ -455,7 +702,39 @@ __device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::ope
     const unsigned int their_y = (this->_parent.loc[1] + relative_cell[1] + this->_parent.metadata->dimensions[1]) % this->_parent.metadata->dimensions[1];
     // Solve to 1 dimensional bin index
     index_1d = their_y * this->_parent.metadata->dimensions[0] +
-        their_x;
+               their_x;
+    return *this;
+}
+__device__ MsgArray2D::In::Filter::Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &_radius)
+    : radius(_radius)
+    , metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    loc[0] = x;
+    loc[1] = y;
+    min_cell[0] = static_cast<int>(x) - static_cast<int>(_radius) < 0 ? -static_cast<int>(x) : -static_cast<int>(_radius);
+    min_cell[1] = static_cast<int>(y) - static_cast<int>(_radius) < 0 ? -static_cast<int>(y) : -static_cast<int>(_radius);
+    max_cell[0] = x + _radius >= _metadata->dimensions[0] ? static_cast<int>(_metadata->dimensions[0]) - 1 - static_cast<int>(x) : static_cast<int>(_radius);
+    max_cell[1] = y + _radius >= _metadata->dimensions[1] ? static_cast<int>(_metadata->dimensions[1]) - 1 - static_cast<int>(y) : static_cast<int>(_radius);
+}
+__device__ MsgArray2D::In::Filter::Message& MsgArray2D::In::Filter::Message::operator++() {
+    if (relative_cell[1] >= _parent.max_cell[1]) {
+        relative_cell[1] = _parent.min_cell[1];
+        relative_cell[0]++;
+    } else {
+        relative_cell[1]++;
+    }
+    // Skip origin cell
+    if (relative_cell[0] == 0 && relative_cell[1] == 0) {
+        if (relative_cell[1] >= _parent.max_cell[1]) {
+            relative_cell[1] = _parent.min_cell[1];
+            relative_cell[0]++;
+        } else {
+            relative_cell[1]++;
+        }
+    }
+    // Solve to 1 dimensional bin index
+    index_1d = (this->_parent.loc[1] + relative_cell[1]) * this->_parent.metadata->dimensions[0] +
+               (this->_parent.loc[0] + relative_cell[0]);
     return *this;
 }
 

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -119,9 +119,12 @@ class MsgArray3D::In {
              */
             __device__ bool operator==(const Message& rhs) const {
                 return this->index_1d == rhs.index_1d
-                    && this->_parent.loc[0] == rhs._parent.loc[0]
-                    && this->_parent.loc[1] == rhs._parent.loc[1]
-                    && this->_parent.loc[2] == rhs._parent.loc[2];
+                    && this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1]
+                    && this->relative_cell[2] == rhs.relative_cell[2];
+                    // && this->_parent.loc[0] == rhs._parent.loc[0]
+                    // && this->_parent.loc[1] == rhs._parent.loc[1]
+                    // && this->_parent.loc[2] == rhs._parent.loc[2];
             }
             /**
              * Inequality operator

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -69,10 +69,11 @@ class MsgArray3D::In {
     /**
      * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
      * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius wraps the message list bounds
      * 
-     * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
+     * @see MsgArray2D::In::wrap()(size_type, size_type, size_type)
      */
-    class Filter {
+    class WrapFilter {
         /**
          * Message has full access to Filter, they are treated as the same class so share everything
          * Reduces/memory data duplication
@@ -89,7 +90,7 @@ class MsgArray3D::In {
             /**
              * Paired Filter class which created the iterator
              */
-            const Filter &_parent;
+            const WrapFilter&_parent;
             /**
              * Relative position within the Moore neighbourhood
              * This is initialised based on user provided radius
@@ -105,7 +106,7 @@ class MsgArray3D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter &parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ Message(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -173,10 +174,10 @@ class MsgArray3D::In {
          public:
             /**
              * Constructor
-             * This iterator is constructed by MsgArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
-             * @see MsgArray3D::In::Operator()(size_type, size_type, size_type, size_type)
+             * This iterator is constructed by MsgArray3D::In::WrapFilter::begin()(size_type, size_type, size_type, size_type)
+             * @see MsgArray3D::In::wrap()(size_type, size_type, size_type, size_type)
              */
-            __device__ iterator(const Filter &parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
                 // Increment to find first message
                 ++_message;
@@ -215,7 +216,7 @@ class MsgArray3D::In {
             __device__ Message* operator->() { return &_message; }
         };
         /**
-         * Constructor, takes the search parameters requried
+         * Constructor, takes the search parameters required
          * @param _metadata Pointer to message list metadata
          * @param _combined_hash agentfn+message hash for accessing message data
          * @param x Search origin x coord
@@ -223,7 +224,7 @@ class MsgArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
+        inline __device__ WrapFilter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
         /**
          * Returns an iterator to the start of the message list subset about the search origin
          */
@@ -260,6 +261,203 @@ class MsgArray3D::In {
         Curve::NamespaceHash combined_hash;
     };
     /**
+     * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
+     * It provides iterator access to a subset of the full message list, according to the provided search origin and radius
+     * The radius does not wrap the message list bounds
+     *
+     * @see MsgArray2D::In::operator()(size_type, size_type, size_type)
+     */
+    class Filter {
+        /**
+         * Message has full access to Filter, they are treated as the same class so share everything
+         * Reduces/memory data duplication
+         */
+        friend class Message;
+
+     public:
+        /**
+         * Provides access to a specific message
+         * Returned by the iterator
+         * @see In::Filter::iterator
+         */
+        class Message {
+            /**
+             * Paired Filter class which created the iterator
+             */
+            const Filter& _parent;
+            /**
+             * Current offset
+             */
+            int relative_cell[3];
+            /**
+             * Index into memory of currently pointed message
+             */
+            size_type index_1d = 0;
+
+         public:
+            /**
+             * Constructs a message and directly initialises all of it's member variables
+             * @note See member variable documentation for their purposes
+             */
+            __device__ Message(const Filter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+                : _parent(parent) {
+                relative_cell[0] = relative_x;
+                relative_cell[1] = relative_y;
+                relative_cell[2] = relative_z;
+            }
+            /**
+             * Equality operator
+             * Compares all internal member vars for equality
+             * @note Does not compare _parent
+             */
+            __device__ bool operator==(const Message& rhs) const {
+                return this->index_1d == rhs.index_1d
+                    && this->_parent.loc[0] == rhs._parent.loc[0]
+                    && this->_parent.loc[1] == rhs._parent.loc[1]
+                    && this->_parent.loc[2] == rhs._parent.loc[2];
+            }
+            /**
+             * Inequality operator
+             * Returns inverse of equality operator
+             * @see operator==(const Message&)
+             */
+            __device__ bool operator!=(const Message& rhs) const { return !(*this == rhs); }
+            /**
+             * Updates the message to return variables from the next cell in the Moore neighbourhood
+             * @return Returns itself
+             */
+            inline __device__ Message& operator++();
+            /**
+             * Returns x array index of message
+             */
+            __device__ size_type getX() const {
+                return this->_parent.loc[0] + relative_cell[0];
+            }
+            /**
+             * Returns y array index of message
+             */
+            __device__ size_type getY() const {
+                return this->_parent.loc[1] + relative_cell[1];
+            }
+            /**
+             * Returns z array index of message
+             */
+            __device__ size_type getZ() const {
+                return this->_parent.loc[2] + relative_cell[2];
+            }
+            /**
+             * Returns the value for the current message attached to the named variable
+             * @param variable_name Name of the variable
+             * @tparam T type of the variable
+             * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+             * @return The specified variable, else 0x0 if an error occurs
+             */
+            template<typename T, unsigned int N>
+            __device__ T getVariable(const char(&variable_name)[N]) const;
+        };
+        /**
+         * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+         */
+        class iterator {
+            /**
+             * The message returned to the user
+             */
+            Message _message;
+
+         public:
+            /**
+             * Constructor
+             * This iterator is constructed by MsgArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
+             * @see MsgArray3D::In::Operator()(size_type, size_type, size_type, size_type)
+             */
+            __device__ iterator(const Filter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+                : _message(parent, relative_x, relative_y, relative_z) {
+                // Increment to find first message
+                ++_message;
+            }
+            /**
+             * Moves to the next message
+             * (Prefix increment operator)
+             */
+            __device__ iterator& operator++() { ++_message;  return *this; }
+            /**
+             * Moves to the next message
+             * (Postfix increment operator, returns value prior to increment)
+             */
+            __device__ iterator operator++(int) {
+                iterator temp = *this;
+                ++* this;
+                return temp;
+            }
+            /**
+             * Equality operator
+             * Compares message
+             */
+            __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+            /**
+             * Inequality operator
+             * Compares message
+             */
+            __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message& operator*() { return _message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message* operator->() { return &_message; }
+        };
+        /**
+         * Constructor, takes the search parameters required
+         * @param _metadata Pointer to message list metadata
+         * @param _combined_hash agentfn+message hash for accessing message data
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param z Search origin z coord
+         * @param _radius Search radius
+         */
+        inline __device__ Filter(const MetaData* _metadata, const Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius);
+        /**
+         * Returns an iterator to the start of the message list subset about the search origin
+         */
+        inline __device__ iterator begin(void) const {
+            // Bin before initial bin, as the constructor calls increment operator
+            return iterator(*this,  min_cell[0], min_cell[1], min_cell[2] - 1);
+        }
+        /**
+         * Returns an iterator to the position beyond the end of the message list subset
+         * @note This iterator is the same for all message list subsets
+         */
+        inline __device__ iterator end(void) const {
+            // Final bin, as the constructor calls increment operator
+            return iterator(*this, max_cell[0], max_cell[1], max_cell[2]);
+        }
+
+     private:
+        /**
+         * Search origin
+         */
+        size_type loc[3];
+        /**
+         * Min offset to be accessed (inclusive)
+         */
+        int min_cell[3];
+        /**
+         * Max offset to be accessed (inclusive)
+         */
+        int max_cell[3];
+        /**
+         * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+         */
+        const MetaData* metadata;
+        /**
+         * CURVE hash for accessing message data
+         * agent function hash + message hash
+         */
+        Curve::NamespaceHash combined_hash;
+    };
+    /**
      * Constructer
      * Initialises member variables
      * @param agentfn_hash Added to msg_hash to produce combined_hash
@@ -271,9 +469,10 @@ class MsgArray3D::In {
         , metadata(reinterpret_cast<const MetaData*>(_metadata))
     { }
     /**
-     * Returns a Filter object which provides access to message iterator
+     * Returns a WrapFilter object which provides access to message iterator
      * for iterating a subset of messages including those within the radius of the search origin
      * this excludes the message at the search origin
+     * The radius will wrap over environment bounds
      *
      * @param x Search origin x coord
      * @param y Search origin y coord
@@ -281,13 +480,57 @@ class MsgArray3D::In {
      * @param radius Search radius
      * @note radius 1 is 26 cells in 3x3x3
      * @note radius 2 is 124 cells in 5x5x5
-     * @note If radius is >= half of the array dimensions, cells will be doubly read
+     * @note radius which produce a message read dimension (radius*2 + 1) greater than one of the message list dimensions are unsupported
      * @note radius of 0 is unsupported
+     * @note The location [x, y, z] must be within the bounds of the message list
      */
-    inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
+    inline __device__ WrapFilter wrap(const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
+#if !defined(SEATBELTS) || SEATBELTS
+        if (radius == 0) {
+            DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
+        } else if ((radius * 2) + 1 > metadata->dimensions[0] ||
+                   (radius * 2) + 1 > metadata->dimensions[1] ||
+                   (radius * 2) + 1 > metadata->dimensions[2]) {
+            unsigned int min_r = metadata->dimensions[0] < metadata->dimensions[1] ? metadata->dimensions[0] : metadata->dimensions[1];
+            min_r = min_r < metadata->dimensions[2] ? min_r : metadata->dimensions[2];
+            min_r = min_r % 2 == 0 ? min_r + 2: min_r + 1;
+            min_r /= 2;
+            DTHROW("%u is not a valid radius for accessing Array3D message lists, as the diameter of messages accessed exceeds one or more of the message list dimensions (%u, %u, %u)."
+            " Maximum supported radius for this message list is %u.\n",
+            radius, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2], min_r);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1] ||
+                   z >= metadata->dimensions[2]) {
+            DTHROW("(%u, %u, %u) is not a valid position for iterating an Array3D message list of dimensions (%u, %u, %u), location must be within bounds.",
+                x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
+        }
+#endif
+        return WrapFilter(metadata, combined_hash, x, y, z, radius);
+    }
+    /**
+     * Returns a Filter object which provides access to message iterator
+     * for iterating a subset of messages including those within the radius of the search origin
+     * this excludes the message at the search origin
+     * The radius will not wrap over environment bounds
+     *
+     * @param x Search origin x coord
+     * @param y Search origin y coord
+     * @param z Search origin y coord
+     * @param radius Search radius
+     * @note radius 1 is 26 cells in 3x3x3
+     * @note radius 2 is 124 cells in 5x5x5
+     * @note radius of 0 is unsupported
+     * @note The location [x, y, z] must be within the bounds of the message list
+     */
+    inline __device__ Filter operator()(const size_type& x, const size_type& y, const size_type& z, const size_type& radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%llu is not a valid radius for accessing Array3D message lists.\n", radius);
+        } else if (x >= metadata->dimensions[0] ||
+                   y >= metadata->dimensions[1] ||
+                   z >= metadata->dimensions[2]) {
+            DTHROW("(%u, %u, %u) is not a valid position for iterating an Array3D message list of dimensions (%u, %u, %u), location must be within bounds.",
+                x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
         }
 #endif
         return Filter(metadata, combined_hash, x, y, z, radius);
@@ -405,6 +648,18 @@ __device__ T MsgArray3D::In::Message::getVariable(const char(&variable_name)[N])
     return Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
 template<typename T, unsigned int N>
+__device__ T MsgArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    return Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, unsigned int N>
 __device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -453,7 +708,7 @@ __device__ inline void MsgArray3D::Out::setIndex(const size_type &x, const size_
     // Set scan flag incase the message is optional
     this->scan_flag[index] = 1;
 }
-__device__ inline MsgArray3D::In::Filter::Filter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
+__device__ inline MsgArray3D::In::WrapFilter::WrapFilter(const MetaData *_metadata, const Curve::NamespaceHash &_combined_hash, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
     : radius(_radius)
     , metadata(_metadata)
     , combined_hash(_combined_hash) {
@@ -461,7 +716,7 @@ __device__ inline MsgArray3D::In::Filter::Filter(const MetaData *_metadata, cons
     loc[1] = y;
     loc[2] = z;
 }
-__device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Message::operator++() {
+__device__ inline MsgArray3D::In::WrapFilter::Message& MsgArray3D::In::WrapFilter::Message::operator++() {
     if (relative_cell[2] >= static_cast<int>(_parent.radius)) {
         relative_cell[2] = -static_cast<int>(_parent.radius);
         if (relative_cell[1] >= static_cast<int>(_parent.radius)) {
@@ -485,6 +740,51 @@ __device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Messa
     index_1d = their_z * this->_parent.metadata->dimensions[0] * this->_parent.metadata->dimensions[1] +
                their_y * this->_parent.metadata->dimensions[0] +
                their_x;
+    return *this;
+}
+__device__ inline MsgArray3D::In::Filter::Filter(const MetaData* _metadata, const Curve::NamespaceHash& _combined_hash, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius)
+    : metadata(_metadata)
+    , combined_hash(_combined_hash) {
+    loc[0] = x;
+    loc[1] = y;
+    loc[2] = z;
+    min_cell[0] = static_cast<int>(x) - static_cast<int>(_radius) < 0 ? -static_cast<int>(x) : - static_cast<int>(_radius);
+    min_cell[1] = static_cast<int>(y) - static_cast<int>(_radius) < 0 ? -static_cast<int>(y) : - static_cast<int>(_radius);
+    min_cell[2] = static_cast<int>(z) - static_cast<int>(_radius) < 0 ? -static_cast<int>(z) : - static_cast<int>(_radius);
+    max_cell[0] = x + _radius >= _metadata->dimensions[0] ? static_cast<int>(_metadata->dimensions[0]) - 1 - static_cast<int>(x) : static_cast<int>(_radius);
+    max_cell[1] = y + _radius >= _metadata->dimensions[1] ? static_cast<int>(_metadata->dimensions[1]) - 1 - static_cast<int>(y) : static_cast<int>(_radius);
+    max_cell[2] = z + _radius >= _metadata->dimensions[2] ? static_cast<int>(_metadata->dimensions[2]) - 1 - static_cast<int>(z) : static_cast<int>(z + _radius);
+}
+__device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Message::operator++() {
+    if (relative_cell[2] >= _parent.max_cell[2]) {
+        relative_cell[2] = _parent.min_cell[2];
+        if (relative_cell[1] >= _parent.max_cell[1]) {
+            relative_cell[1] = _parent.min_cell[1];
+            relative_cell[0]++;
+        } else {
+            relative_cell[1]++;
+        }
+    } else {
+        relative_cell[2]++;
+    }
+    // Skip origin cell
+    if (relative_cell[0] == 0 && relative_cell[1] == 0 && relative_cell[2] == 0) {
+        if (relative_cell[2] >= _parent.max_cell[2]) {
+            relative_cell[2] = _parent.min_cell[2];
+            if (relative_cell[1] >= _parent.max_cell[1]) {
+                relative_cell[1] = _parent.min_cell[1];
+                relative_cell[0]++;
+            } else {
+                relative_cell[1]++;
+            }
+        } else {
+            relative_cell[2]++;
+        }
+    }
+    // Solve to 1 dimensional bin index
+    index_1d = (this->_parent.loc[2] + relative_cell[2]) * this->_parent.metadata->dimensions[0] * this->_parent.metadata->dimensions[1] +
+               (this->_parent.loc[1] + relative_cell[1]) * this->_parent.metadata->dimensions[0] +
+               (this->_parent.loc[0] + relative_cell[0]);
     return *this;
 }
 

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -493,7 +493,7 @@ class MsgArray3D::In {
                    (radius * 2) + 1 > metadata->dimensions[2]) {
             unsigned int min_r = metadata->dimensions[0] < metadata->dimensions[1] ? metadata->dimensions[0] : metadata->dimensions[1];
             min_r = min_r < metadata->dimensions[2] ? min_r : metadata->dimensions[2];
-            min_r = min_r % 2 == 0 ? min_r + 2: min_r + 1;
+            min_r = min_r % 2 == 0 ? min_r - 2: min_r - 1;
             min_r /= 2;
             DTHROW("%u is not a valid radius for accessing Array3D message lists, as the diameter of messages accessed exceeds one or more of the message list dimensions (%u, %u, %u)."
             " Maximum supported radius for this message list is %u.\n",

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -118,8 +118,7 @@ class MsgArray3D::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->index_1d == rhs.index_1d
-                    && this->relative_cell[0] == rhs.relative_cell[0]
+                return this->relative_cell[0] == rhs.relative_cell[0]
                     && this->relative_cell[1] == rhs.relative_cell[1]
                     && this->relative_cell[2] == rhs.relative_cell[2];
                     // && this->_parent.loc[0] == rhs._parent.loc[0]
@@ -314,10 +313,12 @@ class MsgArray3D::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->index_1d == rhs.index_1d
-                    && this->_parent.loc[0] == rhs._parent.loc[0]
-                    && this->_parent.loc[1] == rhs._parent.loc[1]
-                    && this->_parent.loc[2] == rhs._parent.loc[2];
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1]
+                    && this->relative_cell[2] == rhs.relative_cell[2];
+                    // && this->_parent.loc[0] == rhs._parent.loc[0]
+                    // && this->_parent.loc[1] == rhs._parent.loc[1]
+                    // && this->_parent.loc[2] == rhs._parent.loc[2];
             }
             /**
              * Inequality operator
@@ -756,7 +757,7 @@ __device__ inline MsgArray3D::In::Filter::Filter(const MetaData* _metadata, cons
     min_cell[2] = static_cast<int>(z) - static_cast<int>(_radius) < 0 ? -static_cast<int>(z) : - static_cast<int>(_radius);
     max_cell[0] = x + _radius >= _metadata->dimensions[0] ? static_cast<int>(_metadata->dimensions[0]) - 1 - static_cast<int>(x) : static_cast<int>(_radius);
     max_cell[1] = y + _radius >= _metadata->dimensions[1] ? static_cast<int>(_metadata->dimensions[1]) - 1 - static_cast<int>(y) : static_cast<int>(_radius);
-    max_cell[2] = z + _radius >= _metadata->dimensions[2] ? static_cast<int>(_metadata->dimensions[2]) - 1 - static_cast<int>(z) : static_cast<int>(z + _radius);
+    max_cell[2] = z + _radius >= _metadata->dimensions[2] ? static_cast<int>(_metadata->dimensions[2]) - 1 - static_cast<int>(z) : static_cast<int>(_radius);
 }
 __device__ inline MsgArray3D::In::Filter::Message& MsgArray3D::In::Filter::Message::operator++() {
     if (relative_cell[2] >= _parent.max_cell[2]) {

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.h
@@ -75,7 +75,7 @@ class MsgArray3D::In {
      */
     class WrapFilter {
         /**
-         * Message has full access to Filter, they are treated as the same class so share everything
+         * Message has full access to WrapFilter, they are treated as the same class so share everything
          * Reduces/memory data duplication
          */
         friend class Message;
@@ -84,11 +84,11 @@ class MsgArray3D::In {
         /**
          * Provides access to a specific message
          * Returned by the iterator
-         * @see In::Filter::iterator
+         * @see In::WrapFilter::iterator
          */
         class Message {
             /**
-             * Paired Filter class which created the iterator
+             * Paired WrapFilter class which created the iterator
              */
             const WrapFilter&_parent;
             /**
@@ -165,7 +165,7 @@ class MsgArray3D::In {
             __device__ T getVariable(const char(&variable_name)[N]) const;
         };
         /**
-         * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
+         * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
          */
         class iterator {
             /**
@@ -177,7 +177,7 @@ class MsgArray3D::In {
             /**
              * Constructor
              * This iterator is constructed by MsgArray3D::In::WrapFilter::begin()(size_type, size_type, size_type, size_type)
-             * @see MsgArray3D::In::wrap()(size_type, size_type, size_type, size_type)
+             * @see MsgArray3D::In::wrap(size_type, size_type, size_type, size_type)
              */
             __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
@@ -529,7 +529,7 @@ class MsgArray3D::In {
     inline __device__ Filter operator()(const size_type& x, const size_type& y, const size_type& z, const size_type& radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
-            DTHROW("%llu is not a valid radius for accessing Array3D message lists.\n", radius);
+            DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
         } else if (x >= metadata->dimensions[0] ||
                    y >= metadata->dimensions[1] ||
                    z >= metadata->dimensions[2]) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,9 +114,6 @@ SET(TEST_CASE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_rtc_device_exception.cu
 )
 SET(DEV_TEST_CASE_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_2d.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_array_3d.cu
 )
 SET(OTHER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/helpers/host_reductions_common.h

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -15,6 +15,7 @@ namespace test_message_array {
     const char *IN_LAYER_NAME = "InLayer";
     const char *OUT_LAYER_NAME = "OutLayer";
     const unsigned int AGENT_COUNT = 128;
+    __device__ const unsigned int dAGENT_COUNT = 128;
 FLAMEGPU_AGENT_FUNCTION(OutFunction, MsgNone, MsgArray) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("message_write");
     FLAMEGPU->message_out.setVariable<unsigned int>("index_times_3", index * 3);
@@ -182,11 +183,11 @@ FLAMEGPU_AGENT_FUNCTION(OutSimple, MsgNone, MsgArray) {
     FLAMEGPU->message_out.setIndex(index);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreTest1W, MsgArray, MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(my_index);
+    auto filter = FLAMEGPU->message_in.wrap(my_index);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -1; i <= 1; ++i) {
@@ -204,11 +205,11 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest1, MsgArray, MsgNone) {
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreTest2W, MsgArray, MsgNone) {
     const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
 
     // Iterate and check it aligns
-    auto filter = FLAMEGPU->message_in(my_index, 2);
+    auto filter = FLAMEGPU->message_in.wrap(my_index, 2);
     auto msg = filter.begin();
     unsigned int message_read = 0;
     for (int i = -2; i <= 2; ++i) {
@@ -226,7 +227,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTest2, MsgArray, MsgNone) {
     FLAMEGPU->setVariable<unsigned int>("message_read", message_read);
     return ALIVE;
 }
-TEST(TestMessage_Array, Moore1) {
+TEST(TestMessage_Array, Moore1W) {
     ModelDescription m(MODEL_NAME);
     MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
     msg.setLength(AGENT_COUNT);
@@ -235,7 +236,7 @@ TEST(TestMessage_Array, Moore1) {
     a.newVariable<unsigned int>("message_read", UINT_MAX);
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest1W);
     fi.setMessageInput(msg);
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -259,7 +260,7 @@ TEST(TestMessage_Array, Moore1) {
         EXPECT_EQ(3u, message_read);
     }
 }
-TEST(TestMessage_Array, Moore2) {
+TEST(TestMessage_Array, Moore2W) {
     ModelDescription m(MODEL_NAME);
     MsgArray::Description &msg = m.newMessage<MsgArray>(MESSAGE_NAME);
     msg.setLength(AGENT_COUNT);
@@ -268,7 +269,7 @@ TEST(TestMessage_Array, Moore2) {
     a.newVariable<unsigned int>("message_read", UINT_MAX);
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutSimple);
     fo.setMessageOutput(msg);
-    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, MooreTest2W);
     fi.setMessageInput(msg);
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -303,8 +304,6 @@ TEST(TestMessage_Array, DISABLED_DuplicateOutputException) {
     msg.setLength(AGENT_COUNT);
     msg.newVariable<unsigned int>("index_times_3");
     AgentDescription &a = m.newAgent(AGENT_NAME);
-    a.newVariable<unsigned int>("index");
-    a.newVariable<unsigned int>("message_read", UINT_MAX);
     a.newVariable<unsigned int>("message_write");
     AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, OutBad);
     fo.setMessageOutput(msg);
@@ -326,9 +325,7 @@ TEST(TestMessage_Array, DISABLED_DuplicateOutputException) {
     AgentVector pop(a, AGENT_COUNT);
     for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
         AgentVector::Agent ai = pop[i];
-        ai.setVariable<unsigned int>("index", i);
-        ai.setVariable<unsigned int>("message_read", UINT_MAX);
-        ai.setVariable<unsigned int>("message_write", numbers[i]);
+        ai.setVariable<unsigned int>("message_write", i);  // numbers[i]
     }
     // Set pop in model
     CUDASimulation c(m);
@@ -388,6 +385,206 @@ TEST(TestMessage_Array, ReadEmpty) {
     auto ai = pop_out[0];
     EXPECT_EQ(ai.getVariable<unsigned int>("value"), 0u);  // Unset array msgs should be 0
 }
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWOutOfBoundsX, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(dAGENT_COUNT)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, MooreW_InitOutOfBoundsX) {
+#else
+TEST(TestMessage_Array, DISABLED_MooreW_InitOutOfBoundsX) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWOutOfBoundsX);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius1, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, MooreW_BadRadius1) {
+#else
+TEST(TestMessage_Array, DISABLED_MooreW_BadRadius1) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius1);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreWBadRadius2, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in.wrap(0, 64)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, MooreW_BadRadius2) {
+#else
+TEST(TestMessage_Array, DISABLED_MooreW_BadRadius2) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreWBadRadius2);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreOutOfBoundsX, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(dAGENT_COUNT)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, Moore_InitOutOfBoundsX) {
+#else
+TEST(TestMessage_Array, DISABLED_Moore_InitOutOfBoundsX) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreOutOfBoundsX);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), DeviceError);
+}
+#if !defined(SEATBELTS) || SEATBELTS
+FLAMEGPU_AGENT_FUNCTION(InMooreBadRadius, MsgArray, MsgNone) {
+    for (auto a : FLAMEGPU->message_in(0, 0)) {
+        FLAMEGPU->setVariable<unsigned int>("index", a.getVariable<unsigned int>("index_times_3"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Array, Moore_BadRadius) {
+#else
+TEST(TestMessage_Array, DISABLED_Moore_BadRadius) {
+#endif
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int>("index_times_3");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int>("message_read", UINT_MAX);
+    a.newVariable<unsigned int>("message_write");
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, OutFunction);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, InMooreBadRadius);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+        ai.setVariable<unsigned int>("message_read", UINT_MAX);
+        ai.setVariable<unsigned int>("message_write", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    EXPECT_THROW(c.step(), DeviceError);
+}
 
 /*
  * Test for fixed size grids with various com radii to check edge cases + expected cases.
@@ -400,6 +597,121 @@ FLAMEGPU_AGENT_FUNCTION(OutSimpleX, MsgNone, MsgArray) {
     FLAMEGPU->message_out.setIndex(x);
     return ALIVE;
 }
+FLAMEGPU_AGENT_FUNCTION(MooreWTestXC, MsgArray, MsgNone) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
+    const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
+    // Iterate message list counting how many messages were read
+    unsigned int count = 0;
+    for (const auto &message : FLAMEGPU->message_in.wrap(x, COMRADIUS)) {
+        // @todo - check its the correct messages?
+        count++;
+    }
+    FLAMEGPU->setVariable<unsigned int>("message_read", count);
+    return ALIVE;
+}
+
+void test_mooorew_comradius(
+    const unsigned int GRID_WIDTH,
+    const unsigned int COMRADIUS
+    ) {
+    // Calc the population
+    const unsigned int agentCount = GRID_WIDTH;
+
+    // Define the model
+    ModelDescription model("MooreXR");
+
+    // Use an env var for the communication radius to use, rather than a __device__ or a #define.
+    EnvironmentDescription &env = model.Environment();
+    env.newProperty<unsigned int>("COMRADIUS", COMRADIUS);
+
+    // Define the message
+    MsgArray::Description &message = model.newMessage<MsgArray>(MESSAGE_NAME);
+    message.newVariable<unsigned int>("index");
+    message.setLength(GRID_WIDTH);
+    AgentDescription &agent = model.newAgent(AGENT_NAME);
+    agent.newVariable<unsigned int>("index");
+    agent.newVariable<unsigned int>("x");
+    agent.newVariable<unsigned int>("message_read", UINT_MAX);
+    // Define the function and layers.
+    AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleX", OutSimpleX);
+    outputFunction.setMessageOutput(message);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreWTestXC", MooreWTestXC);
+    inputFunction.setMessageInput(message);
+    model.newLayer().addAgentFunction(outputFunction);
+    LayerDescription &li = model.newLayer();
+    li.addAgentFunction(inputFunction);
+    // Assign the numbers in shuffled order to agents
+    AgentVector population(agent, agentCount);
+    for (unsigned int x = 0; x < GRID_WIDTH; x++) {
+        unsigned int idx = x;
+        AgentVector::Agent instance = population[idx];
+        instance.setVariable<unsigned int>("index", idx);
+        instance.setVariable<unsigned int>("x", x);
+        instance.setVariable<unsigned int>("message_read", UINT_MAX);
+    }
+    // Set pop in model
+    CUDASimulation simulation(model);
+    simulation.setPopulationData(population);
+
+    if ((COMRADIUS * 2) + 1 <= GRID_WIDTH) {
+        simulation.step();
+        simulation.getPopulationData(population);
+        // Validate each agent has read correct messages
+
+        // Calc the expected number of messages. This depoends on comm radius for wrapped moore neighbourhood
+        const unsigned int expected_count = COMRADIUS * 2;
+
+        for (AgentVector::Agent instance : population) {
+            const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
+            ASSERT_EQ(expected_count, message_read);
+        }
+    } else {
+        // If the comradius would lead to double message reads, a device error is thrown when SEATBELTS is enabled
+        // Behaviour is otherwise undefined
+#if !defined(SEATBELTS) || SEATBELTS
+        EXPECT_THROW(simulation.step(), DeviceError);
+#endif
+    }
+}
+// Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array, MooreWX1R1) {
+    test_mooorew_comradius(1, 1);
+}
+TEST(TestMessage_Array, MooreWX2R1) {
+    test_mooorew_comradius(2, 1);
+}
+TEST(TestMessage_Array, MooreWX3R1) {
+    test_mooorew_comradius(3, 1);
+}
+TEST(TestMessage_Array, MooreWX4R1) {
+    test_mooorew_comradius(4, 1);
+}
+
+// Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
+// Also try non-uniform dimensions.
+// @todo - decide if these should be one or many tests.
+TEST(TestMessage_Array, MooreWX1R2) {
+    test_mooorew_comradius(1, 2);
+}
+TEST(TestMessage_Array, MooreWX2R2) {
+    test_mooorew_comradius(2, 2);
+}
+TEST(TestMessage_Array, MooreWX3R2) {
+    test_mooorew_comradius(3, 2);
+}
+TEST(TestMessage_Array, MooreWX4R2) {
+    test_mooorew_comradius(4, 2);
+}
+TEST(TestMessage_Array, MooreWX5R2) {
+    test_mooorew_comradius(5, 2);
+}
+TEST(TestMessage_Array, MooreWX6R2) {
+    test_mooorew_comradius(6, 2);
+}
+
 FLAMEGPU_AGENT_FUNCTION(MooreTestXC, MsgArray, MsgNone) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
@@ -420,11 +732,6 @@ void test_mooore_comradius(
     ) {
     // Calc the population
     const unsigned int agentCount = GRID_WIDTH;
-    // Some debug logging. @todo
-    /* printf("GRID_WIDTH %u\n", GRID_WIDTH);
-    printf("GRID_HEIGHT %u\n", GRID_HEIGHT);
-    printf("COMRADIUS %u\n", COMRADIUS);
-    printf("agentCount %u\n", agentCount); */
 
     // Define the model
     ModelDescription model("MooreXR");
@@ -463,34 +770,20 @@ void test_mooore_comradius(
     simulation.setPopulationData(population);
     simulation.step();
     simulation.getPopulationData(population);
-    // Validate each agent has read correct messages
-
-    // Calc the expected number of messages. This depoends on the env dims and the comm radius.
-    // Radius 0 is not supported, and currently the centre cell is not returned for other radii (so usually -1).
-    // If one of the environemnt dimensions is too small, < 2 * radius + 1, then either fewer messages should be read, or messages will be re-read.
-    // In this case, the centre cell may / is currently also read.
-
-    // const unsigned int nowrapExpectedCount = (2 * COMRADIUS) + 1 - 1;
-    // If any dim is less than 2 * rad + 1, then there are fewere unique messages to be read, and the center will be re-read.
-    const bool xFewerReads = (2 * COMRADIUS) + 1 > GRID_WIDTH;
-    const unsigned int xReadRange = !xFewerReads ? (2 * COMRADIUS) + 1 : GRID_WIDTH;
-    // @todo - verify if the self message should ever be returned, even when wrapped. Can always -1 if it should never be read.
-    const unsigned int selfRead = xFewerReads ? 0 : 1;
-    const unsigned int expected_count = (xReadRange) - selfRead;
-
-    /*
-    // @todo 
-    printf("xFewerReads %d\n", xFewerReads);
-    printf("yFewerReads %d\n", yFewerReads);
-    printf("xReadRange %u\n", xReadRange);
-    printf("yReadRange %u\n", yReadRange);
-    printf("selfRead %u\n", selfRead);
-    printf("expected_count %u\n", expected_count); */
-
+    unsigned int right_count = 0;
+    // Validate each agent has read correct number of messages
     for (AgentVector::Agent instance : population) {
+        const unsigned int x = instance.getVariable<unsigned int>("x");
         const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
-        ASSERT_EQ(expected_count, message_read);
+
+        unsigned int expected_read = 1;
+        expected_read *= (std::min<int>(static_cast<int>(x + COMRADIUS), static_cast<int>(GRID_WIDTH) - 1) - std::max<int>(static_cast<int>(x) - static_cast<int>(COMRADIUS), 0) + 1);
+        expected_read--;
+        // ASSERT_EQ(message_read, expected_read);
+        if (message_read == expected_read)
+            right_count++;
     }
+    ASSERT_EQ(right_count, population.size());
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -800,7 +800,7 @@ FLAMEGPU_AGENT_FUNCTION(OutSimpleXYZ, MsgNone, MsgArray3D) {
     FLAMEGPU->message_out.setIndex(x, y, z);
     return ALIVE;
 }
-FLAMEGPU_AGENT_FUNCTION(MooreTestXYZC, MsgArray3D, MsgNone) {
+FLAMEGPU_AGENT_FUNCTION(MooreWTestXYZC, MsgArray3D, MsgNone) {
     const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
     const unsigned int x = FLAMEGPU->getVariable<unsigned int>("x");
     const unsigned int y = FLAMEGPU->getVariable<unsigned int>("y");
@@ -808,7 +808,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTestXYZC, MsgArray3D, MsgNone) {
     const unsigned int COMRADIUS = FLAMEGPU->environment.getProperty<unsigned int>("COMRADIUS");
     // Iterate message list counting how many messages were read.
     unsigned int count = 0;
-    for (const auto &message : FLAMEGPU->message_in(x, y, z, COMRADIUS)) {
+    for (const auto &message : FLAMEGPU->message_in.wrap(x, y, z, COMRADIUS)) {
         // @todo - check its the correct messages?
         /* if(index == 0){
             printf("message from %u: %u %u %u\n", message.getVariable<unsigned int>("index"), message.getX(), message.getY(), message.getZ());
@@ -819,7 +819,7 @@ FLAMEGPU_AGENT_FUNCTION(MooreTestXYZC, MsgArray3D, MsgNone) {
     return ALIVE;
 }
 
-void test_mooore_comradius(
+void test_mooorew_comradius(
     const unsigned int GRID_WIDTH,
     const unsigned int GRID_HEIGHT,
     const unsigned int GRID_DEPTH,
@@ -854,7 +854,7 @@ void test_mooore_comradius(
     // Define the function and layers.
     AgentFunctionDescription &outputFunction = agent.newFunction("OutSimpleXYZ", OutSimpleXYZ);
     outputFunction.setMessageOutput(message);
-    AgentFunctionDescription &inputFunction = agent.newFunction("MooreTestXYZC", MooreTestXYZC);
+    AgentFunctionDescription &inputFunction = agent.newFunction("MooreTestXYZC", MooreWTestXYZC);
     inputFunction.setMessageInput(message);
     model.newLayer().addAgentFunction(outputFunction);
     LayerDescription &li = model.newLayer();
@@ -877,126 +877,123 @@ void test_mooore_comradius(
     // Set pop in model
     CUDASimulation simulation(model);
     simulation.setPopulationData(population);
-    simulation.step();
-    simulation.getPopulationData(population);
-    // Validate each agent has read correct messages
 
-    // Calc the expected number of messages. This depoends on the env dims and the comm radius.
-    // Radius 0 is not supported, and currently the centre cell is not returned for other radii (so usually -1).
-    // If one of the environemnt dimensions is too small, < 2 * radius + 1, then either fewer messages should be read, or messages will be re-read.
-    // In this case, the centre cell may / is currently also read.
+    if ((COMRADIUS * 2) + 1 <= GRID_WIDTH &&
+        (COMRADIUS * 2) + 1 <= GRID_HEIGHT &&
+        (COMRADIUS * 2) + 1 <= GRID_DEPTH) {
+        simulation.step();
+        simulation.getPopulationData(population);
+        // Validate each agent has read correct messages
 
-    // const unsigned int nowrapExpectedCount = pow((2 * COMRADIUS) + 1, 3) - 1;
-    // If any dim is less than 2 * rad + 1, then there are fewere unique messages to be read, and the center will be re-read.
-    const bool xFewerReads = (2 * COMRADIUS) + 1 > GRID_WIDTH;
-    const bool yFewerReads = (2 * COMRADIUS) + 1 > GRID_HEIGHT;
-    const bool zFewerReads = (2 * COMRADIUS) + 1 > GRID_DEPTH;
-    const unsigned int xReadRange = !xFewerReads ? (2 * COMRADIUS) + 1 : GRID_WIDTH;
-    const unsigned int yReadRange = !yFewerReads ? (2 * COMRADIUS) + 1 : GRID_HEIGHT;
-    const unsigned int zReadRange = !zFewerReads ? (2 * COMRADIUS) + 1 : GRID_DEPTH;
-    // @todo - verify if the self message should ever be returned, even when wrapped. Can always -1 if it should never be read.
-    const unsigned int selfRead = xFewerReads || yFewerReads || zFewerReads ? 0 : 1;
-    const unsigned int expected_count = (xReadRange * yReadRange * zReadRange) - selfRead;
+        // Calc the expected number of messages. This depoends on comm radius for wrapped moore neighbourhood
+        const unsigned int expected_count = static_cast<unsigned int>(pow((COMRADIUS * 2) + 1, 3)) - 1;
 
-    /*
-    // @todo 
-    printf("xFewerReads %d\n", xFewerReads);
-    printf("yFewerReads %d\n", yFewerReads);
-    printf("zFewerReads %d\n", zFewerReads);
-    printf("xReadRange %u\n", xReadRange);
-    printf("yReadRange %u\n", yReadRange);
-    printf("zReadRange %u\n", zReadRange);
-    printf("selfRead %u\n", selfRead);
-    printf("expected_count %u\n", expected_count); */
+        /*
+        // @todo 
+        printf("xFewerReads %d\n", xFewerReads);
+        printf("yFewerReads %d\n", yFewerReads);
+        printf("zFewerReads %d\n", zFewerReads);
+        printf("xReadRange %u\n", xReadRange);
+        printf("yReadRange %u\n", yReadRange);
+        printf("zReadRange %u\n", zReadRange);
+        printf("selfRead %u\n", selfRead);
+        printf("expected_count %u\n", expected_count); */
 
-    for (AgentVector::Agent instance : population) {
-        const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
-        ASSERT_EQ(expected_count, message_read);
+        for (AgentVector::Agent instance : population) {
+            const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
+            ASSERT_EQ(expected_count, message_read);
+        }
+    } else {
+        // If the comradius would lead to double message reads, a device error is thrown when SEATBELTS is enabled
+        // Behaviour is otherwise undefined
+#if !defined(SEATBELTS) || SEATBELTS
+        EXPECT_THROW(simulation.step(), DeviceError);
+#endif
     }
 }
 // Test a range of environment sizes for comradius of 1, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreX1Y1Z1R1) {
-    test_mooore_comradius(1, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWX1Y1Z1R1) {
+    test_mooorew_comradius(1, 1, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreX2Y2Z2R1) {
-    test_mooore_comradius(2, 2, 2, 1);
+TEST(TestMessage_Array3D, MooreWX2Y2Z2R1) {
+    test_mooorew_comradius(2, 2, 2, 1);
 }
-TEST(TestMessage_Array3D, MooreX3Y3Z3R1) {
-    test_mooore_comradius(3, 3, 3, 1);
+TEST(TestMessage_Array3D, MooreWX3Y3Z3R1) {
+    test_mooorew_comradius(3, 3, 3, 1);
 }
-TEST(TestMessage_Array3D, MooreX4Y4Z4R1) {
-    test_mooore_comradius(4, 4, 4, 1);
+TEST(TestMessage_Array3D, MooreWX4Y4Z4R1) {
+    test_mooorew_comradius(4, 4, 4, 1);
 }
-TEST(TestMessage_Array3D, MooreX2Y2Z1R1) {
-    test_mooore_comradius(2, 2, 1, 1);
+TEST(TestMessage_Array3D, MooreWX2Y2Z1R1) {
+    test_mooorew_comradius(2, 2, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreX3Y3Z1R1) {
-    test_mooore_comradius(3, 3, 1, 1);
+TEST(TestMessage_Array3D, MooreWX3Y3Z1R1) {
+    test_mooorew_comradius(3, 3, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreX4Y4Z1R1) {
-    test_mooore_comradius(4, 4, 1, 1);
+TEST(TestMessage_Array3D, MooreWX4Y4Z1R1) {
+    test_mooorew_comradius(4, 4, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreX2Y1Z1R1) {
-    test_mooore_comradius(2, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWX2Y1Z1R1) {
+    test_mooorew_comradius(2, 1, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreX3Y1Z1R1) {
-    test_mooore_comradius(3, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWX3Y1Z1R1) {
+    test_mooorew_comradius(3, 1, 1, 1);
 }
-TEST(TestMessage_Array3D, MooreX4Y1Z1R1) {
-    test_mooore_comradius(4, 1, 1, 1);
+TEST(TestMessage_Array3D, MooreWX4Y1Z1R1) {
+    test_mooorew_comradius(4, 1, 1, 1);
 }
 // Test a range of environment sizes for comradius of 2, including small sizes which are an edge case.
 // Also try non-uniform dimensions.
 // @todo - decide if these should be one or many tests.
-TEST(TestMessage_Array3D, MooreXX1Y1Z1R2) {
-    test_mooore_comradius(1, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX1Y1Z1R2) {
+    test_mooorew_comradius(1, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX2Y2Z2R2) {
-    test_mooore_comradius(2, 2, 2, 2);
+TEST(TestMessage_Array3D, MooreWXX2Y2Z2R2) {
+    test_mooorew_comradius(2, 2, 2, 2);
 }
-TEST(TestMessage_Array3D, MooreXX3Y3Z3R2) {
-    test_mooore_comradius(3, 3, 3, 2);
+TEST(TestMessage_Array3D, MooreWXX3Y3Z3R2) {
+    test_mooorew_comradius(3, 3, 3, 2);
 }
-TEST(TestMessage_Array3D, MooreXX4Y4Z4R2) {
-    test_mooore_comradius(4, 4, 4, 2);
+TEST(TestMessage_Array3D, MooreWXX4Y4Z4R2) {
+    test_mooorew_comradius(4, 4, 4, 2);
 }
-TEST(TestMessage_Array3D, MooreXX5Y5Z5R2) {
-    test_mooore_comradius(5, 5, 5, 2);
+TEST(TestMessage_Array3D, MooreWXX5Y5Z5R2) {
+    test_mooorew_comradius(5, 5, 5, 2);
 }
-TEST(TestMessage_Array3D, MooreXX6Y6Z6R2) {
-    test_mooore_comradius(6, 6, 6, 2);
+TEST(TestMessage_Array3D, MooreWXX6Y6Z6R2) {
+    test_mooorew_comradius(6, 6, 6, 2);
 }
-TEST(TestMessage_Array3D, MooreXX2Y2Z1R2) {
-    test_mooore_comradius(2, 2, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX2Y2Z1R2) {
+    test_mooorew_comradius(2, 2, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX3Y3Z1R2) {
-    test_mooore_comradius(3, 3, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX3Y3Z1R2) {
+    test_mooorew_comradius(3, 3, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX4Y4Z1R2) {
-    test_mooore_comradius(4, 4, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX4Y4Z1R2) {
+    test_mooorew_comradius(4, 4, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX5Y5Z1R2) {
-    test_mooore_comradius(5, 5, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX5Y5Z1R2) {
+    test_mooorew_comradius(5, 5, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX6Y6Z1R2) {
-    test_mooore_comradius(6, 6, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX6Y6Z1R2) {
+    test_mooorew_comradius(6, 6, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX2Y1Z1R2) {
-    test_mooore_comradius(2, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX2Y1Z1R2) {
+    test_mooorew_comradius(2, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX3Y1Z1R2) {
-    test_mooore_comradius(3, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX3Y1Z1R2) {
+    test_mooorew_comradius(3, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX4Y1Z1R2) {
-    test_mooore_comradius(4, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX4Y1Z1R2) {
+    test_mooorew_comradius(4, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX5Y1Z1R2) {
-    test_mooore_comradius(5, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX5Y1Z1R2) {
+    test_mooorew_comradius(5, 1, 1, 2);
 }
-TEST(TestMessage_Array3D, MooreXX6Y1Z1R2) {
-    test_mooore_comradius(6, 1, 1, 2);
+TEST(TestMessage_Array3D, MooreWXX6Y1Z1R2) {
+    test_mooorew_comradius(6, 1, 1, 2);
 }
 
 }  // namespace test_message_array_3d

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -360,7 +360,7 @@ TEST(TestMessage_Array3D, DISABLED_DuplicateOutputException) {
     AgentVector pop(a, AGENT_COUNT);
     for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
         AgentVector::Agent ai = pop[i];
-        ai.setVariable<unsigned int>("message_write", i);
+        ai.setVariable<unsigned int>("message_write", i);  // numbers[i]
     }
     // Set pop in model
     CUDASimulation c(m);
@@ -810,9 +810,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreWTestXYZC, MsgArray3D, MsgNone) {
     unsigned int count = 0;
     for (const auto &message : FLAMEGPU->message_in.wrap(x, y, z, COMRADIUS)) {
         // @todo - check its the correct messages?
-        /* if(index == 0){
-            printf("message from %u: %u %u %u\n", message.getVariable<unsigned int>("index"), message.getX(), message.getY(), message.getZ());
-        } */
         count++;
     }
     FLAMEGPU->setVariable<unsigned int>("message_read", count);
@@ -827,12 +824,6 @@ void test_mooorew_comradius(
     ) {
     // Calc the population
     const unsigned int agentCount =  GRID_WIDTH * GRID_HEIGHT * GRID_DEPTH;
-    // Some debug logging. @todo
-    /* printf("GRID_WIDTH %u\n", GRID_WIDTH);
-    printf("GRID_HEIGHT %u\n", GRID_HEIGHT);
-    printf("GRID_DEPTH %u\n", GRID_DEPTH);
-    printf("COMRADIUS %u\n", COMRADIUS);
-    printf("agentCount %u\n", agentCount); */
 
     // Define the model
     ModelDescription model("MooreXYZC");
@@ -887,17 +878,6 @@ void test_mooorew_comradius(
 
         // Calc the expected number of messages. This depoends on comm radius for wrapped moore neighbourhood
         const unsigned int expected_count = static_cast<unsigned int>(pow((COMRADIUS * 2) + 1, 3)) - 1;
-
-        /*
-        // @todo 
-        printf("xFewerReads %d\n", xFewerReads);
-        printf("yFewerReads %d\n", yFewerReads);
-        printf("zFewerReads %d\n", zFewerReads);
-        printf("xReadRange %u\n", xReadRange);
-        printf("yReadRange %u\n", yReadRange);
-        printf("zReadRange %u\n", zReadRange);
-        printf("selfRead %u\n", selfRead);
-        printf("expected_count %u\n", expected_count); */
 
         for (AgentVector::Agent instance : population) {
             const unsigned int message_read = instance.getVariable<unsigned int>("message_read");
@@ -1006,9 +986,6 @@ FLAMEGPU_AGENT_FUNCTION(MooreTestXYZC, MsgArray3D, MsgNone) {
     unsigned int count = 0;
     for (const auto& message : FLAMEGPU->message_in(x, y, z, COMRADIUS)) {
         // @todo - check its the correct messages?
-        // if (threadIdx.x == 0 && blockIdx.x == 0) {
-        //    printf("message from %u: %u %u %u\n", message.getVariable<unsigned int>("index"), message.getX(), message.getY(), message.getZ());
-        // }
         count++;
     }
     FLAMEGPU->setVariable<unsigned int>("message_read", count);


### PR DESCRIPTION
For all 3 forms of Array message

Add alternative not-wrapped iterator which has no restriction on size, it simply clamps if radius exceeds the boundary.
Update existing wrapped iterator, to be behind `wrap()` rather than `operator()()`, and to throw an error for dim/rad combinations that would lead to double message reads.

Updated existing tests and added a bunch of new ones.