### PR TITLE
Target specific warnings

### DIFF
--- a/cmake/Tinyxml2.cmake
+++ b/cmake/Tinyxml2.cmake
@@ -62,5 +62,9 @@ if(NOT tinyxml2_POPULATED)
         if(MSVC)
             target_compile_definitions(tinyxml2 PUBLIC -D_CRT_SECURE_NO_WARNINGS)
         endif(MSVC)
+
+        # Suppress warnigns from this target.
+        include(${CMAKE_CURRENT_LIST_DIR}/warnings.cmake)
+        DisableCompilerWarnings(TARGET tinyxml2)
     endif()
 endif()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -44,47 +44,17 @@ get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG
 if(${GENERATOR_IS_MULTI_CONFIG})
     # CMAKE_CONFIGURATION_TYPES defaults to something platform specific
     # Therefore can't detect if user has changed value and not reset it
-    # So force "Debug;Release;Profile"
-    set(CMAKE_CONFIGURATION_TYPES "Debug;Release;Profile" CACHE INTERNAL
-        "Choose the types of build, options are: Debug Release Profile." FORCE)#
+    # So force "Debug;Release"
+    set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE INTERNAL
+        "Choose the types of build, options are: Debug Release." FORCE)#
 else()
     if(NOT CMAKE_BUILD_TYPE)
         set(default_build_type "Release")
         message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
         set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING 
-            "Choose the type of build, options are: None Debug Release Profile." FORCE)
+            "Choose the type of build, options are: None Debug Release." FORCE)
     endif()
 endif()
-
-# Create the profile build modes, based on release
-SET( CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING
-    "Flags used by the C++ compiler during profile builds."
-    FORCE )
-SET( CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE}" CACHE STRING
-    "Flags used by the C compiler during profile builds."
-    FORCE )
-SET( CMAKE_CUDA_FLAGS_PROFILE "${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING
-    "Flags used by the CUDA compiler during profile builds."
-    FORCE )
-SET( CMAKE_EXE_LINKER_FLAGS_PROFILE
-    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}" CACHE STRING
-    "Flags used for linking binaries during profile builds."
-    FORCE )
-SET( CMAKE_SHARED_LINKER_FLAGS_PROFILE
-    "${CMAKE_SHARED_LINKER_FLAGS_RELEASE}" CACHE STRING
-    "Flags used by the shared libraries linker during profile builds."
-    FORCE )
-MARK_AS_ADVANCED(
-    CMAKE_CXX_FLAGS_PROFILE
-    CMAKE_C_FLAGS_PROFILE
-    CMAKE_EXE_LINKER_FLAGS_PROFILE
-    CMAKE_SHARED_LINKER_FLAGS_PROFILE )
-
-    
-    # If using profile build, imply NVTX
-    if(CMAKE_BUILD_TYPE MATCHES "Profile")
-    SET(NVTX "ON")
-    endif()
 
 # Ask Cmake to output compile_commands.json (if supported). This is useful for vscode include paths, clang-tidy/clang-format etc
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "Control the output of compile_commands.json")
@@ -158,8 +128,6 @@ set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G -D_DEBUG -DDEBUG")
 # Lineinfo for non -G release
 set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE} -lineinfo")
 
-# profile specific CUDA flags.
-set(CMAKE_CUDA_FLAGS_PROFILE "${CMAKE_CUDA_FLAGS_PROFILE} -lineinfo -DPROFILE -D_PROFILE")
 # Addresses a cub::histogram warning
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -171,6 +171,9 @@ if(CPPLINT)
             list(FILTER SRC EXCLUDE REGEX "${EXCLUDE_FILTER}")
         endforeach()
 
+        # Only lint accepted file type extensions h++, hxx, cuh, cu, c, c++, cxx, cc, hpp, h, cpp, hh
+        list(FILTER SRC INCLUDE REGEX ".*\\.(h\\+\\+|hxx|cuh|cu|c|c\\+\\+|cxx|cc|hpp|h|cpp|hh)$")
+
         # Build a list of arguments to pass to CPPLINT
         LIST(APPEND CPPLINT_ARGS "")
 

--- a/cmake/cuda_arch.cmake
+++ b/cmake/cuda_arch.cmake
@@ -11,7 +11,7 @@ endif()
 string(LENGTH "${CUDA_ARCH}" CUDA_ARCH_LENGTH)
 
 # Define the default compute capabilites incase not provided by the user
-set(DEFAULT_CUDA_ARCH "20;35;50;60;70;80;")
+set(DEFAULT_CUDA_ARCH "35;50;60;70;80;")
 
 # Get the valid options for the current compiler.
 # Run nvcc --help to get the help string which contains all valid compute_ sm_ for that version.

--- a/cmake/cxxstd.cmake
+++ b/cmake/cxxstd.cmake
@@ -1,0 +1,70 @@
+# Select the CXX standard to use. 
+if(NOT FLAMEGPU_CXX_STD)
+    # FLAME GPU is c++14, however due to MSVC 16.10 regressions we build as 17 if possible, else 14. 
+    # 14 Support is still required (CUDA 10.x, swig?).
+    # Start by assuming both should be availble.
+    set(CXX17_SUPPORTED ON)
+    # CMake 3.18 adds CUDA CXX 17, 20
+    # CMake 3.10 adds CUDA CXX 14
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+        # 17 OK
+    elseif(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
+        set(CXX17_SUPPORTED OFF)
+    else()
+        message(FATAL_ERROR "CMAKE ${CMAKE_VERSION} does not support -std=c++14")
+    endif()
+    # CUDA 11.0 adds CXX 17
+    # CUDA 9.0 adds CXX 14
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.0)
+        # 17 is ok.
+    elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0.0)
+        # 14 is ok, 17 is not.
+        set(CXX17_SUPPORTED OFF)
+    else()
+        # Fatal Error.
+        message(FATAL_ERROR "CUDA ${CMAKE_CUDA_COMPILER_VERSION} does not support -std=c++14")
+    endif()
+
+    # VS 2019 16.10.0 breaks CXX 14 + cuda. - 1930? 19.29.30037?
+    # VS 2017 version 15.3 added /std:c++17 - 1911
+    # MSVC VS2015 Update 3 added /std:c++14 >= 1900 && < 1910? 
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.29)
+            # 17 required.
+            if(NOT CXX17_SUPPORTED)
+                message(FATAL_ERROR "MSVC >= 19.29 requires CMake >= 3.18 and CUDA >= 11.0")
+            endif()
+        elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.11)
+            # 17 available?
+        elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
+            set(CXX17_SUPPORTED OFF)
+        else()
+            message(FATAL_ERROR "MSVC ${CMAKE_CXX_COMPILER_VERSION} does not support -std=c++14")
+        endif()
+    endif()
+
+    # gcc supported C++17 since 5, so any version supported by cuda 10+ (no need to check, a configure time error will already occur.)
+    # Inside source code, __STDC_VERSION__ can be used on msvc, which will have a value such as 201710L for c++17
+
+    # Set a cmake variable so this is only calcualted once, and can be applied afterwards.
+    if(CXX17_SUPPORTED)
+        set(FLAMEGPU_CXX_STD 17)
+    else()
+        set(FLAMEGPU_CXX_STD 14)
+    endif()
+    # if(NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    #     # Forward to the parent scope so it persists between calls.
+    #     set(FLAMEGPU_CXX_STD ${FLAMEGPU_CXX_STD} PARENT_SCOPE)
+    # endif()
+endif()
+
+# @future - set this on a per target basis using set_target_properties?
+set(CMAKE_CXX_EXTENSIONS OFF)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD ${FLAMEGPU_CXX_STD})
+    set(CMAKE_CXX_STANDARD_REQUIRED true)
+endif()
+if(NOT DEFINED CMAKE_CUDA_STANDARD)
+    set(CMAKE_CUDA_STANDARD ${FLAMEGPU_CXX_STD})
+    set(CMAKE_CUDA_STANDARD_REQUIRED True)
+endif()

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -25,5 +25,10 @@ if(NOT googletest_POPULATED)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
     CMAKE_SET_TARGET_FOLDER("gtest" "Tests/Dependencies")
+    # Suppress warnigns from this target.
+    include(${CMAKE_CURRENT_LIST_DIR}/warnings.cmake)
+    if(TARGET gtest)
+        DisableCompilerWarnings(TARGET gtest)
+    endif()
 endif()
 

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,0 +1,110 @@
+# Function to suppress compiler warnings for a given target
+function(DisableCompilerWarnings)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        DISABLE_COMPILER_WARNINGS
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT DISABLE_COMPILER_WARNINGS_TARGET)
+        message( FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required." )
+    elseif(NOT TARGET ${DISABLE_COMPILER_WARNINGS_TARGET} )
+        message( FATAL_ERROR "DisableCompilerWarnings: TARGET '${DISABLE_COMPILER_WARNINGS_TARGET}' is not a valid target" )
+    endif()
+    # By default, suppress all warnings, so that warnings are applied per-target.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(${DISABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
+    else()
+        target_compile_options(${DISABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
+    endif()
+    # Always tell nvcc to disable warnings
+    target_compile_options(${DISABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
+endfunction()
+# Define a function which applies warning flags to a given target.
+# Also enables the treating of warnings as errors if required.
+function(EnableCompilerWarnings)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        ENABLE_COMPILER_WARNINGS
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT ENABLE_COMPILER_WARNINGS_TARGET)
+        message( FATAL_ERROR "EnableCompilerWarnings: 'TARGET' argument required." )
+    elseif(NOT TARGET ${ENABLE_COMPILER_WARNINGS_TARGET} )
+        message( FATAL_ERROR "EnableCompilerWarnings: TARGET '${ENABLE_COMPILER_WARNINGS_TARGET}' is not a valid target" )
+    endif()
+    # Host Compiler version specific high warnings
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
+        # Also suppress some unwanted W4 warnings
+        # decorated name length exceeded, name was truncated
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
+        # 'function' : unreferenced local function has been removed
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
+        # unreferenced formal parameter warnings disabled - tests make use of it.
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
+        # C4127: conditional expression is constant. Longer term true static assertions would be better.
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
+        # Suppress some VS2015 specific warnings.
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
+        endif()
+    else()
+        # Assume using GCC/Clang which Wall is relatively sane for. 
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
+        # CUB 1.9.10 prevents Wreorder being usable on windows. Cannot suppress via diag_suppress pragmas.
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
+    endif()
+    # Promote warnings to errors if requested
+    if(WARNINGS_AS_ERRORS)
+        # OS Specific flags
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
+        else()
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
+        endif()
+        # Generic WError settings for nvcc
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
+        # If CUDA 10.2+, add all_warnings to the Werror option
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
+        endif()
+        # If not msvc, add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
+        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call >")
+        endif()
+        # If not msvc, add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
+        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder >")
+        endif()
+    endif()
+    # Ask the cuda frontend to include warnings numbers, so they can be targetted for suppression.
+    target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+    # Suppress nodiscard warnings from the cuda frontend
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
+    endif()
+    # Supress CUDA 11.3 specific warnings.
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
+        # Suppress 117-D, declared_but_not_referenced
+        target_compile_options(${ENABLE_COMPILER_WARNINGS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
+    endif()
+endfunction()

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -3,20 +3,13 @@
 #include(../../cmake/common.cmake)
 # Just include cuda_arch to suppress CMAKE 3.18 warnings on windows (where nvcc is used even when not neccesary)
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../ REALPATH)
+
+# Set CUDA gencode arguments
 include(${FLAMEGPU_ROOT}/cmake/cuda_arch.cmake)
+# Set the C++ and CUDA standard to use
+include(${FLAMEGPU_ROOT}/cmake/cxxstd.cmake)
+# Get FLAMEGPU Version information
 include(${FLAMEGPU_ROOT}/cmake/version.cmake)
-
-
-# Duplicated because common is not imported. Must be before swig_add_library.#
-set(CMAKE_CXX_EXTENSIONS OFF)
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD ${FLAMEGPU_CXX_STD})
-    set(CMAKE_CXX_STANDARD_REQUIRED true)
-endif()
-if(NOT DEFINED CMAKE_CUDA_STANDARD)
-    set(CMAKE_CUDA_STANDARD ${FLAMEGPU_CXX_STD})
-    set(CMAKE_CUDA_STANDARD_REQUIRED True)
-endif()
 
 # Python module name (must match module name in swig input *.i file)
 SET(PYTHON_MODULE_NAME pyflamegpu)

--- a/tests/test_cases/model/test_dependency_graph.cu
+++ b/tests/test_cases/model/test_dependency_graph.cu
@@ -531,7 +531,7 @@ TEST(DependencyGraphTest, UnattachedFunctionWarning) {
     ModelDescription _m(MODEL_NAME);
     AgentDescription &a = _m.newAgent(AGENT_NAME);
     AgentFunctionDescription &f = a.newFunction(FUNCTION_NAME1, agent_fn1);
-    AgentFunctionDescription &f2 = a.newFunction(FUNCTION_NAME2, agent_fn2);
+    a.newFunction(FUNCTION_NAME2, agent_fn2);
 
     DependencyGraph& graph = _m.getDependencyGraph();
     graph.addRoot(f);

--- a/tests/test_cases/test_version.cpp
+++ b/tests/test_cases/test_version.cpp
@@ -16,24 +16,20 @@ TEST(TestVersion, version) {
     const char * namespaced_version_string = flamegpu::VERSION_STRING;
     const char * namespaced_version_full = flamegpu::VERSION_FULL;
 
-    // @todo - figure out a way of embedding the pre-release status? Maybe extern const char *?
-    // std::string version_prerelease = flamegpu::version_prerelease()
-
     EXPECT_EQ(macro_version, namespaced_version);
     // Major must be a positive integer >= 2
-    EXPECT_GE(namespaced_version_major, 2);
+    EXPECT_GE(namespaced_version_major, 2u);
     // Minor must be a non negative integer
-    EXPECT_GE(namespaced_version_minor, 0);
+    EXPECT_GE(namespaced_version_minor, 0u);
     // Patch be a non negative integer
-    EXPECT_GE(namespaced_version_patch, 0);
+    EXPECT_GE(namespaced_version_patch, 0u);
 
     // Perelease must be a string, which may be empty.
-    EXPECT_GE(strlen(namespaced_version_prerelease), 0);
+    EXPECT_GE(strlen(namespaced_version_prerelease), 0u);
     // build must be a string
-    EXPECT_GE(strlen(namespaced_version_buildmetadata), 0);
+    EXPECT_GE(strlen(namespaced_version_buildmetadata), 0u);
     // stirng version must be a string
-    EXPECT_GE(strlen(namespaced_version_string), 0);
+    EXPECT_GE(strlen(namespaced_version_string), 0u);
     // build must be a string
-    EXPECT_GE(strlen(namespaced_version_full), 0);
-    // printf("git_commit_hash %s\n", git_commit_hash.c_str());
+    EXPECT_GE(strlen(namespaced_version_full), 0u);
 }

--- a/tests/test_cases/util/test_SteadyClockTimer.cpp
+++ b/tests/test_cases/util/test_SteadyClockTimer.cpp
@@ -14,7 +14,7 @@ TEST(TestSteadyClockTimer, SteadyClockTimer) {
     // Time an arbitrary event, and check the value is approximately correct.
     timer->start();
     const int sleep_duration_seconds = 1;
-    const int min_expected_millis = sleep_duration_seconds * 1000. * 0.9;
+    const int min_expected_millis = static_cast<int>(sleep_duration_seconds * 1000. * 0.9);
     std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_seconds));
     timer->stop();
     EXPECT_GE(timer->getElapsedMilliseconds(), min_expected_millis);


### PR DESCRIPTION
This makes the warning compiler flag setting target specific (using more-modern cmake). 
This should enable CI-based visualiastion builds for tagged releases.

This must be merged at the same time as https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/73, as they are dependent on one another.

Also made a few minor changes I noticed while waiting on builds.
+ Disables SM20 as a default build target (for older CUDAs that still supported it). Fermi is very EoL. 
+ Slight CMake tidying
+ Removes the Profile build target, that no one uses and just adds CMake that would otherwise want modernising.
+ pre-filters cpp files to only match files cpplint will accept (i.e. not the application icon)
+ Fixes some MSVC test suite warnings