### PR TITLE
Known issue, cub error checking and cub version bump.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Only documentation can be built without the required dependencies (however Doxyg
 + CMake 3.16 has known issues on some platforms.
 + Python <= 3.5 may encounter issues with dependency installation such as setuptools. If so, please manually install the correct version.
   + i.e. `python3 -m pip install --upgrade 'setuptools; python_version >= "3.6"' 'setuptools<51.3.0; python_version < "3.6" and python_version >= "3.0"'`
++ Debug builds under linux with CUDA 11.0 may encounter cuda errors during `validateIDCollisions`. Consider using an alternate CUDA version if this is required. See [FLAMEGPU/FLAMEGPU2#569](https://github.com/FLAMEGPU/FLAMEGPU2/issues/569)
 
 
 ### Building FLAME GPU 2

--- a/cmake/Thrust.cmake
+++ b/cmake/Thrust.cmake
@@ -18,7 +18,7 @@ cmake_policy(SET CMP0079 NEW)
 # Once https://github.com/NVIDIA/thrust/issues/1294 is resolved (CUDA 11.2?) Then we can attempt to find the CUDA distributed version of thrust, and use that if it is atleast the supported version 
 # (This will prevent us having to track the CUDA release version explicitly in the future. )
 
-set(THRUST_DOWNLOAD_VERSION 1.10.0)
+set(THRUST_DOWNLOAD_VERSION 1.13.0)
 
 FetchContent_Declare(
     thrust

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -254,13 +254,13 @@ void CUDAAgent::validateIDCollisions() const {
     gpuErrchkLaunch();
     // Check whether any flags were set
     size_t temp_storage_bytes2 = 0;
-    cub::DeviceReduce::Sum(nullptr, temp_storage_bytes2, d_keysIn, d_keysOut, agentCount - 1);
+    gpuErrchk(cub::DeviceReduce::Sum(nullptr, temp_storage_bytes2, d_keysIn, d_keysOut, agentCount - 1));
     if (temp_storage_bytes2 > temp_storage_bytes) {
         gpuErrchk(cudaFree(d_temp_storage));
         temp_storage_bytes = temp_storage_bytes2;
         gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytes));
     }
-    cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_keysIn, d_keysOut, agentCount - 1);
+    gpuErrchk(cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_keysIn, d_keysOut, agentCount - 1));
     id_t flagsSet = 0;
     gpuErrchk(cudaMemcpy(&flagsSet, d_keysOut, sizeof(id_t), cudaMemcpyDeviceToHost));
     // Cleanup


### PR DESCRIPTION
+ Adds some missing gpuErrchk for cub calls. 
+ Updates cub to 1.13.0. Tested using CUDA 10.0 under linux to ensure old versions have not been harmed.
+ Adds a known issue with CUDA 11.0 debug builds to the readme. Closes #569.