### PR TITLE
Rtc glm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ option(BUILD_FLAMEGPU "Enable building FLAMEGPU library" ON)
 
 # Option to enable/disable building the static library
 option(VISUALISATION "Enable visualisation support" OFF)
+
 if(NOT NO_EXAMPLES)
     # Option to enable building all examples
     option(BUILD_ALL_EXAMPLES "Enable building examples" ON)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -18,6 +18,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/Thrust.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/Jitify.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/Tinyxml2.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/rapidjson.cmake)
+if(USE_GLM)
+include(${CMAKE_CURRENT_LIST_DIR}/glm.cmake)
+endif()
 
 # Common rules for other cmake files
 # Don't create installation scripts (and hide CMAKE_INSTALL_PREFIX from cmake-gui)
@@ -332,6 +335,16 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
                     $<TARGET_FILE_DIR:${NAME}>)
         endif()
         add_compile_definitions(VISUALISATION)
+    
+        # Make GLM accessible via include
+        if (USE_GLM)
+            if(glm_FOUND)
+                target_include_directories(${NAME} PUBLIC "${glm_INCLUDE_DIRS}")
+            else()
+                message(WARNING "USE_GLM enabled, but glm_FOUND is False.")
+            endif()
+            add_compile_definitions(USE_GLM)
+        endif()
     endif()
     
     # Pass the SEATBELTS macro, which when set to off/0 (for non debug builds) removes expensive operations.
@@ -393,7 +406,18 @@ function(add_flamegpu_library NAME SRC FLAMEGPU_ROOT)
         CMAKE_SET_TARGET_FOLDER(flamegpu2_visualiser "FLAMEGPU")
         add_compile_definitions(VISUALISATION)
         # set(SDL2_DIR ${VISUALISATION_BUILD}/sdl2)
-        # find_package(SDL2 REQUIRED)   
+        # find_package(SDL2 REQUIRED)
+
+        # Make the visualisers GLM accessible via include
+        if (USE_GLM)
+            if(glm_FOUND)
+                target_include_directories(${NAME} PUBLIC "${glm_INCLUDE_DIRS}")
+                add_compile_definitions(GLM_PATH="${glm_INCLUDE_DIRS}")
+            else()
+                message(WARNING "USE_GLM enabled, but glm_FOUND is False.")
+            endif()
+            add_compile_definitions(USE_GLM)
+        endif()   
     endif()
     
     # Pass the SEATBELTS macro, which when set to off/0 (for non debug builds) removes expensive operations.

--- a/cmake/glm.cmake
+++ b/cmake/glm.cmake
@@ -1,0 +1,22 @@
+#######
+# glm #
+#######
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
+include(FetchContent)
+
+# Head of master at point BugFix for NVRTC support was merged
+FetchContent_Declare(
+    glm
+    URL            "https://github.com/g-truc/glm/archive/66062497b104ca7c297321bd0e970869b1e6ece5.zip"
+)
+FetchContent_GetProperties(glm)
+if(NOT glm_POPULATED)
+    FetchContent_Populate(glm)
+    # glm CMake wants to generate the find file in a system location, so handle it manually
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${glm_SOURCE_DIR}")
+endif()
+if (NOT glm_FOUND)
+    find_package(glm REQUIRED)
+    # Include path is ${glm_INCLUDE_DIRS}
+endif()

--- a/cmake/modules/Findglm.cmake
+++ b/cmake/modules/Findglm.cmake
@@ -1,0 +1,39 @@
+# CMake module to find glm headers/library
+# 
+# Very basic.
+#
+# Usage:
+#    find_package( glm )
+#    if(glm_FOUND)
+#        include_directories(${glm_INCLUDE_DIRS})
+#    endif()
+#
+# Variables:
+#    glm_FOUND
+#    glm_INCLUDE_DIRS
+#    glm_VERSION
+#
+# Manually specify glm paths via -Dglm_ROOT=/path/to/glm
+
+include(FindPackageHandleStandardArgs)
+
+# Find the main Jitify header
+find_path(glm_INCLUDE_DIRS
+    NAMES
+        glm/glm.hpp
+)
+
+# if found, get the version number.
+if(glm_INCLUDE_DIRS)
+    # glm nolonger has official releases, so there isn't a way to detect a version
+    set(glm_VERSION "VERSION_UNKNOWN")
+endif()
+# Apply standard cmake find package rules / variables. I.e. QUIET, glm_FOUND etc.
+# Outside the if, so REQUIRED works.
+find_package_handle_standard_args(glm
+    REQUIRED_VARS glm_INCLUDE_DIRS
+    VERSION_VAR glm_VERSION
+)
+
+# Set returned values as advanced?
+mark_as_advanced(glm_INCLUDE_DIRS glm_VERSION)

--- a/include/flamegpu/flamegpu.h
+++ b/include/flamegpu/flamegpu.h
@@ -1,6 +1,13 @@
 #ifndef INCLUDE_FLAMEGPU_FLAMEGPU_H_
 #define INCLUDE_FLAMEGPU_FLAMEGPU_H_
 
+#ifdef USE_GLM
+#ifdef __CUDACC__
+#pragma diag_suppress = esa_on_defaulted_function_ignored
+#endif
+#include <glm/glm.hpp>
+#endif
+
 // include all host API classes (top level header from each module)
 #include "flamegpu/version.h"
 #include "flamegpu/runtime/HostAPI.h"

--- a/include/flamegpu/runtime/DeviceAPI.cuh
+++ b/include/flamegpu/runtime/DeviceAPI.cuh
@@ -54,25 +54,26 @@ class ReadOnlyDeviceAPI {
     /**
      * Returns the specified variable from the currently executing agent
      * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
-     * @tparam T Type of the agent variable property being accessed
+     * @tparam T Type of the agent variable being accessed
      * @tparam N Length of variable name, this should always be implicit if passing a string literal
      * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
      * @throws exception::DeviceError If T is not the type of variable 'name' within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N> __device__
-    T getVariable(const char(&variable_name)[N]);
+    T getVariable(const char(&variable_name)[N]) const;
     /**
      * Returns the specified variable array element from the currently executing agent
      * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
      * @param index Index of the element within the variable array to return
-     * @tparam T Type of the agent variable property being accessed
-     * @tparam N Length of variable_name, this should always be implicit if passing a string literal
+     * @tparam T Type of the agent variable being accessed
+     * @tparam N The length of the array variable, as set within the model description hierarchy
+     * @tparam M Length of variable_name, this should always be implicit if passing a string literal
      * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
      * @throws exception::DeviceError If T is not the type of variable 'name' within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M> __device__
-    T getVariable(const char(&variable_name)[M], const unsigned int &index);
+    T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
     /**
      * Returns the agent's unique identifier
      */
@@ -271,10 +272,10 @@ class DeviceAPI : public ReadOnlyDeviceAPI{
      * Sets an element of an array variable within the currently executing agent
      * @param variable_name The name of the array variable
      * @param index The index to set within the array variable
-     * @param value The value to set the element of the array velement
+     * @param value The value to set the element of the array element
      * @tparam T The type of the variable, as set within the model description hierarchy
      * @tparam N The length of the array variable, as set within the model description hierarchy
-     * @tparam M variable_namelength, this should be ignored as it is implicitly set
+     * @tparam M variable_name length, this should be ignored as it is implicitly set
      * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
      * @throws exception::DeviceError If T is not the type of variable 'name' within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
@@ -300,7 +301,7 @@ class DeviceAPI : public ReadOnlyDeviceAPI{
 /******************************************************************************************************* Implementation ********************************************************/
 
 template<typename T, unsigned int N>
-__device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[N]) {
+__device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[N]) const {
     // simple indexing assumes index is the thread number (this may change later)
     const unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
@@ -323,7 +324,7 @@ __device__ void DeviceAPI<MsgIn, MsgOut>::setVariable(const char(&variable_name)
     detail::curve::Curve::setAgentVariable<T>(variable_name, agent_func_name_hash,  value, index);
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[M], const unsigned int &array_index) {
+__device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[M], const unsigned int &array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
     const unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 

--- a/include/flamegpu/runtime/DeviceAPI.cuh
+++ b/include/flamegpu/runtime/DeviceAPI.cuh
@@ -18,6 +18,13 @@
 #include "flamegpu/runtime/AgentFunctionCondition.cuh"
 #include "flamegpu/defines.h"
 
+#ifdef USE_GLM
+#ifdef __CUDACC__
+#pragma diag_suppress = esa_on_defaulted_function_ignored
+#endif
+#include <glm/glm.hpp>
+#endif
+
 namespace flamegpu {
 
 /**
@@ -334,7 +341,6 @@ __device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[M], const
     // return the variable from curve
     return value;
 }
-
 template<typename MsgIn, typename MsgOut>
 template<typename T, unsigned int N, unsigned int M>
 __device__ void DeviceAPI<MsgIn, MsgOut>::setVariable(const char(&variable_name)[M], const unsigned int &array_index, const T &value) {

--- a/include/flamegpu/runtime/detail/curve/curve.cuh
+++ b/include/flamegpu/runtime/detail/curve/curve.cuh
@@ -289,6 +289,21 @@ class Curve {
     template <typename T, unsigned int N, unsigned int M>
     __device__ __forceinline__ static T getAgentArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, unsigned int variable_index, unsigned int array_index);
     /**
+     * This forwards directly to Curve::getArrayVariable(const char(&variableName)[N], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index)
+     *
+     * The proxy method allows RTC's dynamic Curve headers to remove otherwise redundant branches when accessing agent variables
+     * @param variableName A constant char array (C string) variable name.
+     * @param namespace_hash Curve namespace hash for the variable
+     * @param variable_index The index of the variable in the named variable vector. This corresponds to the agent's index within the agent population.
+     * @param array_index The index of the element in the named variable array.
+     * @tparam T Type of the variable (This should be type of an element, if variable is an array).
+     * @tparam N Length of the array variable specified by variableName
+     * @tparam M Length of variableName, this should always be implicit if passing a string literal
+     * @see Curve::getArrayVariable(const char(&variableName)[N], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index)
+     */
+    template <typename T, unsigned int N, unsigned int M>
+    __device__ __forceinline__ static T getMessageArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, unsigned int variable_index, unsigned int array_index);
+    /**
      * This forwards directly to Curve::getArrayVariable_ldg(const char(&variableName)[N], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index)
      *
      * The proxy method allows RTC's dynamic Curve headers to remove otherwise redundant branches when accessing agent variables
@@ -303,6 +318,21 @@ class Curve {
      */
     template <typename T, unsigned int N, unsigned int M>
     __device__ __forceinline__ static T getAgentArrayVariable_ldg(const char(&variableName)[M], VariableHash namespace_hash, unsigned int variable_index, unsigned int array_index);
+    /**
+     * This forwards directly to Curve::getArrayVariable_ldg(const char(&variableName)[N], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index)
+     *
+     * The proxy method allows RTC's dynamic Curve headers to remove otherwise redundant branches when accessing agent variables
+     * @param variableName A constant char array (C string) variable name.
+     * @param namespace_hash Curve namespace hash for the variable
+     * @param variable_index The index of the variable in the named variable vector. This corresponds to the agent's index within the agent population.
+     * @param array_index The index of the element in the named variable array.
+     * @tparam T Type of the variable (This should be type of an element, if variable is an array).
+     * @tparam N Length of the array variable specified by variableName
+     * @tparam M Length of variableName, this should always be implicit if passing a string literal
+     * @see Curve::getArrayVariable_ldg(const char(&variableName)[N], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index)
+     */
+    template <typename T, unsigned int N, unsigned int M>
+    __device__ __forceinline__ static T getMessageArrayVariable_ldg(const char(&variableName)[M], VariableHash namespace_hash, unsigned int variable_index, unsigned int array_index);
     /**
      * Device function for setting a single typed value from a VariableHash
      *
@@ -389,6 +419,23 @@ class Curve {
      */
     template <typename T, unsigned int N, unsigned int M>
     __device__ __forceinline__ static void setAgentArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, T variable, unsigned int variable_index, unsigned int array_index);
+    /**
+     * This forwards directly to Curve::setArrayVariable(const char(&variableName)[N], VariableHash namespace_hash, T variable, unsigned int agent_index, unsigned int array_index)
+     *
+     * The proxy method allows RTC's dynamic Curve headers to remove otherwise redundant branches when accessing agent variables
+     * @param variableName A constant char array (C string) variable name.
+     * @param namespace_hash Curve namespace hash for the variable
+     * @param variable The value to set the specified variable
+     * @param variable_index The index of the variable in the named variable vector. This corresponds to the agent's index within the agent population.
+     * @param array_index The index of the element in the named variable array.
+     * @tparam T Type of the variable (This should be type of an element, if variable is an array).
+     * @tparam N Length of the array variable specified by variableName
+     * @tparam M Length of variableName, this should always be implicit if passing a string literal
+     *
+     * @see Curve::setArrayVariable(const char(&variableName)[N], VariableHash namespace_hash, T variable, unsigned int agent_index, unsigned int array_index)
+     */
+    template <typename T, unsigned int N, unsigned int M>
+    __device__ __forceinline__ static void setMessageArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, T variable, unsigned int variable_index, unsigned int array_index);
     /**
      * This forwards directly to Curve::setArrayVariable(const char(&variableName)[N], VariableHash namespace_hash, T variable, unsigned int agent_index, unsigned int array_index)
      *
@@ -833,6 +880,10 @@ __device__ __forceinline__ T Curve::getAgentArrayVariable(const char(&variableNa
     return getArrayVariable<T, N>(variableName, namespace_hash, agent_index, array_index);
 }
 template <typename T, unsigned int N, unsigned int M>
+__device__ __forceinline__ T Curve::getMessageArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, unsigned int message_index, unsigned int array_index) {
+    return getArrayVariable<T, N>(variableName, namespace_hash, message_index, array_index);
+}
+template <typename T, unsigned int N, unsigned int M>
 __device__ __forceinline__ T Curve::getArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index) {
     VariableHash variable_hash = variableHash(variableName);
 #if !defined(SEATBELTS) || SEATBELTS
@@ -856,6 +907,10 @@ __device__ __forceinline__ T Curve::getArrayVariable(const char(&variableName)[M
 template <typename T, unsigned int N, unsigned int M>
 __device__ __forceinline__ T Curve::getAgentArrayVariable_ldg(const char(&variableName)[M], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index) {
     return getArrayVariable_ldg<T, N>(variableName, namespace_hash, agent_index, array_index);
+}
+template <typename T, unsigned int N, unsigned int M>
+__device__ __forceinline__ T Curve::getMessageArrayVariable_ldg(const char(&variableName)[M], VariableHash namespace_hash, unsigned int message_index, unsigned int array_index) {
+    return getArrayVariable_ldg<T, N>(variableName, namespace_hash, message_index, array_index);
 }
 template <typename T, unsigned int N, unsigned int M>
 __device__ __forceinline__ T Curve::getArrayVariable_ldg(const char(&variableName)[M], VariableHash namespace_hash, unsigned int agent_index, unsigned int array_index) {
@@ -935,6 +990,10 @@ __device__ __forceinline__ void Curve::setVariable(const char(&variableName)[N],
 template <typename T, unsigned int N, unsigned int M>
 __device__ __forceinline__ void Curve::setAgentArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, T variable, unsigned int agent_index, unsigned int array_index) {
     setArrayVariable<T, N>(variableName, namespace_hash, variable, agent_index, array_index);
+}
+template <typename T, unsigned int N, unsigned int M>
+__device__ __forceinline__ void Curve::setMessageArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, T variable, unsigned int message_index, unsigned int array_index) {
+    setArrayVariable<T, N>(variableName, namespace_hash, variable, message_index, array_index);
 }
 template <typename T, unsigned int N, unsigned int M>
 __device__ __forceinline__ void Curve::setNewAgentArrayVariable(const char(&variableName)[M], VariableHash namespace_hash, T variable, unsigned int agent_index, unsigned int array_index) {

--- a/include/flamegpu/runtime/messaging/Array/ArrayDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Array/ArrayDevice.cuh
@@ -65,6 +65,19 @@ class MsgArray::In {
         */
         template<typename T, unsigned int N>
         __device__ T getVariable(const char(&variable_name)[N]) const;
+        /**
+         * Returns the specified variable array element from the current message attached to the named variable
+         * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+         * @param index Index of the element within the variable array to return
+         * @tparam T Type of the message variable being accessed
+         * @tparam N The length of the array variable, as set within the model description hierarchy
+         * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+         * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+         * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+         * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+         */
+        template<typename T, MsgNone::size_type N, unsigned int M>
+        __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
     };
     /**
      * This class is created when a search origin is provided to MsgArray::In::operator()(size_type, size_type, size_type = 1)
@@ -144,6 +157,19 @@ class MsgArray::In {
              */
             template<typename T, unsigned int N>
             __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MsgNone::size_type N, unsigned int M> __device__
+            T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
         };
         /**
          * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
@@ -320,6 +346,19 @@ class MsgArray::In {
              */
             template<typename T, unsigned int N>
             __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MsgNone::size_type N, unsigned int M>
+            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
         };
         /**
          * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
@@ -555,6 +594,20 @@ class MsgArray::Out {
      */
     template<typename T, unsigned int N>
     __device__ void setVariable(const char(&variable_name)[N], T value) const;
+    /**
+     * Sets an element of an array variable for this agents message
+     * @param variable_name The name of the array variable
+     * @param index The index to set within the array variable
+     * @param value The value to set the element of the array element
+     * @tparam T The type of the variable, as set within the model description hierarchy
+     * @tparam N The length of the array variable, as set within the model description hierarchy
+     * @tparam M variable_name length, this should be ignored as it is implicitly set
+     * @throws exception::DeviceError If name is not a valid variable within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+     * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+     * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+     */
+    template<typename T, unsigned int N, unsigned int M>
+    __device__ void setVariable(const char(&variable_name)[M], const unsigned int& index, T value) const;
 
  protected:
     /**
@@ -584,6 +637,20 @@ __device__ T MsgArray::In::Message::getVariable(const char(&variable_name)[N]) c
     // get the value from curve using the stored hashes and message index.
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgArray::In::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+    // simple indexing assumes index is the thread number (this may change later)
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index >= this->_parent.length) {
+        DTHROW("Invalid Array message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index, array_index);
+    return value;
+}
 template<typename T, unsigned int N>
 __device__ T MsgArray::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
@@ -595,6 +662,20 @@ __device__ T MsgArray::In::WrapFilter::Message::getVariable(const char(&variable
 #endif
     // get the value from curve using the stored hashes and message index.
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgArray::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+    // simple indexing assumes index is the thread number (this may change later)
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.length) {
+        DTHROW("Invalid Array message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index_1d, array_index);
+    return value;
 }
 template<typename T, unsigned int N>
 __device__ T MsgArray::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
@@ -608,6 +689,20 @@ __device__ T MsgArray::In::Filter::Message::getVariable(const char(&variable_nam
     // get the value from curve using the stored hashes and message index.
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
 }
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgArray::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+    // simple indexing assumes index is the thread number (this may change later)
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.length) {
+        DTHROW("Invalid Array message, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index_1d, array_index);
+    return value;
+}
 
 template<typename T, unsigned int N>
 __device__ void MsgArray::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
@@ -618,6 +713,18 @@ __device__ void MsgArray::Out::setVariable(const char(&variable_name)[N], T valu
 
     // set the variable using curve
     detail::curve::Curve::setMessageVariable<T>(variable_name, combined_hash, value, index);
+
+    // setIndex() sets the optional msg scan flag
+}
+template<typename T, unsigned int N, unsigned int M>
+__device__ void MsgArray::Out::setVariable(const char(&variable_name)[M], const unsigned int& array_index, T value) const {
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+
+    // set the variable using curve
+    detail::curve::Curve::setMessageArrayVariable<T, N>(variable_name, combined_hash, value, index, array_index);
 
     // setIndex() sets the optional msg scan flag
 }

--- a/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Array3D/Array3DDevice.cuh
@@ -67,6 +67,19 @@ class MsgArray3D::In {
          */
         template<typename T, size_type N>
         __device__ T getVariable(const char(&variable_name)[N]) const;
+        /**
+         * Returns the specified variable array element from the current message attached to the named variable
+         * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+         * @param index Index of the element within the variable array to return
+         * @tparam T Type of the message variable being accessed
+         * @tparam N The length of the array variable, as set within the model description hierarchy
+         * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+         * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+         * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+         * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+         */
+        template<typename T, MsgNone::size_type N, unsigned int M>
+        __device__ T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
     };
     /**
      * This class is created when a search origin is provided to MsgArray2D::In::operator()(size_type, size_type, size_type = 1)
@@ -165,6 +178,19 @@ class MsgArray3D::In {
              */
             template<typename T, unsigned int N>
             __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MsgNone::size_type N, unsigned int M>
+            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
         };
         /**
          * Stock iterator for iterating MsgSpatial3D::In::WrapFilter::Message objects
@@ -360,6 +386,19 @@ class MsgArray3D::In {
              */
             template<typename T, unsigned int N>
             __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MsgNone::size_type N, unsigned int M>
+            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
         };
         /**
          * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
@@ -624,6 +663,20 @@ class MsgArray3D::Out {
      */
     template<typename T, unsigned int N>
     __device__ void setVariable(const char(&variable_name)[N], T value) const;
+    /**
+     * Sets an element of an array variable for this agents message
+     * @param variable_name The name of the array variable
+     * @param index The index to set within the array variable
+     * @param value The value to set the element of the array element
+     * @tparam T The type of the variable, as set within the model description hierarchy
+     * @tparam N The length of the array variable, as set within the model description hierarchy
+     * @tparam M variable_name length, this should be ignored as it is implicitly set
+     * @throws exception::DeviceError If name is not a valid variable within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+     * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+     * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+     */
+    template<typename T, unsigned int N, unsigned int M>
+    __device__ void setVariable(const char(&variable_name)[M], const unsigned int& index, T value) const;
 
  protected:
     /**
@@ -653,6 +706,20 @@ __device__ T MsgArray3D::In::Message::getVariable(const char(&variable_name)[N])
     // get the value from curve using the stored hashes and message index.
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
 }
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgArray3D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+    // simple indexing assumes index is the thread number (this may change later)
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
+        return {};
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index, array_index);
+    return value;
+}
 template<typename T, unsigned int N>
 __device__ T MsgArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
 #if !defined(SEATBELTS) || SEATBELTS
@@ -664,6 +731,20 @@ __device__ T MsgArray3D::In::WrapFilter::Message::getVariable(const char(&variab
 #endif
     // get the value from curve using the stored hashes and message index.
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
+}
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+    // simple indexing assumes index is the thread number (this may change later)
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
+        return {};
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index, array_index);
+    return value;
 }
 template<typename T, unsigned int N>
 __device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_name)[N]) const {
@@ -677,6 +758,20 @@ __device__ T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_n
     // get the value from curve using the stored hashes and message index.
     return detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index_1d);
 }
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgArray3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+    // simple indexing assumes index is the thread number (this may change later)
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (index_1d >= this->_parent.metadata->length) {
+        DTHROW("Invalid Array3D message, unable to get variable '%s'.\n", variable_name);
+        return {};
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index, array_index);
+    return value;
+}
 
 template<typename T, unsigned int N>
 __device__ void MsgArray3D::Out::setVariable(const char(&variable_name)[N], T value) const {  // message name or variable name
@@ -687,6 +782,18 @@ __device__ void MsgArray3D::Out::setVariable(const char(&variable_name)[N], T va
 
     // set the variable using curve
     detail::curve::Curve::setMessageVariable<T>(variable_name, combined_hash, value, index);
+
+    // setIndex() sets the optional msg scan flag
+}
+template<typename T, unsigned int N, unsigned int M>
+__device__ void MsgArray3D::Out::setVariable(const char(&variable_name)[M], const unsigned int& array_index, T value) const {
+    if (variable_name[0] == '_') {
+        return;  // Fail silently
+    }
+    unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
+
+    // set the variable using curve
+    detail::curve::Curve::setMessageArrayVariable<T, N>(variable_name, combined_hash, value, index, array_index);
 
     // setIndex() sets the optional msg scan flag
 }

--- a/include/flamegpu/runtime/messaging/Bucket/BucketDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Bucket/BucketDevice.cuh
@@ -77,6 +77,19 @@ class MsgBucket::In {
             */
             template<typename T, size_type N>
             __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MsgNone::size_type N, unsigned int M> __device__
+            T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
         };
         /**
         * Stock iterator for iterating MsgBucket::In::Filter::Message objects
@@ -313,6 +326,19 @@ __device__ T MsgBucket::In::Filter::Message::getVariable(const char(&variable_na
 #endif
     // get the value from curve using the stored hashes and message index.
     T value = detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
+    return value;
+}
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgBucket::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (cell_index >= _parent.bucket_end) {
+        DTHROW("Bucket message index exceeds bin length, unable to get variable '%s'.\n", variable_name);
+        return {};
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, cell_index, array_index);
     return value;
 }
 }  // namespace flamegpu

--- a/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/Spatial3D/Spatial3DDevice.cuh
@@ -112,6 +112,19 @@ class MsgSpatial3D::In {
              */
             template<typename T, size_type N>
             __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MsgNone::size_type N, unsigned int M> __device__
+            T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
         };
         /**
          * Stock iterator for iterating MsgSpatial3D::In::Filter::Message objects
@@ -298,6 +311,19 @@ __device__ T MsgSpatial3D::In::Filter::Message::getVariable(const char(&variable
 #endif
     // get the value from curve using the stored hashes and message index.
     T value = detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, cell_index);
+    return value;
+}
+template<typename T, MsgNone::size_type N, unsigned int M> __device__
+T MsgSpatial3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (relative_cell[0] >= 2) {
+        DTHROW("MsgSpatial3D in invalid bin, unable to get variable '%s'.\n", variable_name);
+        return {};
+    }
+#endif
+    // get the value from curve using the stored hashes and message index.
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, cell_index, array_index);
     return value;
 }
 

--- a/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
@@ -92,8 +92,13 @@ __device__ __forceinline__ T DeviceEnvironment::getProperty(const char(&name)[N]
 #if !defined(SEATBELTS) || SEATBELTS
     if (cv ==  detail::curve::Curve::UNKNOWN_VARIABLE) {
         DTHROW("Environment property with name: %s was not found.\n", name);
+#if defined(USE_GLM)
+    } else if (detail::curve::detail::d_sizes[cv] * detail::curve::detail::d_lengths[cv] != sizeof(T)) {
+        DTHROW("Environment property with name: %s type size mismatch %llu != %llu.\n", name, detail::curve::detail::d_sizes[cv] * detail::curve::detail::d_lengths[cv], sizeof(T));
+#else
     } else if (detail::curve::detail::d_sizes[cv] != sizeof(T)) {
         DTHROW("Environment property with name: %s type size mismatch %llu != %llu.\n", name, detail::curve::detail::d_sizes[cv], sizeof(T));
+#endif
     } else {
         return *reinterpret_cast<T*>(detail::c_envPropBuffer + reinterpret_cast<ptrdiff_t>(detail::curve::detail::d_variables[cv]));
     }

--- a/include/flamegpu/visualiser/AgentVis.h
+++ b/include/flamegpu/visualiser/AgentVis.h
@@ -53,12 +53,84 @@ class AgentVis {
      * Set the name of the variable representing the agents x/y/z location coordinates
      * @param var_name Name of the agent variable
      * @note unnecessary if the variables are named "x", "y", "z" respectively
+     * @note Implicitly calls clearXYVariable(), clearXYZVariable()
+     * @throws InvalidAgentVar If the variable is not type float[1]
      */
     void setXVariable(const std::string &var_name);
     void setYVariable(const std::string &var_name);
     void setZVariable(const std::string &var_name);
     /**
-     * Set the name of the variable representing the agents x/y/z direction vector components
+     * Set the name of the array variable (length 2) representing the agents x/y location coordinates
+     * @param var_name Name of the agent variable
+     * @note Implicitly calls clearXVariable(),  clearYVariable(), clearZVariable(),clearXYZVariable()
+     * @throws InvalidAgentVar If the variable is not type float[2]
+     */
+    void setXYVariable(const std::string &var_name);
+    /**
+     * Set the name of the array variable (length 3) representing the agents x/y/z location coordinates
+     * @param var_name Name of the agent variable
+     * @note Implicitly calls clearXVariable(),  clearYVariable(), clearZVariable(),clearXYVariable()
+     * @throws InvalidAgentVar If the variable is not type float[3]
+     */
+    void setXYZVariable(const std::string &var_name);
+    /**
+     * Set the name of the variable representing the agents x direction vector components
+     * Single axis rotation only requires x/z components
+     * Double axis rotation requires all 3 components
+     * Triple axis rotation requires all 3 components and additionally all 3 Up components
+     * @param var_name Name of the agent variable
+     * @note setForwardXVariable() and setForwardZVariable() are an alternate to providing a yaw angle
+     * @see setYawVariable(const std::string&)
+     * @note Forward is a synonym for Direction
+     * @note Implicitly calls clearHeadingVariable(), clearForwardXZVariable(), clearForwardXYZVariable(),
+     * clearDirectionYPVariable(), clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[1]
+     */
+    void setForwardXVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents y direction vector components
+     * Single axis rotation only requires x/z components
+     * Double axis rotation requires all 3 components
+     * Triple axis rotation requires all 3 components and additionally all 3 Up components
+     * @param var_name Name of the agent variable
+     * @note setForwardYVariable() is an alternate to providing a pitch angle
+     * @see setPitchVariable(const std::string&)
+     * @note Forward is a synonym for Direction
+     * @note Implicitly calls clearPitchVariable(), clearForwardXYZVariable(), clearDirectionYPVariable(),
+     * clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[1]
+     */
+    void setForwardYVariable(const std::string& var_name);
+    /**
+     * Set the name of the variable representing the agents z direction vector components
+     * Single axis rotation only requires x/z components
+     * Double axis rotation requires all 3 components
+     * Triple axis rotation requires all 3 components and additionally all 3 Up components
+     * @param var_name Name of the agent variable
+     * @note setForwardXVariable() and setForwardZVariable() are an alternate to providing a yaw angle
+     * @see setYawVariable(const std::string&)
+     * @note Forward is a synonym for Direction
+     * @note Implicitly calls clearHeadingVariable(), clearForwardXZVariable(), clearForwardXYZVariable(),
+     * clearDirectionYPVariable(), clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[1]
+     */
+    void setForwardZVariable(const std::string& var_name);
+    /**
+     * Set the name of the array variable (length 2) representing the agents x/z direction vector components
+     * Single axis rotation only requires x/z components
+     * @param var_name Name of the agent variable
+     * @note setForwardXVariable() and setForwardZVariable() are an alternate to providing a yaw angle, setting either of these will erase yaw if bound
+     * @see setYawVariable(const std::string&)
+     * @note setForwardYVariable() is an alternate to providing a pitch angle, setting this will erase pitch if bound
+     * @see setPitchVariable(const std::string&)
+     * @note Forward is a synonym for Direction
+     * @note Implicitly calls clearHeadingVariable(), clearForwardXVariable(), clearForwardYVariable(),
+     * clearForwardZVariable(), clearForwardXYZVariable(),clearDirectionYPVariable(), clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[2]
+     */
+    void setForwardXZVariable(const std::string& var_name);
+    /**
+     * Set the name of the array variable (length 3) representing the agents x/y/z direction vector components
      * Single axis rotation only requires x/z components
      * Double axis rotation requires all 3 components
      * Triple axis rotation requires all 3 components and additionally all 3 Up components
@@ -68,20 +140,36 @@ class AgentVis {
      * @note setForwardYVariable() is an alternate to providing a pitch angle, setting this will erase pitch if bound
      * @see setPitchVariable(const std::string&)
      * @note Forward is a synonym for Direction
+     * @note Implicitly calls clearHeadingVariable(), clearForwardXVariable(), clearForwardYVariable(),
+     * clearForwardZVariable(), clearForwardXZVariable(),clearDirectionYPVariable(), clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[3]
      */
-    void setForwardXVariable(const std::string& var_name);
-    void setForwardYVariable(const std::string& var_name);
-    void setForwardZVariable(const std::string& var_name);
+    void setForwardXYZVariable(const std::string& var_name);
     /**
      * Set the name of the variable representing the agents x/y/z UP vector
      * This should be 90 degrees perpendicular to the direction vector
      * @param var_name Name of the agent variable
      * @note setUpXVariable(), setUpYVariable() and setUpZVariable() are an alternate to providing a roll angle, setting any of these will erase roll if bound
      * @see setRollVariable(const std::string&)
+     * @note Implicitly calls clearRollVariable(), clearUpXYZVariable(), clearDirectionYPRVariable()
+     * @note Up can only be used in combination with Forward x/y/z (and not Yaw, Pitch or directionYP)
+     * @throws InvalidAgentVar If the variable is not type float[1]
      */
     void setUpXVariable(const std::string& var_name);
     void setUpYVariable(const std::string& var_name);
     void setUpZVariable(const std::string& var_name);
+    /**
+     * Set the name of the array variable (length 3) representing the agents x/y/z UP vector
+     * This should be 90 degrees perpendicular to the direction vector
+     * @param var_name Name of the agent variable
+     * @note setUpXVariable(), setUpYVariable() and setUpZVariable() are an alternate to providing a roll angle, setting any of these will erase roll if bound
+     * @see setRollVariable(const std::string&)
+     * @note Implicitly calls clearRollVariable(), clearUpXVariable(), clearUpYVariable(), clearUpZVariable(),
+     * clearDirectionYPRVariable()
+     * @note Up can only be used in combination with Forward x/y/z (and not Yaw, Pitch or directionYP)
+     * @throws InvalidAgentVar If the variable is not type float[3]
+     */
+    void setUpXYZVariable(const std::string& var_name);
     /**
      * Set the name of the variable representing the agents yaw rotation angle (radians)
      *
@@ -89,7 +177,12 @@ class AgentVis {
      * @note This is an alternate to providing a direction vector, setting this will erase forward x/z if bound
      * @see setForwardXVariable(const std::string&)
      * @see setForwardZVariable(const std::string&)
+     * @see setDirectionYPVariable(const std::string&)
+     * @see setDirectionYPRVariable(const std::string&)
      * @note Heading is a synonym for Yaw
+     * @note Implicitly calls clearForwardXVariable(), clearForwardYVariable(), clearForwardZVariable(),
+     * clearForwardXYZVariable(), clearDirectionYPVariable(), clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[1]
      */
     void setYawVariable(const std::string& var_name);
     /**
@@ -98,6 +191,10 @@ class AgentVis {
      * @param var_name Name of the agent variable
      * @note This is an alternate to providing a direction vector, setting this will erase forward y if bound
      * @see setForwardYVariable(const std::string&)
+     * @see setDirectionYPVariable(const std::string&)
+     * @see setDirectionYPRVariable(const std::string&)
+     * @note Implicitly calls clearForwardYVariable(), clearForwardXYZVariable(), clearDirectionYPVariable(),
+     * clearDirectionYPRVariable()
      */
     void setPitchVariable(const std::string& var_name);
     /**
@@ -108,9 +205,42 @@ class AgentVis {
      * @see setUpXVariable(const std::string&)
      * @see setUpYVariable(const std::string&)
      * @see setUpZVariable(const std::string&)
+     * @see setDirectionYPRVariable(const std::string&)
      * @note Bank is a synonym for Roll
+     * @note Implicitly calls clearUpXVariable(), clearUpYVariable(), clearUpZVariable(), clearUpXYZVariable(),
+     * clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[1]
      */
     void setRollVariable(const std::string& var_name);
+    /**
+     * Set the name of the array variable (length 2) representing the agents yaw/pitch rotation angles (radians)
+     *
+     * @param var_name Name of the agent variable
+     * @note This is an alternate to providing a direction vector, setting this will erase forward x/z if bound
+     * @see setForwardXVariable(const std::string&)
+     * @see setForwardZVariable(const std::string&)
+     * @note Heading is a synonym for Yaw
+     * @note Implicitly calls clearForwardXVariable(), clearForwardYVariable(), clearForwardZVariable(),
+     * clearForwardXZVariable(), clearForwardXYZVariable(), clearHeadingVariable(), clearPitchVariable(),
+     * clearDirectionYPRVariable()
+     * @throws InvalidAgentVar If the variable is not type float[2]
+     */
+    void setDirectionYPVariable(const std::string& var_name);
+    /**
+     * Set the name of the array variable (length 3) representing the agents yaw/pitch/roll rotation angles (radians)
+     *
+     * @param var_name Name of the agent variable
+     * @note This is an alternate to providing a direction vector, setting this will erase forward x/z if bound
+     * @see setForwardXVariable(const std::string&)
+     * @see setForwardZVariable(const std::string&)
+     * @note Heading is a synonym for Yaw
+     * @note Bank is a synonym for Roll
+     * @note Implicitly calls clearForwardXVariable(), clearForwardYVariable(), clearForwardZVariable(),
+     * clearForwardXZVariable(), clearForwardXYZVariable(), clearUpXVariable(), clearUpYVariable(), clearUpZVariable(),
+     * clearUpXYZVariable(), clearHeadingVariable(), clearPitchVariable(), clearRollVariable(), clearDirectionYPVariable()
+     * @throws InvalidAgentVar If the variable is not type float[3]
+     */
+    void setDirectionYPRVariable(const std::string& var_name);
     /**
      * Set the name of the variable representing the agents uniform scale multiplier
      *
@@ -136,19 +266,58 @@ class AgentVis {
      * @see setUniformScaleVariable(const std::string&)
      * @see setModelScale(float)
      * @see setModelScale(float, float, float)
+     * @throws InvalidAgentVar If the variable is not type float[1]
      */
     void setScaleXVariable(const std::string& var_name);
     void setScaleYVariable(const std::string& var_name);
     void setScaleZVariable(const std::string& var_name);
     /**
+     * Set the name of the array variable (length 2) representing the agents x/y scale multiplier components
+     * It is not necessary to set all 3 components if only 1 or 2 are required. Unset values will be treated as a 1.0 multiplier
+     *
+     * The scale multiplier is multiplied by the model scale
+     *
+     * @param var_name Name of the agent variable
+     * @note This is an alternate to providing a single uniform scale multiplier, setting this will erase uniform scale or individual scale components if bound
+     * @see setUniformScaleVariable(const std::string&)
+     * @see setModelScale(float)
+     * @see setModelScale(float, float, float)
+     * @throws InvalidAgentVar If the variable is not type float[2]
+     */
+    void setScaleXYVariable(const std::string& var_name);
+    /**
+     * Set the name of the array variable (length 3) representing the agents x/y/z scale multiplier components
+     * It is not necessary to set all 3 components if only 1 or 2 are required. Unset values will be treated as a 1.0 multiplier
+     *
+     * The scale multiplier is multiplied by the model scale
+     *
+     * @param var_name Name of the agent variable
+     * @note This is an alternate to providing a single uniform scale multiplier, setting this will erase uniform scale or individual scale components if bound
+     * @see setUniformScaleVariable(const std::string&)
+     * @see setModelScale(float)
+     * @see setModelScale(float, float, float)
+     * @throws InvalidAgentVar If the variable is not type float[3]
+     */
+    void setScaleXYZVariable(const std::string& var_name);
+    /**
      * Clears the agent's x/y/z location variable bindings
-     * @see setXVariable(conCst std::string &)
-     * @see setYVariable(conCst std::string &)
-     * @see setZVariable(conCst std::string &)
+     * @see setXVariable(const std::string &)
+     * @see setYVariable(const std::string &)
+     * @see setZVariable(const std::string &)
      */
     void clearXVariable();
     void clearYVariable();
     void clearZVariable();
+    /**
+     * Clears the agent's xy location variable bindings
+     * @see setXYVariable(const std::string &)
+     */
+    void clearXYVariable();
+    /**
+     * Clears the agent's xyz location variable bindings
+     * @see setXYZVariable(const std::string &)
+     */
+    void clearXYZVariable();
     /**
      * Clears the agent's x/y/z forward variable bindings
      * @see setForwardXVariable(const std::string &)
@@ -159,6 +328,16 @@ class AgentVis {
     void clearForwardYVariable();
     void clearForwardZVariable();
     /**
+     * Clears the agent's xz forward variable bindings
+     * @see setForwardXZVariable(const std::string &)
+     */
+    void clearForwardXZVariable();
+    /**
+     * Clears the agent's xyz forward variable bindings
+     * @see setForwardXYZVariable(const std::string &)
+     */
+    void clearForwardXYZVariable();
+    /**
      * Clears the agent's x/y/z UP variable bindings
      * @see setUpXVariable(const std::string &)
      * @see setUpYVariable(const std::string &)
@@ -167,6 +346,11 @@ class AgentVis {
     void clearUpXVariable();
     void clearUpYVariable();
     void clearUpZVariable();
+    /**
+     * Clears the agent's xyz UP variable bindings
+     * @see setUpXYZVariable(const std::string &)
+     */
+    void clearUpXYZVariable();
     /**
      * Clears the agent's yaw angle variable bindings
      * @see setYawVariable(const std::string &)
@@ -183,6 +367,16 @@ class AgentVis {
      */
     void clearRollVariable();
     /**
+     * Clears the agent's yaw angle variable bindings
+     * @see setDirectionYPVariable(const std::string &)
+     */
+    void clearDirectionYPVariable();
+    /**
+     * Clears the agent's yaw angle variable bindings
+     * @see setDirectionYPRVariable(const std::string &)
+     */
+    void clearDirectionYPRVariable();
+    /**
      * Clears the agent's uniform scale multiplier variable bindings
      * @see setUniformScaleVariable(const std::string &)
      */
@@ -197,11 +391,29 @@ class AgentVis {
     void clearScaleYVariable();
     void clearScaleZVariable();
     /**
+     * Clears the agent's xy scale multiplier variable bindings
+     * @see setScaleXYVariable(const std::string &)
+     */
+    void clearScaleXYVariable();
+    /**
+     * Clears the agent's xyz scale multiplier variable bindings
+     * @see setScaleXYZVariable(const std::string &)
+     */
+    void clearScaleXYZVariable();
+    /**
      * Returns the variable used for the agent's x/y/z location coordinates
      */
     std::string getXVariable() const;
     std::string getYVariable() const;
     std::string getZVariable() const;
+    /**
+     * Returns the variable used for the agent's xy location coordinates
+     */
+    std::string getXYVariable() const;
+    /**
+     * Returns the variable used for the agent's xyz location coordinates
+     */
+    std::string getXYZVariable() const;
     /**
      * Returns the variable used for the agent's x/y/z forward vector components
      */
@@ -209,11 +421,23 @@ class AgentVis {
     std::string getForwardYVariable() const;
     std::string getForwardZVariable() const;
     /**
+     * Returns the variable used for the agent's xz forward vector components
+     */
+    std::string getForwardXZVariable() const;
+    /**
+     * Returns the variable used for the agent's xyz forward vector components
+     */
+    std::string getForwardXYZVariable() const;
+    /**
      * Returns the variable used for the agent's x/y/z up vector components
      */
     std::string getUpXVariable() const;
     std::string getUpYVariable() const;
     std::string getUpZVariable() const;
+    /**
+     * Returns the variable used for the agent's xyz up vector components
+     */
+    std::string getUpXYZVariable() const;
     /**
      * Returns the variable used for the agent's yaw angle
      */
@@ -227,6 +451,14 @@ class AgentVis {
      */
     std::string getRollVariable() const;
     /**
+     * Returns the variable used for the agent's roll angle
+     */
+    std::string getDirectionYPVariable() const;
+    /**
+     * Returns the variable used for the agent's roll angle
+     */
+    std::string getDirectionYPRVariable() const;
+    /**
      * Returns the variable used for the agent's uniform scaling multiplier
      */
     std::string getUniformScaleVariable() const;
@@ -236,6 +468,14 @@ class AgentVis {
     std::string getScaleXVariable() const;
     std::string getScaleYVariable() const;
     std::string getScaleZVariable() const;
+    /**
+     * Returns the variable used for the agent's xy scale multiplier components
+     */
+    std::string getScaleXYVariable() const;
+    /**
+     * Returns the variable used for the agent's xyz scale multiplier components
+     */
+    std::string getScaleXYZVariable() const;
 
     /**
      * Use a model from file

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,10 @@ option(SEATBELTS "Enable runtime checks which harm performance for release/profi
 # Option to enable/disable the default status of JitifyCache
 option(RTC_DISK_CACHE "Enable caching of RTC kernels to disk by default (this can still be overridden programatically)." ON)
 
+# Option to make put glm on the include path
+option(USE_GLM "Experimental: Make GLM available to flamegpu2 projects on the include path" OFF)
+mark_as_advanced(USE_GLM)
+
 # Include common rules.
 include(${FLAMEGPU_ROOT}/cmake/common.cmake)
 include(${FLAMEGPU_ROOT}/cmake/doxygen.cmake)

--- a/src/flamegpu/gpu/CUDAMessage.cu
+++ b/src/flamegpu/gpu/CUDAMessage.cu
@@ -111,7 +111,7 @@ void CUDAMessage::mapReadRuntimeVariables(const AgentFunctionData& func, const C
         detail::curve::Curve::VariableHash var_hash = detail::curve::Curve::getInstance().variableRuntimeHash(mmp.first.c_str());
 
         // get the message variable size
-        size_t size = mmp.second.type_size;
+        const size_t size = mmp.second.type_size * mmp.second.elements;
 
         if (func.func) {
             // maximum population size
@@ -162,7 +162,7 @@ void CUDAMessage::mapWriteRuntimeVariables(const AgentFunctionData& func, const 
         detail::curve::Curve::VariableHash var_hash = detail::curve::Curve::variableRuntimeHash(mmp.first.c_str());
 
         // get the message variable size
-        size_t size = mmp.second.type_size;
+        const size_t size = mmp.second.type_size * mmp.second.elements;
 
         if (func.func) {
             // maximum population size

--- a/src/flamegpu/util/detail/JitifyCache.cu
+++ b/src/flamegpu/util/detail/JitifyCache.cu
@@ -186,6 +186,14 @@ break_flamegpu_inc_dir_loop:
     // cuda include directory (via CUDA_PATH)
     options.push_back(std::string("-I" + env_cuda_path + "/include"));
 
+#ifdef USE_GLM
+    // GLM headers increase build time ~5x, so only enable glm if user is using it
+    if (kernel_src.find("glm") != std::string::npos) {
+        options.push_back(std::string("-I") + GLM_PATH);
+        options.push_back(std::string("-DUSE_GLM"));
+    }
+#endif
+
     // Set the compilation architecture target if it was successfully detected.
     int currentDeviceIdx = 0;
     cudaError_t status = cudaGetDevice(&currentDeviceIdx);

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -64,6 +64,8 @@ void AgentVis::setXVariable(const std::string &var_name) {
             "in AgentVis::setXVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Position_xy);
+    core_tex_buffers.erase(TexBufferConfig::Position_xyz);
     core_tex_buffers[TexBufferConfig::Position_x].agentVariableName = var_name;
 }
 void AgentVis::setYVariable(const std::string &var_name) {
@@ -77,6 +79,8 @@ void AgentVis::setYVariable(const std::string &var_name) {
             "in AgentVis::setYVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Position_xy);
+    core_tex_buffers.erase(TexBufferConfig::Position_xyz);
     core_tex_buffers[TexBufferConfig::Position_y].agentVariableName = var_name;
 }
 void AgentVis::setZVariable(const std::string &var_name) {
@@ -90,49 +94,135 @@ void AgentVis::setZVariable(const std::string &var_name) {
             "in AgentVis::setZVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
+    core_tex_buffers.erase(TexBufferConfig::Position_xy);
+    core_tex_buffers.erase(TexBufferConfig::Position_xyz);
     core_tex_buffers[TexBufferConfig::Position_z].agentVariableName = var_name;
+}
+void AgentVis::setXYVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setXYVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 2) {
+        THROW exception::InvalidAgentVar("Visualisation position x variable must be type float[2], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setXYVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Position_x);
+    core_tex_buffers.erase(TexBufferConfig::Position_y);
+    core_tex_buffers.erase(TexBufferConfig::Position_z);
+    core_tex_buffers.erase(TexBufferConfig::Position_xyz);
+    core_tex_buffers[TexBufferConfig::Position_xy].agentVariableName = var_name;
+}
+void AgentVis::setXYZVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setXYZVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 3) {
+        THROW exception::InvalidAgentVar("Visualisation position x variable must be type float[3], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setXYZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Position_x);
+    core_tex_buffers.erase(TexBufferConfig::Position_y);
+    core_tex_buffers.erase(TexBufferConfig::Position_z);
+    core_tex_buffers.erase(TexBufferConfig::Position_xy);
+    core_tex_buffers[TexBufferConfig::Position_xyz].agentVariableName = var_name;
 }
 void AgentVis::setForwardXVariable(const std::string& var_name) {
     auto it = agentData.variables.find(var_name);
     if (it == agentData.variables.end()) {
         THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
-            "in AgentVis::setDirectionXVariable()\n",
+            "in AgentVis::setForwardXVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
         THROW exception::InvalidAgentVar("Visualisation forward x variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
-            "in AgentVis::setDirectionXVariable()\n",
+            "in AgentVis::setForwardXVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Heading);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Forward_x].agentVariableName = var_name;
 }
 void AgentVis::setForwardYVariable(const std::string& var_name) {
     auto it = agentData.variables.find(var_name);
     if (it == agentData.variables.end()) {
         THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
-            "in AgentVis::setDirectionYVariable()\n",
+            "in AgentVis::setForwardYVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
         THROW exception::InvalidAgentVar("Visualisation forward y variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
-            "in AgentVis::setDirectionYVariable()\n",
+            "in AgentVis::setForwardYVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Pitch);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Forward_y].agentVariableName = var_name;
 }
 void AgentVis::setForwardZVariable(const std::string& var_name) {
     auto it = agentData.variables.find(var_name);
     if (it == agentData.variables.end()) {
         THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
-            "in AgentVis::setDirectionZVariable()\n",
+            "in AgentVis::setForwardZVariable()\n",
             var_name.c_str(), agentData.name.c_str());
     } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 1) {
         THROW exception::InvalidAgentVar("Visualisation forward z variable must be type float[1], agent '%s' variable '%s' is type %s[%u], "
-            "in AgentVis::setDirectionZVariable()\n",
+            "in AgentVis::setForwardZVariable()\n",
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Heading);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Forward_z].agentVariableName = var_name;
+}
+void AgentVis::setForwardXZVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setForwardXZVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 2) {
+        THROW exception::InvalidAgentVar("Visualisation forward xz variable must be type float[2], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setForwardXZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Heading);
+    core_tex_buffers.erase(TexBufferConfig::Forward_x);
+    core_tex_buffers.erase(TexBufferConfig::Forward_y);
+    core_tex_buffers.erase(TexBufferConfig::Forward_z);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
+    core_tex_buffers[TexBufferConfig::Forward_xz].agentVariableName = var_name;
+}
+void AgentVis::setForwardXYZVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setForwardXYZVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 3) {
+        THROW exception::InvalidAgentVar("Visualisation forward xyz variable must be type float[2], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setForwardXYZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Heading);
+    core_tex_buffers.erase(TexBufferConfig::Forward_x);
+    core_tex_buffers.erase(TexBufferConfig::Forward_z);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
+    core_tex_buffers[TexBufferConfig::Forward_xyz].agentVariableName = var_name;
 }
 void AgentVis::setUpXVariable(const std::string& var_name) {
     auto it = agentData.variables.find(var_name);
@@ -146,6 +236,8 @@ void AgentVis::setUpXVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Bank);
+    core_tex_buffers.erase(TexBufferConfig::Up_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Up_x].agentVariableName = var_name;
 }
 void AgentVis::setUpYVariable(const std::string& var_name) {
@@ -160,6 +252,8 @@ void AgentVis::setUpYVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Bank);
+    core_tex_buffers.erase(TexBufferConfig::Up_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Up_y].agentVariableName = var_name;
 }
 void AgentVis::setUpZVariable(const std::string& var_name) {
@@ -174,7 +268,27 @@ void AgentVis::setUpZVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Bank);
+    core_tex_buffers.erase(TexBufferConfig::Up_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Up_z].agentVariableName = var_name;
+}
+void AgentVis::setUpXYZVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setUpXYZVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 3) {
+        THROW exception::InvalidAgentVar("Visualisation up xyz variable must be type float[3], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setUpXYZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Bank);
+    core_tex_buffers.erase(TexBufferConfig::Up_x);
+    core_tex_buffers.erase(TexBufferConfig::Up_y);
+    core_tex_buffers.erase(TexBufferConfig::Up_z);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
+    core_tex_buffers[TexBufferConfig::Up_xyz].agentVariableName = var_name;
 }
 void AgentVis::setYawVariable(const std::string& var_name) {
     auto it = agentData.variables.find(var_name);
@@ -189,6 +303,10 @@ void AgentVis::setYawVariable(const std::string& var_name) {
     }
     core_tex_buffers.erase(TexBufferConfig::Forward_x);
     core_tex_buffers.erase(TexBufferConfig::Forward_z);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Heading].agentVariableName = var_name;
 }
 void AgentVis::setPitchVariable(const std::string& var_name) {
@@ -203,6 +321,9 @@ void AgentVis::setPitchVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::Forward_y);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Pitch].agentVariableName = var_name;
 }
 void AgentVis::setRollVariable(const std::string& var_name) {
@@ -219,7 +340,54 @@ void AgentVis::setRollVariable(const std::string& var_name) {
     core_tex_buffers.erase(TexBufferConfig::Up_x);
     core_tex_buffers.erase(TexBufferConfig::Up_y);
     core_tex_buffers.erase(TexBufferConfig::Up_z);
+    core_tex_buffers.erase(TexBufferConfig::Up_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
     core_tex_buffers[TexBufferConfig::Bank].agentVariableName = var_name;
+}
+void AgentVis::setDirectionYPVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setDirectionYPVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 2) {
+        THROW exception::InvalidAgentVar("Visualisation direction yaw/pitch variable must be type float[2], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setDirectionYPVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Forward_x);
+    core_tex_buffers.erase(TexBufferConfig::Forward_z);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Heading);
+    core_tex_buffers.erase(TexBufferConfig::Pitch);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
+    core_tex_buffers[TexBufferConfig::Heading].agentVariableName = var_name;
+}
+void AgentVis::setDirectionYPRVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setDirectionYPRVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 3) {
+        THROW exception::InvalidAgentVar("Visualisation direction yaw/pitch/roll variable must be type float[3], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setDirectionYPRVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::Forward_x);
+    core_tex_buffers.erase(TexBufferConfig::Forward_z);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Up_x);
+    core_tex_buffers.erase(TexBufferConfig::Up_y);
+    core_tex_buffers.erase(TexBufferConfig::Up_z);
+    core_tex_buffers.erase(TexBufferConfig::Up_xyz);
+    core_tex_buffers.erase(TexBufferConfig::Heading);
+    core_tex_buffers.erase(TexBufferConfig::Pitch);
+    core_tex_buffers.erase(TexBufferConfig::Bank);
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+    core_tex_buffers[TexBufferConfig::Heading].agentVariableName = var_name;
 }
 void AgentVis::setUniformScaleVariable(const std::string& var_name) {
     auto it = agentData.variables.find(var_name);
@@ -235,6 +403,8 @@ void AgentVis::setUniformScaleVariable(const std::string& var_name) {
     core_tex_buffers.erase(TexBufferConfig::Scale_x);
     core_tex_buffers.erase(TexBufferConfig::Scale_y);
     core_tex_buffers.erase(TexBufferConfig::Scale_z);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xy);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xyz);
     core_tex_buffers[TexBufferConfig::UniformScale].agentVariableName = var_name;
 }
 void AgentVis::setScaleXVariable(const std::string& var_name) {
@@ -249,6 +419,8 @@ void AgentVis::setScaleXVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xy);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xyz);
     core_tex_buffers[TexBufferConfig::Scale_x].agentVariableName = var_name;
 }
 void AgentVis::setScaleYVariable(const std::string& var_name) {
@@ -263,6 +435,8 @@ void AgentVis::setScaleYVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xy);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xyz);
     core_tex_buffers[TexBufferConfig::Scale_y].agentVariableName = var_name;
 }
 void AgentVis::setScaleZVariable(const std::string& var_name) {
@@ -277,7 +451,45 @@ void AgentVis::setScaleZVariable(const std::string& var_name) {
             agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
     }
     core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xy);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xyz);
     core_tex_buffers[TexBufferConfig::Scale_z].agentVariableName = var_name;
+}
+void AgentVis::setScaleXYVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setScaleXYVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 2) {
+        THROW exception::InvalidAgentVar("Visualisation scale xy variable must be type float[2], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setScaleXYVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers.erase(TexBufferConfig::Scale_x);
+    core_tex_buffers.erase(TexBufferConfig::Scale_y);
+    core_tex_buffers.erase(TexBufferConfig::Scale_z);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xyz);
+    core_tex_buffers[TexBufferConfig::Scale_xy].agentVariableName = var_name;
+}
+void AgentVis::setScaleXYZVariable(const std::string& var_name) {
+    auto it = agentData.variables.find(var_name);
+    if (it == agentData.variables.end()) {
+        THROW exception::InvalidAgentVar("Variable '%s' was not found within agent '%s', "
+            "in AgentVis::setScaleXYZVariable()\n",
+            var_name.c_str(), agentData.name.c_str());
+    } else if (it->second.type != std::type_index(typeid(float)) || it->second.elements != 3) {
+        THROW exception::InvalidAgentVar("Visualisation scale xyz variable must be type float[3], agent '%s' variable '%s' is type %s[%u], "
+            "in AgentVis::setScaleXYZVariable()\n",
+            agentData.name.c_str(), var_name.c_str(), it->second.type.name(), it->second.elements);
+    }
+    core_tex_buffers.erase(TexBufferConfig::UniformScale);
+    core_tex_buffers.erase(TexBufferConfig::Scale_x);
+    core_tex_buffers.erase(TexBufferConfig::Scale_y);
+    core_tex_buffers.erase(TexBufferConfig::Scale_z);
+    core_tex_buffers.erase(TexBufferConfig::Scale_xy);
+    core_tex_buffers[TexBufferConfig::Scale_xyz].agentVariableName = var_name;
 }
 void AgentVis::clearXVariable() {
     core_tex_buffers.erase(TexBufferConfig::Position_x);
@@ -288,6 +500,12 @@ void AgentVis::clearYVariable() {
 void AgentVis::clearZVariable() {
     core_tex_buffers.erase(TexBufferConfig::Position_z);
 }
+void AgentVis::clearXYVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Position_xy);
+}
+void AgentVis::clearXYZVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Position_xyz);
+}
 void AgentVis::clearForwardXVariable() {
     core_tex_buffers.erase(TexBufferConfig::Forward_x);
 }
@@ -296,6 +514,12 @@ void AgentVis::clearForwardYVariable() {
 }
 void AgentVis::clearForwardZVariable() {
     core_tex_buffers.erase(TexBufferConfig::Forward_z);
+}
+void AgentVis::clearForwardXZVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Forward_xz);
+}
+void AgentVis::clearForwardXYZVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Forward_xyz);
 }
 void AgentVis::clearUpXVariable() {
     core_tex_buffers.erase(TexBufferConfig::Up_x);
@@ -306,6 +530,9 @@ void AgentVis::clearUpYVariable() {
 void AgentVis::clearUpZVariable() {
     core_tex_buffers.erase(TexBufferConfig::Up_z);
 }
+void AgentVis::clearUpXYZVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Up_xyz);
+}
 void AgentVis::clearYawVariable() {
     core_tex_buffers.erase(TexBufferConfig::Heading);
 }
@@ -314,6 +541,12 @@ void AgentVis::clearPitchVariable() {
 }
 void AgentVis::clearRollVariable() {
     core_tex_buffers.erase(TexBufferConfig::Bank);
+}
+void AgentVis::clearDirectionYPVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Direction_hp);
+}
+void AgentVis::clearDirectionYPRVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Direction_hpb);
 }
 void AgentVis::clearUniformScaleVariable() {
     core_tex_buffers.erase(TexBufferConfig::UniformScale);
@@ -327,6 +560,12 @@ void AgentVis::clearScaleYVariable() {
 void AgentVis::clearScaleZVariable() {
     core_tex_buffers.erase(TexBufferConfig::Scale_z);
 }
+void AgentVis::clearScaleXYVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Scale_xy);
+}
+void AgentVis::clearScaleXYZVariable() {
+    core_tex_buffers.erase(TexBufferConfig::Scale_xyz);
+}
 std::string AgentVis::getXVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Position_x);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
@@ -337,6 +576,14 @@ std::string AgentVis::getYVariable() const {
 }
 std::string AgentVis::getZVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Position_z);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getXYVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Position_xy);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getXYZVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Position_xyz);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
 std::string AgentVis::getForwardXVariable() const {
@@ -355,12 +602,24 @@ std::string AgentVis::getUpXVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Up_x);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
+std::string AgentVis::getForwardXZVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Forward_xz);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getForwardXYZVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Forward_xyz);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
 std::string AgentVis::getUpYVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Up_y);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
 std::string AgentVis::getUpZVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Up_z);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getUpXYZVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Up_xyz);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
 std::string AgentVis::getYawVariable() const {
@@ -373,6 +632,14 @@ std::string AgentVis::getPitchVariable() const {
 }
 std::string AgentVis::getRollVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Bank);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getDirectionYPVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Direction_hp);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getDirectionYPRVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Direction_hpb);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
 std::string AgentVis::getUniformScaleVariable() const {
@@ -389,6 +656,14 @@ std::string AgentVis::getScaleYVariable() const {
 }
 std::string AgentVis::getScaleZVariable() const {
     const auto it = core_tex_buffers.find(TexBufferConfig::Scale_z);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getScaleXYVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Scale_xy);
+    return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
+}
+std::string AgentVis::getScaleXYZVariable() const {
+    const auto it = core_tex_buffers.find(TexBufferConfig::Scale_xyz);
     return it != core_tex_buffers.end() ? it->second.agentVariableName : "";
 }
 void AgentVis::initBindings(std::unique_ptr<FLAMEGPU_Visualisation> &vis) {

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -69,7 +69,9 @@ void ModelVis::_activate() {
             // If x and y aren't set, throw exception
             if (agent.second.core_tex_buffers.find(TexBufferConfig::Position_x) == agent.second.core_tex_buffers.end() &&
                 agent.second.core_tex_buffers.find(TexBufferConfig::Position_y) == agent.second.core_tex_buffers.end() &&
-                agent.second.core_tex_buffers.find(TexBufferConfig::Position_z) == agent.second.core_tex_buffers.end()) {
+                agent.second.core_tex_buffers.find(TexBufferConfig::Position_z) == agent.second.core_tex_buffers.end() &&
+                agent.second.core_tex_buffers.find(TexBufferConfig::Position_xy) == agent.second.core_tex_buffers.end() &&
+                agent.second.core_tex_buffers.find(TexBufferConfig::Position_xyz) == agent.second.core_tex_buffers.end()) {
                 THROW exception::VisualisationException("Agent '%s' has not had x, y or z variables set, agent requires location to render, "
                     "in ModelVis::activate()\n",
                     agent.second.agentData.name.c_str());

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -721,6 +721,13 @@ TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MsgArray::Description::n
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MsgArray2D::Description::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MsgArray3D::Description::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MsgBucket::Description::newVariable)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgBruteForce::Description::newVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgSpatial2D::Description::newVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgSpatial3D::Description::newVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgArray::Description::newVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgArray2D::Description::newVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgArray3D::Description::newVariableArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MsgBucket::Description::newVariableArray)
 
 // Instantiate template versions of host random functions from the API
 

--- a/tests/test_cases/runtime/messaging/test_array.cu
+++ b/tests/test_cases/runtime/messaging/test_array.cu
@@ -889,5 +889,113 @@ TEST(TestRTCMessage_Array, ArrayVariable) {
     }
 }
 
+#ifdef USE_GLM
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, MsgNone, MsgArray) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    glm::uvec3 t = glm::uvec3(index * 3, index * 7, index * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setIndex(index);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn_glm, MsgArray, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const auto& message = FLAMEGPU->message_in.at(my_index);
+    FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+    return ALIVE;
+}
+TEST(TestMessage_Array, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+const char* rtc_ArrayOut_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgArray) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    glm::uvec3 t = glm::uvec3(index * 3, index * 7, index * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setIndex(index);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgArray, flamegpu::MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    const auto& message = FLAMEGPU->message_in.at(my_index);
+    FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_Array, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray::Description& msg = m.newMessage<MsgArray>(MESSAGE_NAME);
+    msg.setLength(AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+#else
+TEST(TestMessage_Array, DISABLED_ArrayVariable_glm) { }
+TEST(TestRTCMessage_Array, DISABLED_ArrayVariable_glm) { }
+#endif
+
 }  // namespace test_message_array
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -1050,5 +1050,123 @@ TEST(TestRTCMessage_Array2D, ArrayVariable) {
     }
 }
 
+#if defined(USE_GLM)
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, MsgNone, MsgArray2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    glm::uvec3 t = glm::uvec3(x * 3, y * 7, y * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setIndex(x, y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn_glm, MsgArray2D, MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    const auto& message = FLAMEGPU->message_in.at(x, y);
+    FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+const char* rtc_ArrayOut_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, flamegpu::MsgNone, flamegpu::MsgArray2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    glm::uvec3 t = glm::uvec3(x * 3, y * 7, y * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setIndex(x, y);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgArray2D, flamegpu::MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    const auto& message = FLAMEGPU->message_in.at(x, y);
+    FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_Array2D, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+#else
+TEST(TestMessage_Array2D, DISABLED_ArrayVariable_glm) { }
+TEST(TestRTCMessage_Array2D, DISABLED_ArrayVariable_glm) { }
+#endif
+
 }  // namespace test_message_array_2d
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_array_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_2d.cu
@@ -931,5 +931,124 @@ TEST(TestMessage_Array2D, MooreR2NonUniform) {
     test_mooore_comradius(6, 1, 2);
 }
 
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, MsgNone, MsgArray2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, x * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, y * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, y * 11);
+    FLAMEGPU->message_out.setIndex(x, y);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, MsgArray2D, MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    const auto& message = FLAMEGPU->message_in.at(x, y);
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+    return ALIVE;
+}
+TEST(TestMessage_Array2D, ArrayVariable) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description &msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", {i, j});
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+const char* rtc_ArrayOut_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgArray2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, x * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, y * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, y * 11);
+    FLAMEGPU->message_out.setIndex(x, y);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgArray2D, flamegpu::MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    const auto& message = FLAMEGPU->message_in.at(x, y);
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_Array2D, ArrayVariable) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray2D::Description& msg = m.newMessage<MsgArray2D>(MESSAGE_NAME);
+    msg.setDimensions(SQRT_AGENT_COUNT, SQRT_AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+
 }  // namespace test_message_array_2d
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_array_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_array_3d.cu
@@ -1054,5 +1054,132 @@ TEST(TestMessage_Array3D, MooreR2NonUniform) {
     test_mooore_comradius(6, 1, 1, 2);
 }
 
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, MsgNone, MsgArray3D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, x * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, y * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, z * 11);
+    FLAMEGPU->message_out.setIndex(x, y, z);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, MsgArray3D, MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    const auto& message = FLAMEGPU->message_in.at(x, y, z);
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+    return ALIVE;
+}
+TEST(TestMessage_Array3D, ArrayVariable) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT, CBRT_AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 3>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, CBRT_AGENT_COUNT * CBRT_AGENT_COUNT * CBRT_AGENT_COUNT);
+    int t = 0;
+    for (unsigned int i = 0; i < CBRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < CBRT_AGENT_COUNT; ++j) {
+            for (unsigned int k = 0; k < CBRT_AGENT_COUNT; ++k) {
+                AgentVector::Agent ai = pop[t++];
+                ai.setVariable<unsigned int, 3>("index", { i, j, k });
+            }
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 3> index = ai.getVariable<unsigned int, 3>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[2] * 11);
+    }
+}
+const char* rtc_ArrayOut_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgArray3D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, x * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, y * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, z * 11);
+    FLAMEGPU->message_out.setIndex(x, y, z);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgArray3D, flamegpu::MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    const auto& message = FLAMEGPU->message_in.at(x, y, z);
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+    FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_Array3D, ArrayVariable) {
+    ModelDescription m(MODEL_NAME);
+    MsgArray3D::Description& msg = m.newMessage<MsgArray3D>(MESSAGE_NAME);
+    msg.setDimensions(CBRT_AGENT_COUNT, CBRT_AGENT_COUNT, CBRT_AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 3>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, CBRT_AGENT_COUNT * CBRT_AGENT_COUNT * CBRT_AGENT_COUNT);
+    int t = 0;
+    for (unsigned int i = 0; i < CBRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < CBRT_AGENT_COUNT; ++j) {
+            for (unsigned int k = 0; k < CBRT_AGENT_COUNT; ++k) {
+                AgentVector::Agent ai = pop[t++];
+                ai.setVariable<unsigned int, 3>("index", { i, j, k });
+            }
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 3> index = ai.getVariable<unsigned int, 3>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[2] * 11);
+    }
+}
+
 }  // namespace test_message_array_3d
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_brute_force.cu
+++ b/tests/test_cases/runtime/messaging/test_brute_force.cu
@@ -349,5 +349,122 @@ TEST(TestMessage_BruteForce, ReadEmpty) {
     EXPECT_EQ(ai.getVariable<unsigned int>("count"), 0u);
 }
 
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, MsgNone, MsgBruteForce) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index", index);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, index * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, index * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, index * 11);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, MsgBruteForce, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    for (auto &message : FLAMEGPU->message_in) {
+        if (message.getVariable<unsigned int>("index") == my_index) {
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+            break;
+        }
+    }
+    return ALIVE;
+}
+TEST(TestMessage_BruteForce, ArrayVariable) {
+    ModelDescription m(MODEL_NAME);
+    MsgBruteForce::Description &msg = m.newMessage<MsgBruteForce>(MESSAGE_NAME);
+    msg.newVariable<unsigned int, 3>("v");
+    msg.newVariable<unsigned int>("index");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+const char* rtc_ArrayOut_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgBruteForce) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index", index);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, index * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, index * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, index * 11);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgBruteForce, flamegpu::MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    for (auto &message : FLAMEGPU->message_in) {
+        if (message.getVariable<unsigned int>("index") == my_index) {
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+            break;
+        }
+    }
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_BruteForce, ArrayVariable) {
+    ModelDescription m(MODEL_NAME);
+    MsgBruteForce::Description& msg = m.newMessage<MsgBruteForce>(MESSAGE_NAME);
+    msg.newVariable<unsigned int, 3>("v");
+    msg.newVariable<unsigned int>("index");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+
 }  // namespace test_message_brute_force
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_brute_force.cu
+++ b/tests/test_cases/runtime/messaging/test_brute_force.cu
@@ -466,5 +466,121 @@ TEST(TestRTCMessage_BruteForce, ArrayVariable) {
     }
 }
 
+#if defined(USE_GLM)
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, MsgNone, MsgBruteForce) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index", index);
+    glm::uvec3 t = glm::uvec3(index * 3, index * 7, index * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn_glm, MsgBruteForce, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    for (auto &message : FLAMEGPU->message_in) {
+        if (message.getVariable<unsigned int>("index") == my_index) {
+            FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+            break;
+        }
+    }
+    return ALIVE;
+}
+TEST(TestMessage_BruteForce, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgBruteForce::Description &msg = m.newMessage<MsgBruteForce>(MESSAGE_NAME);
+    msg.newVariable<unsigned int, 3>("v");
+    msg.newVariable<unsigned int>("index");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn_glm);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+const char* rtc_ArrayOut_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgBruteForce) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    FLAMEGPU->message_out.setVariable<unsigned int>("index", index);
+    glm::uvec3 t = glm::uvec3(index * 3, index * 7, index * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgBruteForce, flamegpu::MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    for (auto &message : FLAMEGPU->message_in) {
+        if (message.getVariable<unsigned int>("index") == my_index) {
+            FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+            break;
+        }
+    }
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_BruteForce, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgBruteForce::Description& msg = m.newMessage<MsgBruteForce>(MESSAGE_NAME);
+    msg.newVariable<unsigned int, 3>("v");
+    msg.newVariable<unsigned int>("index");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+#else
+TEST(TestMessage_BruteForce, DISABLED_ArrayVariable_glm) { }
+TEST(TestRTCMessage_BruteForce, DISABLED_ArrayVariable_glm) { }
+#endif
+
 }  // namespace test_message_brute_force
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_bucket.cu
+++ b/tests/test_cases/runtime/messaging/test_bucket.cu
@@ -481,5 +481,115 @@ TEST(TestRTCMessage_Bucket, ArrayVariable) {
     }
 }
 
+#if defined(USE_GLM)
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, MsgNone, MsgBucket) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    glm::uvec3 t = glm::uvec3(index * 3, index * 7, index * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setKey(index);
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn_glm, MsgBucket, MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    for (auto &message : FLAMEGPU->message_in(my_index)) {
+        FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+    }
+    return ALIVE;
+}
+TEST(TestMessage_Bucket, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgBucket::Description &msg = m.newMessage<MsgBucket>(MESSAGE_NAME);
+    msg.setBounds(0, AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn_glm);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+const char* rtc_ArrayOut_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgBucket) {
+    const unsigned int index = FLAMEGPU->getVariable<unsigned int>("index");
+    glm::uvec3 t = glm::uvec3(index * 3, index * 7, index * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setKey(index);
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgBucket, flamegpu::MsgNone) {
+    const unsigned int my_index = FLAMEGPU->getVariable<unsigned int>("index");
+    for (auto &message : FLAMEGPU->message_in(my_index)) {
+        FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+    }
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(TestRTCMessage_Bucket, ArrayVariable_glm) {
+    ModelDescription m(MODEL_NAME);
+    MsgBucket::Description& msg = m.newMessage<MsgBucket>(MESSAGE_NAME);
+    msg.setBounds(0, AGENT_COUNT);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    // Assign the numbers in shuffled order to agents
+    AgentVector pop(a, AGENT_COUNT);
+    for (unsigned int i = 0; i < AGENT_COUNT; ++i) {
+        AgentVector::Agent ai = pop[i];
+        ai.setVariable<unsigned int>("index", i);
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const unsigned int index = ai.getVariable<unsigned int>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index * 3);
+        ASSERT_EQ(v[1], index * 7);
+        ASSERT_EQ(v[2], index * 11);
+    }
+}
+#else
+TEST(TestMessage_Bucket, DISABLED_ArrayVariable_glm) { }
+TEST(TestRTCMessage_Bucket, DISABLED_ArrayVariable_glm) { }
+#endif
+
 }  // namespace test_message_bucket
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -645,5 +645,151 @@ TEST(RTCSpatial2DMsgTest, ArrayVariable) {
     }
 }
 
+#if defined(USE_GLM)
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, MsgNone, MsgSpatial2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    glm::uvec3 t = glm::uvec3(x * 3, y * 7, y * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setLocation(static_cast<float>(x), static_cast<float>(y));
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn_glm, MsgSpatial2D, MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    for (auto &message : FLAMEGPU->message_in(static_cast<float>(x), static_cast<float>(y))) {
+        if (static_cast<unsigned int>(message.getVariable<float>("x")) == x &&
+            static_cast<unsigned int>(message.getVariable<float>("y")) == y) {
+            FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+            break;
+        }
+    }
+    return ALIVE;
+}
+TEST(Spatial2DMsgTest, ArrayVariable_glm) {
+    const char* MODEL_NAME = "Model";
+    const char* AGENT_NAME = "Agent";
+    const char* MESSAGE_NAME = "Message";
+    const char* IN_FUNCTION_NAME = "InFunction";
+    const char* OUT_FUNCTION_NAME = "OutFunction";
+    const char* IN_LAYER_NAME = "InLayer";
+    const char* OUT_LAYER_NAME = "OutLayer";
+    const unsigned int SQRT_AGENT_COUNT = 64;
+    ModelDescription m(MODEL_NAME);
+    MsgSpatial2D::Description &msg = m.newMessage<MsgSpatial2D>(MESSAGE_NAME);
+    msg.setMin(0, 0);
+    msg.setMax(static_cast<float>(SQRT_AGENT_COUNT), static_cast<float>(SQRT_AGENT_COUNT));
+    msg.setRadius(1);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn_glm);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+const char* rtc_ArrayOut_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgSpatial2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    glm::uvec3 t = glm::uvec3(x * 3, y * 7, y * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setLocation(static_cast<float>(x), static_cast<float>(y));
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgSpatial2D, flamegpu::MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    for (auto &message : FLAMEGPU->message_in(static_cast<float>(x), static_cast<float>(y))) {
+        if (static_cast<unsigned int>(message.getVariable<float>("x")) == x &&
+            static_cast<unsigned int>(message.getVariable<float>("y")) == y) {
+            FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+            break;
+        }
+    }
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(RTCSpatial2DMsgTest, ArrayVariable_glm) {
+    const char* MODEL_NAME = "Model";
+    const char* AGENT_NAME = "Agent";
+    const char* MESSAGE_NAME = "Message";
+    const char* IN_FUNCTION_NAME = "InFunction";
+    const char* OUT_FUNCTION_NAME = "OutFunction";
+    const char* IN_LAYER_NAME = "InLayer";
+    const char* OUT_LAYER_NAME = "OutLayer";
+    const unsigned int SQRT_AGENT_COUNT = 64;
+    ModelDescription m(MODEL_NAME);
+    MsgSpatial2D::Description& msg = m.newMessage<MsgSpatial2D>(MESSAGE_NAME);
+    msg.setMin(0, 0);
+    msg.setMax(static_cast<float>(SQRT_AGENT_COUNT), static_cast<float>(SQRT_AGENT_COUNT));
+    msg.setRadius(1);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+#else
+TEST(Spatial2DMsgTest, DISABLED_ArrayVariable_glm) { }
+TEST(RTCSpatial2DMsgTest, DISABLED_ArrayVariable_glm) { }
+#endif
+
 }  // namespace test_message_spatial2d
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -497,5 +497,153 @@ TEST(Spatial2DMsgTest, ReadEmpty) {
     EXPECT_EQ(pop_out.size(), 1u);
     EXPECT_EQ(pop_out[0].getVariable<unsigned int>("count"), 0u);
 }
+
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, MsgNone, MsgSpatial2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, x * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, y * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, y * 11);
+    FLAMEGPU->message_out.setLocation(static_cast<float>(x), static_cast<float>(y));
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, MsgSpatial2D, MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    for (auto &message : FLAMEGPU->message_in(static_cast<float>(x), static_cast<float>(y))) {
+        if (static_cast<unsigned int>(message.getVariable<float>("x")) == x &&
+            static_cast<unsigned int>(message.getVariable<float>("y")) == y) {
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+            break;
+        }
+    }
+    return ALIVE;
+}
+TEST(Spatial2DMsgTest, ArrayVariable) {
+    const char* MODEL_NAME = "Model";
+    const char* AGENT_NAME = "Agent";
+    const char* MESSAGE_NAME = "Message";
+    const char* IN_FUNCTION_NAME = "InFunction";
+    const char* OUT_FUNCTION_NAME = "OutFunction";
+    const char* IN_LAYER_NAME = "InLayer";
+    const char* OUT_LAYER_NAME = "OutLayer";
+    const unsigned int SQRT_AGENT_COUNT = 64;
+    ModelDescription m(MODEL_NAME);
+    MsgSpatial2D::Description &msg = m.newMessage<MsgSpatial2D>(MESSAGE_NAME);
+    msg.setMin(0, 0);
+    msg.setMax(static_cast<float>(SQRT_AGENT_COUNT), static_cast<float>(SQRT_AGENT_COUNT));
+    msg.setRadius(1);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+const char* rtc_ArrayOut_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgSpatial2D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 0, x * 3);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 1, y * 7);
+    FLAMEGPU->message_out.setVariable<unsigned int, 3>("v", 2, y * 11);
+    FLAMEGPU->message_out.setLocation(static_cast<float>(x), static_cast<float>(y));
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgSpatial2D, flamegpu::MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 2>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 2>("index", 1);
+    for (auto &message : FLAMEGPU->message_in(static_cast<float>(x), static_cast<float>(y))) {
+        if (static_cast<unsigned int>(message.getVariable<float>("x")) == x &&
+            static_cast<unsigned int>(message.getVariable<float>("y")) == y) {
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 0, message.getVariable<unsigned int, 3>("v", 0));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 1, message.getVariable<unsigned int, 3>("v", 1));
+            FLAMEGPU->setVariable<unsigned int, 3>("message_read", 2, message.getVariable<unsigned int, 3>("v", 2));
+            break;
+        }
+    }
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(RTCSpatial2DMsgTest, ArrayVariable) {
+    const char* MODEL_NAME = "Model";
+    const char* AGENT_NAME = "Agent";
+    const char* MESSAGE_NAME = "Message";
+    const char* IN_FUNCTION_NAME = "InFunction";
+    const char* OUT_FUNCTION_NAME = "OutFunction";
+    const char* IN_LAYER_NAME = "InLayer";
+    const char* OUT_LAYER_NAME = "OutLayer";
+    const unsigned int SQRT_AGENT_COUNT = 64;
+    ModelDescription m(MODEL_NAME);
+    MsgSpatial2D::Description& msg = m.newMessage<MsgSpatial2D>(MESSAGE_NAME);
+    msg.setMin(0, 0);
+    msg.setMax(static_cast<float>(SQRT_AGENT_COUNT), static_cast<float>(SQRT_AGENT_COUNT));
+    msg.setRadius(1);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 2>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    AgentVector pop(a, SQRT_AGENT_COUNT * SQRT_AGENT_COUNT);
+    int k = 0;
+    for (unsigned int i = 0; i < SQRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < SQRT_AGENT_COUNT; ++j) {
+            AgentVector::Agent ai = pop[k++];
+            ai.setVariable<unsigned int, 2>("index", { i, j });
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 2> index = ai.getVariable<unsigned int, 2>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[1] * 11);
+    }
+}
+
 }  // namespace test_message_spatial2d
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/messaging/test_spatial_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_3d.cu
@@ -702,5 +702,161 @@ TEST(RTCSpatial3DMsgTest, ArrayVariable) {
     }
 }
 
+#if defined(USE_GLM)
+FLAMEGPU_AGENT_FUNCTION(ArrayOut_glm, MsgNone, MsgSpatial3D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    glm::uvec3 t = glm::uvec3(x * 3, y * 7, z * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setLocation(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(ArrayIn_glm, MsgSpatial3D, MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    for (auto &message : FLAMEGPU->message_in(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z))) {
+        if (static_cast<unsigned int>(message.getVariable<float>("x")) == x &&
+            static_cast<unsigned int>(message.getVariable<float>("y")) == y &&
+            static_cast<unsigned int>(message.getVariable<float>("z")) == z) {
+            FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+            break;
+        }
+    }
+    return ALIVE;
+}
+TEST(Spatial3DMsgTest, ArrayVariable_glm) {
+    const char* MODEL_NAME = "Model";
+    const char* AGENT_NAME = "Agent";
+    const char* MESSAGE_NAME = "Message";
+    const char* IN_FUNCTION_NAME = "InFunction";
+    const char* OUT_FUNCTION_NAME = "OutFunction";
+    const char* IN_LAYER_NAME = "InLayer";
+    const char* OUT_LAYER_NAME = "OutLayer";
+    const unsigned int CBRT_AGENT_COUNT = 11;
+    ModelDescription m(MODEL_NAME);
+    MsgSpatial3D::Description &msg = m.newMessage<MsgSpatial3D>(MESSAGE_NAME);
+    msg.setMin(0, 0, 0);
+    msg.setMax(static_cast<float>(CBRT_AGENT_COUNT), static_cast<float>(CBRT_AGENT_COUNT), static_cast<float>(CBRT_AGENT_COUNT));
+    msg.setRadius(1);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription &a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 3>("index");
+    a.newVariable<unsigned int, 3>("message_read", {UINT_MAX, UINT_MAX, UINT_MAX});
+    AgentFunctionDescription &fo = a.newFunction(OUT_FUNCTION_NAME, ArrayOut_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription &fi = a.newFunction(IN_FUNCTION_NAME, ArrayIn_glm);
+    fi.setMessageInput(msg);
+    LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription &li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    AgentVector pop(a, CBRT_AGENT_COUNT * CBRT_AGENT_COUNT * CBRT_AGENT_COUNT);
+    int t = 0;
+    for (unsigned int i = 0; i < CBRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < CBRT_AGENT_COUNT; ++j) {
+            for (unsigned int k = 0; k < CBRT_AGENT_COUNT; ++k) {
+                AgentVector::Agent ai = pop[t++];
+                ai.setVariable<unsigned int, 3>("index", { i, j, k });
+            }
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 3> index = ai.getVariable<unsigned int, 3>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[2] * 11);
+    }
+}
+const char* rtc_ArrayOut_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayOut, flamegpu::MsgNone, flamegpu::MsgSpatial3D) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    glm::uvec3 t = glm::uvec3(x * 3, y * 7, z * 11);
+    FLAMEGPU->message_out.setVariable<glm::uvec3>("v", t);
+    FLAMEGPU->message_out.setLocation(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+    return flamegpu::ALIVE;
+}
+)###";
+const char* rtc_ArrayIn_func_glm = R"###(
+FLAMEGPU_AGENT_FUNCTION(ArrayIn, flamegpu::MsgSpatial3D, flamegpu::MsgNone) {
+    const unsigned int x = FLAMEGPU->getVariable<unsigned int, 3>("index", 0);
+    const unsigned int y = FLAMEGPU->getVariable<unsigned int, 3>("index", 1);
+    const unsigned int z = FLAMEGPU->getVariable<unsigned int, 3>("index", 2);
+    for (auto &message : FLAMEGPU->message_in(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z))) {
+        if (static_cast<unsigned int>(message.getVariable<float>("x")) == x &&
+            static_cast<unsigned int>(message.getVariable<float>("y")) == y &&
+            static_cast<unsigned int>(message.getVariable<float>("z")) == z) {
+            FLAMEGPU->setVariable<glm::uvec3>("message_read", message.getVariable<glm::uvec3>("v"));
+            break;
+        }
+    }
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(RTCSpatial3DMsgTest, ArrayVariable_glm) {
+    const char* MODEL_NAME = "Model";
+    const char* AGENT_NAME = "Agent";
+    const char* MESSAGE_NAME = "Message";
+    const char* IN_FUNCTION_NAME = "InFunction";
+    const char* OUT_FUNCTION_NAME = "OutFunction";
+    const char* IN_LAYER_NAME = "InLayer";
+    const char* OUT_LAYER_NAME = "OutLayer";
+    const unsigned int CBRT_AGENT_COUNT = 11;
+    ModelDescription m(MODEL_NAME);
+    MsgSpatial3D::Description& msg = m.newMessage<MsgSpatial3D>(MESSAGE_NAME);
+    msg.setMin(0, 0, 0);
+    msg.setMax(static_cast<float>(CBRT_AGENT_COUNT), static_cast<float>(CBRT_AGENT_COUNT), static_cast<float>(CBRT_AGENT_COUNT));
+    msg.setRadius(1);
+    msg.newVariable<unsigned int, 3>("v");
+    AgentDescription& a = m.newAgent(AGENT_NAME);
+    a.newVariable<unsigned int, 3>("index");
+    a.newVariable<unsigned int, 3>("message_read", { UINT_MAX, UINT_MAX, UINT_MAX });
+    AgentFunctionDescription& fo = a.newRTCFunction(OUT_FUNCTION_NAME, rtc_ArrayOut_func_glm);
+    fo.setMessageOutput(msg);
+    AgentFunctionDescription& fi = a.newRTCFunction(IN_FUNCTION_NAME, rtc_ArrayIn_func_glm);
+    fi.setMessageInput(msg);
+    LayerDescription& lo = m.newLayer(OUT_LAYER_NAME);
+    lo.addAgentFunction(fo);
+    LayerDescription& li = m.newLayer(IN_LAYER_NAME);
+    li.addAgentFunction(fi);
+    AgentVector pop(a, CBRT_AGENT_COUNT * CBRT_AGENT_COUNT * CBRT_AGENT_COUNT);
+    int t = 0;
+    for (unsigned int i = 0; i < CBRT_AGENT_COUNT; ++i) {
+        for (unsigned int j = 0; j < CBRT_AGENT_COUNT; ++j) {
+            for (unsigned int k = 0; k < CBRT_AGENT_COUNT; ++k) {
+                AgentVector::Agent ai = pop[t++];
+                ai.setVariable<unsigned int, 3>("index", { i, j, k });
+            }
+        }
+    }
+    // Set pop in model
+    CUDASimulation c(m);
+    c.setPopulationData(pop);
+    c.step();
+    c.getPopulationData(pop);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : pop) {
+        const std::array<unsigned int, 3> index = ai.getVariable<unsigned int, 3>("index");
+        std::array<unsigned int, 3> v = ai.getVariable<unsigned int, 3>("message_read");
+        ASSERT_EQ(v[0], index[0] * 3);
+        ASSERT_EQ(v[1], index[1] * 7);
+        ASSERT_EQ(v[2], index[2] * 11);
+    }
+}
+#else
+TEST(Spatial3DMsgTest, DISABLED_ArrayVariable_glm) { }
+TEST(RTCSpatial3DMsgTest, DISABLED_ArrayVariable_glm) { }
+#endif
+
 }  // namespace test_message_spatial3d
 }  // namespace flamegpu

--- a/tests/test_cases/util/test_SteadyClockTimer.cpp
+++ b/tests/test_cases/util/test_SteadyClockTimer.cpp
@@ -14,7 +14,7 @@ TEST(TestSteadyClockTimer, SteadyClockTimer) {
     // Time an arbitrary event, and check the value is approximately correct.
     timer->start();
     const int sleep_duration_seconds = 1;
-    const int min_expected_millis = static_cast<int>(sleep_duration_seconds * 1000. * 0.9);
+    const int min_expected_millis = static_cast<int>(sleep_duration_seconds * 1000.0 * 0.9);
     std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_seconds));
     timer->stop();
     EXPECT_GE(timer->getElapsedMilliseconds(), min_expected_millis);


### PR DESCRIPTION
This PR can be merged as-is, the 3 commits are all be distinct and clearly separated. There is a matching Vis PR [here](https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/70), which is also required for the first of these commits.

# Tests
* Windows/Release/CUDA 11.2/USE_GLM=OFF/SEATBELTS=ON: 880 passes, 25 disabled (Laptop, 10m45s runtime)
* Windows/Release/CUDA 11.4/USE_GLM=ON/SEATBELTS=ON: 902 passes, 5 disabled (Office, 81m8s runtime)
* Windows/Release/CUDA 11.4/USE_GLM=ON/SEATBELTS=ON: 902 passes, 5 disabled (Office, 25m22s runtime, after I added a patch to remove GLM headers if not required)

# To Do
- [x] Rebase vs master
- [x] Improve how GLM is linked in, currently it depends on visualisation
- [x] Make USE_GLM support set/get variables inside RTC curve
- [x] Update vis to support vector variables for agent location (and rotation?)
- [x] Cleanup commits, I think 2918630 needs to be reverted.
- [x] Agent Variable
- [x] New Agent Variable tests
- [x] Environment property test
- [x] ?Add array variable support to messages
- [x] Message Variable tests
- [x] Squash commits, but keep vis changes + message array variable + curve changes separate 
* ~~Update boids examples to use vec?~~ (Not worth doing whilst option is considered experimental, could add a 2nd one just for testing purposes that doesn't get merged).

# Issues
## `__ldg()`
The CUDA intrinsic `__ldg()` cannot be used to load non-primitive types (e.g. all glm types). As such, the brute force variable path, which uses `__ldg()` leads to a compile error. For this reason I have simply disabled `__ldg()` where `USE_GLM` is enabled.

I did try a `constexpr if` to make the `__ldg()` path disabled for glm types, however that did not work (presumably because the path is optimised out after it has been parsed and thrown that error).

I found [this](https://github.com/bryancatanzaro/generics) small header library which overrides `__ldg()`, to load any generic type as multiple loads of a smaller primitive type. We could perhaps use this or something similar.

## RTC build times.

Adding the glm header to the include hierarchy makes RTC build time increase by ~6.4x. I've added a patch that will only enable `USE_GLM` during RTC compilation if a file contains the string `glm` (either them using a glm type or using the namespace). This works as intended.

I looked into this further, and found that NVRTC (`createProgram`, `compileProgram`, ..., `destroyProgram`) has a fairly stable runtime of 0.6s. Whereas the entire call to `jitify::Program` constructor, Takes 9s without glm headers, 63s with glm headers.
So Jitify's mini pre-processor that loads the headers, is to blame not NVRTC. 

---------

Pairs with: https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/70