### PR TITLE
CLI Tweaks

### DIFF
--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -47,10 +47,10 @@ class CUDAEnsemble {
         /**
          * If true progress logging to stdout will be suppressed
          */
-        bool silent = false;
+        bool quiet = false;
         /**
          * If true, the total runtime for the ensemble will be printed to stdout at completion
-         * This is independent of the EnsembleConfig::silent
+         * This is independent of the EnsembleConfig::quiet
          */
         bool timing = false;
     };

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -183,6 +183,11 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
         // Get arg as lowercase
         std::string arg(argv[i]);
         std::transform(arg.begin(), arg.end(), arg.begin(), [](unsigned char c) { return std::use_facet< std::ctype<char>>(std::locale()).tolower(c); });
+        // -h/--help. Print the help output and exit.
+        if (arg.compare("--help") == 0 || arg.compare("-h") == 0) {
+            printHelp(argv[0]);
+            return false;
+        }
         // --concurrent <runs>, Number of concurrent simulations to run per device
         if (arg.compare("--concurrent") == 0 || arg.compare("-c") == 0) {
             if (i + 1 >= argc) {
@@ -268,6 +273,7 @@ void CUDAEnsemble::printHelp(const char *executable) {
     printf("Usage: %s [optional arguments]\n", executable);
     printf("Optional Arguments:\n");
     const char *line_fmt = "%-18s %s\n";
+    printf(line_fmt, "-h, --help", "show this help message and exit");
     printf(line_fmt, "-d, --devices <device ids>", "Comma separated list of device ids to be used");
     printf(line_fmt, "", "By default, all available devices will be used.");
     printf(line_fmt, "-c, --concurrent <runs>", "Number of concurrent simulations to run per device");

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <condition_variable>
 
+#include "flamegpu/version.h"
 #include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/sim/RunPlanVector.h"
 #include "flamegpu/util/detail/compute_capability.cuh"
@@ -170,6 +171,10 @@ void CUDAEnsemble::initialise(int argc, const char** argv) {
     if (!checkArgs(argc, argv)) {
         exit(EXIT_FAILURE);
     }
+    // If verbsoe, output the flamegpu version.
+    if (!config.silent) {
+        fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
+    }
 }
 int CUDAEnsemble::checkArgs(int argc, const char** argv) {
     // Parse optional args
@@ -259,6 +264,7 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
     return true;
 }
 void CUDAEnsemble::printHelp(const char *executable) {
+    printf("FLAME GPU %s\n", flamegpu::VERSION_FULL);
     printf("Usage: %s [optional arguments]\n", executable);
     printf("Optional Arguments:\n");
     const char *line_fmt = "%-18s %s\n";

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -114,12 +114,12 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
 
     // Init with placement new
     {
-        if (!config.silent)
+        if (!config.quiet)
             printf("\rCUDAEnsemble progress: %u/%u", 0, static_cast<unsigned int>(plans.size()));
         unsigned int i = 0;
         for (auto &d : devices) {
             for (unsigned int j = 0; j < config.concurrent_runs; ++j) {
-                new (&runners[i++]) SimRunner(model, err_ct, next_run, plans, step_log_config, exit_log_config, d, j, !config.silent, run_logs, log_export_queue, log_export_queue_mutex, log_export_queue_cdn);
+                new (&runners[i++]) SimRunner(model, err_ct, next_run, plans, step_log_config, exit_log_config, d, j, !config.quiet, run_logs, log_export_queue, log_export_queue_mutex, log_export_queue_cdn);
             }
         }
     }
@@ -154,7 +154,7 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
     ensemble_elapsed_time = ensemble_timer.getElapsedMilliseconds();
 
     // Ensemble has finished, print summary
-    if (!config.silent) {
+    if (!config.quiet) {
         printf("\rCUDAEnsemble completed %u runs successfully!\n", static_cast<unsigned int>(plans.size() - err_ct));
         if (err_ct)
             printf("There were a total of %u errors.\n", err_ct.load());
@@ -172,7 +172,7 @@ void CUDAEnsemble::initialise(int argc, const char** argv) {
         exit(EXIT_FAILURE);
     }
     // If verbsoe, output the flamegpu version.
-    if (!config.silent) {
+    if (!config.quiet) {
         fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
     }
 }
@@ -247,9 +247,9 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
             }
             continue;
         }
-        // -s/--silent, Don't report progress to console.
-        if (arg.compare("--silent") == 0 || arg.compare("-s") == 0) {
-            config.silent = true;
+        // -q/--quiet, Don't report progress to console.
+        if (arg.compare("--quiet") == 0 || arg.compare("-q") == 0) {
+            config.quiet = true;
             continue;
         }
         // -t/--timing, Output timing information to stdout
@@ -273,7 +273,7 @@ void CUDAEnsemble::printHelp(const char *executable) {
     printf(line_fmt, "-c, --concurrent <runs>", "Number of concurrent simulations to run per device");
     printf(line_fmt, "", "By default, 4 will be used.");
     printf(line_fmt, "-o, --out <directory> <filetype>", "Directory and filetype for ensemble outputs");
-    printf(line_fmt, "-s, --silent", "Don't print progress information to console");
+    printf(line_fmt, "-q, --quiet", "Don't print progress information to console");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
 }
 void CUDAEnsemble::setStepLog(const StepLoggingConfig &stepConfig) {

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -149,7 +149,7 @@ CUDASimulation::CUDASimulation(const std::shared_ptr<SubModelData> &submodel_des
     for (auto it_sm = smm.cbegin(); it_sm != smm.cend(); ++it_sm) {
         submodel_map.emplace(it_sm->first, std::unique_ptr<CUDASimulation>(new CUDASimulation(it_sm->second, this)));
     }
-    // Submodels all run silent by default
+    // Submodels all run quiet/not verbose by default
     SimulationConfig().verbose = false;
     SimulationConfig().steps = submodel_desc->max_steps;
 }

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <atomic>
 
+#include "flamegpu/version.h"
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/model/SubModelData.h"
 #include "flamegpu/io/XMLStateWriter.h"
@@ -90,6 +91,10 @@ void Simulation::applyConfig() {
         } catch(std::exception &e) {
             THROW exception::InvalidArgument("Failed to init exit log file directory: '%s': %s\n", t_path.c_str(), e.what());
         }
+    }
+    // If verbsoe, output the flamegpu version.
+    if (config.verbose) {
+        fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
     }
     // Call derived class config stuff first
     applyConfig_derived();
@@ -261,6 +266,7 @@ int Simulation::checkArgs(int argc, const char** argv) {
 }
 
 void Simulation::printHelp(const char* executable) {
+    printf("FLAME GPU %s\n", flamegpu::VERSION_FULL);
     printf("Usage: %s [-s steps] [-d device_id] [-r random_seed]\n", executable);
     printf("Optional Arguments:\n");
     const char *line_fmt = "%-18s %s\n";

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -225,8 +225,8 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.timing = true;
             continue;
         }
-        // -os/--out_step <file.xml/file.json>, Step log file path
-        if (arg.compare("--out_step") == 0 || arg.compare("-os") == 0) {
+        // --out-step <file.xml/file.json>, Step log file path
+        if (arg.compare("--out-step") == 0) {
             if (i + 1 >= argc) {
                 fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
                 return false;
@@ -234,8 +234,8 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.step_log_file = argv[++i];
             continue;
         }
-        // -oe/--out_exit <file.xml/file.json>, Exit log file path
-        if (arg.compare("--out_exit") == 0 || arg.compare("-oe") == 0) {
+        // --out-exit <file.xml/file.json>, Exit log file path
+        if (arg.compare("--out-exit") == 0) {
             if (i + 1 >= argc) {
                 fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
                 return false;
@@ -243,8 +243,8 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.exit_log_file = argv[++i];
             continue;
         }
-        // -ol/--out_log <file.xml/file.json>, Common log file path
-        if (arg.compare("--out_log") == 0 || arg.compare("-ol") == 0) {
+        // --out-log <file.xml/file.json>, Common log file path
+        if (arg.compare("--out-log") == 0) {
             if (i + 1 >= argc) {
                 fprintf(stderr, "%s requires a trailing argument\n", arg.c_str());
                 return false;
@@ -277,9 +277,9 @@ void Simulation::printHelp(const char* executable) {
     const char *line_fmt = "%-18s %s\n";
     printf(line_fmt, "-h, --help", "show this help message and exit");
     printf(line_fmt, "-i, --in <file.xml/file.json>", "Initial state file (XML or JSON)");
-    printf(line_fmt, "-os, --out_step <file.xml/file.json>", "Step log file (XML or JSON)");
-    printf(line_fmt, "-oe, --out_exit <file.xml/file.json>", "Exit log file (XML or JSON)");
-    printf(line_fmt, "-ol, --out_log <file.xml/file.json>", "Common log file (XML or JSON)");
+    printf(line_fmt, "    --out-step <file.xml/file.json>", "Step log file (XML or JSON)");
+    printf(line_fmt, "    --out-exit <file.xml/file.json>", "Exit log file (XML or JSON)");
+    printf(line_fmt, "    --out-log <file.xml/file.json>", "Common log file (XML or JSON)");
     printf(line_fmt, "-s, --steps <steps>", "Number of simulation iterations");
     printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
     printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -185,6 +185,11 @@ int Simulation::checkArgs(int argc, const char** argv) {
         // Get arg as lowercase
         std::string arg(argv[i]);
         std::transform(arg.begin(), arg.end(), arg.begin(), [](unsigned char c) { return std::use_facet< std::ctype<char>>(std::locale()).tolower(c); });
+        // -h/--help. Print the help output and exit.
+        if (arg.compare("--help") == 0 || arg.compare("-h") == 0) {
+            printHelp(argv[0]);
+            return false;
+        }
         // -in <string>, Specifies the input state file
         if (arg.compare("--in") == 0 || arg.compare("-i") == 0) {
             // We already processed input file above, skip here
@@ -270,6 +275,7 @@ void Simulation::printHelp(const char* executable) {
     printf("Usage: %s [-s steps] [-d device_id] [-r random_seed]\n", executable);
     printf("Optional Arguments:\n");
     const char *line_fmt = "%-18s %s\n";
+    printf(line_fmt, "-h, --help", "show this help message and exit");
     printf(line_fmt, "-i, --in <file.xml/file.json>", "Initial state file (XML or JSON)");
     printf(line_fmt, "-os, --out_step <file.xml/file.json>", "Step log file (XML or JSON)");
     printf(line_fmt, "-oe, --out_exit <file.xml/file.json>", "Exit log file (XML or JSON)");

--- a/tests/swig/python/io/test_logging.py
+++ b/tests/swig/python/io/test_logging.py
@@ -389,7 +389,7 @@ class LoggingTest(TestCase):
         # Run model
         sim = pyflamegpu.CUDAEnsemble(m);
         sim.Config().concurrent_runs = 5;
-        sim.Config().silent = True;
+        sim.Config().quiet = True;
         sim.Config().timing = False;
         # sim.Config().out_directory = "ensemble_out";
         # sim.Config().out_format = "json";

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -376,7 +376,7 @@ TEST(LoggingTest, CUDAEnsembleSimulate) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().silent = true;
+    sim.Config().quiet = true;
     sim.Config().timing = false;
     // sim.Config().out_directory = "ensemble_out";
     // sim.Config().out_format = "json";


### PR DESCRIPTION
+ Output Full version number in help and if output is verbose / not silent
+ Replace CUDAEnsemble `-s/--silent` with `-q/--quiet` to avoid confusion with Simulation -s/--steps
+ `-h/--help` as expected arguments not unexpected for Ensembles and Simulations
+ remove short options `-oe` `-ol` `-os`. Short options should be single char