### PR TITLE
Fix linting from standalone examples

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -333,6 +333,12 @@ endif()
 # Define a function to add a lint target.
 find_file(CPPLINT NAMES cpplint cpplint.exe)
 if(CPPLINT)
+    # Create the all_lint meta target if it does not exist
+    if(NOT TARGET all_lint)
+        add_custom_target(all_lint)
+        set_target_properties(all_lint PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endif()
+    # Define a cmake function for adding a new lint target.
     function(new_linter_target NAME SRC)
         cmake_parse_arguments(
             NEW_LINTER_TARGET
@@ -346,31 +352,44 @@ if(CPPLINT)
         foreach(EXCLUDE_FILTER ${NEW_LINTER_TARGET_EXCLUDE_FILTERS})
             list(FILTER SRC EXCLUDE REGEX "${EXCLUDE_FILTER}")
         endforeach()
-        # Add custom target for linting this
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            # Output in visual studio format
-            add_custom_target(
-                "lint_${NAME}"
-                COMMAND ${CPPLINT} "--output" "vs7"
-                ${SRC}
-            )
-        else()
-            # Output in default format
-            add_custom_target(
-                "lint_${NAME}"
-                COMMAND ${CPPLINT}
-                ${SRC}
-            )
+
+        # Build a list of arguments to pass to CPPLINT
+        LIST(APPEND CPPLINT_ARGS "")
+
+        # Specify output format for msvc highlighting
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            LIST(APPEND CPPLINT_ARGS "--output" "vs7")
         endif()
+        # Set the --repository argument if included as a sub project.
+        if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+            # Use find the repository root via git, to pass to cpplint.
+            execute_process(COMMAND git rev-parse --show-toplevel
+            WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+            RESULT_VARIABLE git_repo_found
+            OUTPUT_VARIABLE abs_repo_root
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+            if(git_repo_found EQUAL 0)
+                LIST(APPEND CPPLINT_ARGS "--repository=${abs_repo_root}")
+            endif()
+        endif()
+        # Add the lint_ target
+        add_custom_target(
+            "lint_${PROJECT_NAME}"
+            COMMAND ${CPPLINT} ${CPPLINT_ARGS}
+            ${SRC}
+        )
+
         # Don't trigger this target on ALL_BUILD or Visual Studio 'Rebuild Solution'
         set_target_properties("lint_${NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
-        # set_target_properties("lint_${NAME}" PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE #This breaks all_lint in visual studio
         # Add the custom target as a dependency of the global lint target
         if(TARGET all_lint)
             add_dependencies(all_lint lint_${NAME})
         endif()
         # Put within Lint filter
-        CMAKE_SET_TARGET_FOLDER("lint_${NAME}" "Lint")
+        if (CMAKE_USE_FOLDERS)
+            set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+            set_property(TARGET "lint_${PROJECT_NAME}" PROPERTY FOLDER "Lint")
+        endif ()
     endfunction()
 else()
     # Don't create this message multiple times


### PR DESCRIPTION
This uses git to find the root of the standalone repository, which cpplint was not correctly finding
because _deps/flamegpu2-src is not a parent of _deps/flamegpu2-build or build/ depending on standalone example cmake differences

Closes #478