### PR TITLE
RTC #Line

### DIFF
--- a/include/flamegpu/model/AgentFunctionDescription.h
+++ b/include/flamegpu/model/AgentFunctionDescription.h
@@ -188,9 +188,20 @@ class AgentFunctionDescription : public DependencyNode {
      * Only agents which return true perform the attached FLAMEGPU_AGENT_FUNCTION
      * and transition from the initial to end state.
      * The string will be compiled at runtime.
-     *
+     * @param func_cond_src Source containing RTC agent function condition source
+     * @see setRTCFunctionConditionFile()
      */
     void setRTCFunctionCondition(std::string func_cond_src);
+    /**
+     * Sets the RTC function condition for the agent function, with an agent function condition loaded from file
+     * This is file containing a definition of an FLAMEGPU_AGENT_FUNCTION_CONDITION which returns a boolean value (true or false)
+     * Only agents which return true perform the attached FLAMEGPU_AGENT_FUNCTION
+     * and transition from the initial to end state.
+     * The string will be compiled at runtime.
+     * @param file_path Location on disk of file containing RTC agent function condition source
+     * @see setRTCFunctionCondition()
+     */
+    void setRTCFunctionConditionFile(const std::string& file_path);
 
     /**
      * @return A mutable reference to the message input of this agent function

--- a/include/flamegpu/runtime/detail/curve/curve_rtc.cuh
+++ b/include/flamegpu/runtime/detail/curve/curve_rtc.cuh
@@ -143,6 +143,12 @@ class CurveRTCHost {
      */
     void unregisterEnvVariable(const char* propertyName);
     /**
+     * Set the filename tagged in the file (goes into a #line statement)
+     * @param filename Name to be used for the file in compile errors
+     * @note Do not include quotes
+     */
+    void setFileName(const std::string& filename);
+    /**
      * Generates and returns the dynamic header based on the currently registered variables and properties
      * @return The dynamic Curve header
      */

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -581,8 +581,14 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, bool f
         }
     }
 
+    std::string header_filename = std::string(func.rtc_func_name).append("_impl");
+    if (function_condition)
+        header_filename.append("_condition");
+    header_filename.append("_curve_rtc_dynamic.h");
+    curve_header.setFileName(header_filename);
+
     // get the dynamically generated header from curve rtc
-    std::string curve_dynamic_header = curve_header.getDynamicHeader();
+    const std::string curve_dynamic_header = curve_header.getDynamicHeader();
 
     // output to disk if OUTPUT_RTC_DYNAMIC_FILES macro is set
 #ifdef OUTPUT_RTC_DYNAMIC_FILES

--- a/src/flamegpu/model/AgentFunctionDescription.cpp
+++ b/src/flamegpu/model/AgentFunctionDescription.cpp
@@ -409,6 +409,20 @@ void AgentFunctionDescription::setRTCFunctionCondition(std::string func_cond_src
     function->rtc_func_condition_name = func_cond_name;
     function->rtc_condition_source = func_cond_src_str;
 }
+void AgentFunctionDescription::setRTCFunctionConditionFile(const std::string& file_path) {
+    // Load file and forward to regular RTC method
+    std::ifstream file;
+    file.open(file_path);
+    if (file.is_open()) {
+        std::stringstream sstream;
+        sstream << file.rdbuf();
+        const std::string func_src = sstream.str();
+        setRTCFunctionCondition(func_src);
+    }
+    THROW exception::InvalidFilePath("Unable able to open file '%s', "
+        "in AgentDescription::newRTCFunctionFile().",
+        file_path.c_str());
+}
 
 MessageBruteForce::Description &AgentFunctionDescription::MessageInput() {
     if (auto m = function->message_input.lock())

--- a/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
+++ b/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
@@ -19,6 +19,7 @@ namespace curve {
 
 
 const char* CurveRTCHost::curve_rtc_dynamic_h_template = R"###(dynamic/curve_rtc_dynamic.h
+#line 1 "$FILENAME"
 #ifndef CURVE_RTC_DYNAMIC_H_
 #define CURVE_RTC_DYNAMIC_H_
 
@@ -918,6 +919,10 @@ void CurveRTCHost::initDataBuffer() {
     for (auto &element : newAgent_variables) {
         element.second.h_data_ptr = h_data_buffer + newAgent_data_offset + (ct++ * sizeof(void*));
     }
+}
+
+void CurveRTCHost::setFileName(const std::string &filename) {
+    setHeaderPlaceholder("$FILENAME", filename);
 }
 
 std::string CurveRTCHost::getDynamicHeader() {


### PR DESCRIPTION
~~This is currently a draft, we need to decide how we want these line numbers to appear.~~

e.g.

If a user has not got `EXPORT_RTC_SOURCES` enabled, then their only reference to line, is the string/file they pass to FLAMEGPU. So first line of that should be line 1 (ignoring injected includes etc).

If a user has got `EXPORT_RTC_SOURCES` enabled, then instead it can be assumed they will be referring to the exported files. In which case, the start of that string should be appended `#line 2 filename`. 2, because the exported source will include the `#line` statement on line 1.

I'm not really a fan of this inconsistency, but it makes sense. So if agreed I will tweak the PR to handle those cases.

Addresses #608