### PR TITLE
Prevent Absolute paths (gcc/clang only)

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -32,6 +32,7 @@ mark_as_advanced(CMAKE_USE_FOLDERS)
 # Include files which define target specific functions.
 include(${CMAKE_CURRENT_LIST_DIR}/warnings.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cxxstd.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/embedded_paths.cmake)
 
 # Cmake 3.16 has an issue with the order of CUDA includes when using SYSTEM for user-provided thrust. Avoid this by not using SYSTEM for cmake 3.16
 set(INCLUDE_SYSTEM_FLAG SYSTEM)
@@ -256,6 +257,7 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
 
     # Set target level warnings.
     EnableCompilerWarnings(TARGET "${NAME}")
+    TargetStripBuildDirectoryInformation(TARGET "${NAME}")
     
     # @todo - Once public/private/interface is perfected on the library, some includes may need adding back here.
 
@@ -382,6 +384,7 @@ function(add_flamegpu_library NAME SRC FLAMEGPU_ROOT)
 
     # Set target level warnings.
     EnableCompilerWarnings(TARGET "${NAME}")
+    TargetStripBuildDirectoryInformation(TARGET "${NAME}")
 
     # enable "fpic" for linux to allow shared libraries to be build from the static library (required for swig)
     set_property(TARGET ${NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cmake/embedded_paths.cmake
+++ b/cmake/embedded_paths.cmake
@@ -1,0 +1,38 @@
+# Series of cmake rules that remove absoluate paths from binary (i.e. for reprdoucibility)
+# See https://reproducible-builds.org/docs/build-path/ for some informatio non this.
+
+# Define a function which modifies absoluate paths for a given target.
+function(TargetStripBuildDirectoryInformation)
+    # Parse the expected arguments, prefixing variables.
+    cmake_parse_arguments(
+        STRIP_BUILD_DIR_INFO
+        ""
+        "TARGET"
+        ""
+        ${ARGN}
+    )
+    # Ensure that a target has been passed, and that it is a valid target.
+    if(NOT STRIP_BUILD_DIR_INFO_TARGET)
+        message( FATAL_ERROR "EnableCompilerWarnings: 'TARGET' argument required." )
+    elseif(NOT TARGET ${STRIP_BUILD_DIR_INFO_TARGET} )
+        message( FATAL_ERROR "EnableCompilerWarnings: TARGET '${STRIP_BUILD_DIR_INFO_TARGET}' is not a valid target" )
+    endif()
+    # GCC 8+, clang 10+ supports -ffile-prefix-map as an aliase for -fmacro-prefix-map (__FILE__) and -fdebug-prefix-map (Debug info)
+    # GCC, clang 3.8+ support -fdebug-prefix-map to strip debug info.
+    # NVCC/NVHPC/MSVC do not appear to support similar options.
+    if(
+        (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
+        OR 
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    )
+        target_compile_options(${STRIP_BUILD_DIR_INFO_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.>")
+        target_compile_options(${STRIP_BUILD_DIR_INFO_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -ffile-prefix-map=${CMAKE_SOURCE_DIR}=.>")
+    elseif(
+        (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        OR 
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "3.8")
+    )
+        target_compile_options(${STRIP_BUILD_DIR_INFO_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-debug-prefix-map=${CMAKE_SOURCE_DIR}=.>")
+        target_compile_options(${STRIP_BUILD_DIR_INFO_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -debug-prefix-map=${CMAKE_SOURCE_DIR}=.>")
+    endif()
+endfunction()

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -31,6 +31,9 @@ FLAMEGPU_AGENT_FUNCTION(update, flamegpu::MsgArray2D, flamegpu::MsgNone) {
     return flamegpu::ALIVE;
 }
 int main(int argc, const char ** argv) {
+
+    printf("FILE LINE %s:%d\n", __FILE__, __LINE__);
+
     const unsigned int SQRT_AGENT_COUNT = 1000;
     const unsigned int AGENT_COUNT = SQRT_AGENT_COUNT * SQRT_AGENT_COUNT;
     NVTX_RANGE("main");


### PR DESCRIPTION
Use clang/gcc flags to replace absolute embeded paths with relative to the repo root

Part of #499. 

MSVC/NVHPC do not currently have equivalent flags, also undecided how desirable this is.