### PR TITLE
Make windows CI installs aware of CUDA 11.4.1 patch release

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -27,6 +27,7 @@ $CUDA_KNOWN_URLS = @{
     "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe"
     "11.3.1" = "https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe"
     "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe"
+    "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
-            cuda: "11.4.0"
+            cuda: "11.4.1"
             cuda_arch: 52
             visual_studio: "Visual Studio 16 2019"
           # - os: windows-2019


### PR DESCRIPTION
11.4.1 is generally uninteresting other than shipping with a slightly more recent driver, a few library bugfixes and support for gcc 11 and clang 12 (although there may still be issues with the distributed release of gcc 10.3? and 11.0? if they are unpatched (see #575)

Linux CI automaticlaly uses the latest patch for a given minor release, but this is not possible with windows. 