### PR TITLE
Post namespaces-improvements

### DIFF
--- a/include/flamegpu/exception/FLAMEGPUException.h
+++ b/include/flamegpu/exception/FLAMEGPUException.h
@@ -13,7 +13,7 @@ namespace exception {
  * If this macro is used instead of 'throw', FLAMEGPUException will 
  * prepend '__FILE__ (__LINE__): ' to err_message 
  */
-#define THROW exception::FLAMEGPUException::setLocation(__FILE__, __LINE__); throw
+#define THROW flamegpu::exception::FLAMEGPUException::setLocation(__FILE__, __LINE__); throw
 
 /*! Class for unknown exceptions thrown*/
 class UnknownError : public std::exception {};

--- a/include/flamegpu/gpu/detail/CUDAErrorChecking.cuh
+++ b/include/flamegpu/gpu/detail/CUDAErrorChecking.cuh
@@ -1,8 +1,6 @@
 #ifndef INCLUDE_FLAMEGPU_GPU_DETAIL_CUDAERRORCHECKING_CUH_
 #define INCLUDE_FLAMEGPU_GPU_DETAIL_CUDAERRORCHECKING_CUH_
 
-// #include <device_launch_parameters.h>
-// #include <cuda_runtime.h>
 #include <cuda.h>
 
 #include <string>

--- a/include/flamegpu/runtime/messaging/BruteForce/BruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/BruteForce/BruteForceHost.h
@@ -1,9 +1,6 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_BRUTEFORCE_BRUTEFORCEHOST_H_
 #define INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_BRUTEFORCE_BRUTEFORCEHOST_H_
 
-// TODO: This should *not* be required in a .h file. Need to separate concerns between c++ and CUDA.
-#include <device_launch_parameters.h>
-
 #include <typeindex>
 #include <memory>
 #include <unordered_map>

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -2,6 +2,7 @@
 #define INCLUDE_FLAMEGPU_RUNTIME_UTILITY_HOSTENVIRONMENT_CUH_
 
 #include <cuda_runtime.h>
+#include <device_launch_parameters.h>  // Required for SEATBELTS=OFF builds for some reason.
 
 #include <unordered_map>
 #include <array>


### PR DESCRIPTION
+ Fixes the use of the `THROW` macro outside of the `flamegpu` namespace (used in ratesetter)
+ `#include` fix for `SEATBELTS=OFF` builds
    + `#include <device_launch_parameters.h>` is required in `HostEnvironment.cuh` when SEATBELTS is off. This doesn't make a huge amount of sense, but it fixes the problem.


Will merge once CI approves.