### PR TITLE
Add CMake Deprecation messages for CUDA 10, CMake<3.18, C++14

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -27,7 +27,7 @@ jobs:
         echo "$(pwd)/bin" >> $GITHUB_PATH
 
     - name: Configure cmake
-      run: cmake . -B build -DBUILD_API_DOCUMENTATION=ON -DWARNINGS_AS_ERRORS=${{ env.Werror }}
+      run: cmake . -B build -DBUILD_API_DOCUMENTATION=ON -DWARNINGS_AS_ERRORS=${{ env.Werror }} -DCMAKE_WARN_DEPRECATED=OFF
 
     - name: Docs
       run: cmake --build . --target docs --verbose -j `nproc`

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Configure cmake, including tests to make sure they are linted.
     - name: Configure cmake
-      run: cmake . -B ${{ env.build_dir }} -DBUILD_TESTS=${{ env.build_tests }} 
+      run: cmake . -B ${{ env.build_dir }} -DBUILD_TESTS=${{ env.build_tests }} -DCMAKE_WARN_DEPRECATED=OFF
 
     # Run the linter.
     - name: Lint

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -64,7 +64,7 @@ jobs:
       run: sudo apt-get install python3-venv
 
     - name: Configure cmake
-      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.Werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DBUILD_SWIG_PYTHON=ON -DUSE_NVTX=ON
+      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.Werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DCMAKE_WARN_DEPRECATED=OFF -DBUILD_SWIG_PYTHON=ON -DUSE_NVTX=ON
 
     - name: Build flamegpu
       run: cmake --build . --target flamegpu --verbose -j `nproc`
@@ -84,7 +84,7 @@ jobs:
       working-directory: ${{ env.build_dir }}
 
     - name: Configure Individual example
-      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -DWARNINGS_AS_ERRORS=${{ env.Werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev
+      run: cmake . -B ${{ env.build_dir }} -DCMAKE_BUILD_TYPE=${{ env.config }} -DWARNINGS_AS_ERRORS=${{ env.Werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DCMAKE_WARN_DEPRECATED=OFF
       working-directory: examples/${{ env.individual_example }}
     
     - name: Build Individual example

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -57,7 +57,7 @@ jobs:
     # Windows GHA fix: specify Python3_ROOT_DIR and _EXECUTABLE to make sure python.exe is found, not python3.exe which does not work with venv
     - name: Configure CMake
       id: configure
-      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DBUILD_SWIG_PYTHON=ON -DPython3_ROOT_DIR=$(dirname $(which python)) -DPython3_EXECUTABLE=$(which python) -DUSE_NVTX=ON
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DBUILD_TESTS=${{ env.build_tests }} -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DCMAKE_WARN_DEPRECATED=OFF -DBUILD_SWIG_PYTHON=ON -DPython3_ROOT_DIR=$(dirname $(which python)) -DPython3_EXECUTABLE=$(which python) -DUSE_NVTX=ON
       shell: bash
 
     - name: Build flamegpu
@@ -78,7 +78,7 @@ jobs:
       working-directory: ${{ env.build_dir }}
 
     - name: Configure Individual example
-      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev
+      run: cmake . -B ${{ env.build_dir }} -G "${{ matrix.visual_studio }}" -A x64 -DWARNINGS_AS_ERRORS=${{ env.werror }} -DCUDA_ARCH="${{ matrix.cuda_arch }}" -Werror=dev -DCMAKE_WARN_DEPRECATED=OFF
       working-directory: examples/${{ env.individual_example }}
     
     - name: Build Individual example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,12 +44,19 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-# CUDA 10.0 is the current minimum supported verison.
-set(MINIMUM_SUPPORTED_CUDA_VERSION 10.0)
+# CUDA 10.0 is the current minimum working but deprecated verison, which will be removed.
+set(MINIMUM_CUDA_VERSION 10.0)
 # If the CUDA compiler is too old, trigger a docs only build.
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_SUPPORTED_CUDA_VERSION})
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_CUDA_VERSION})
     set(DOCUMENTATION_ONLY_BUILD ON)
     message(STATUS "Documentation-only build: CUDA ${MINIMUM_SUPPORTED_CUDA_VERSION} or greater is required for compilation.")
+endif()
+
+# CUDA 11.0 is the current minimum supported version.
+set(MINIMUM_SUPPORTED_CUDA_VERSION 11.0)
+# If the CUDA compiler is atleast the minimum deprecated version, but less than the minimum actually supported version, issue a dev warning.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL ${MINIMUM_CUDA_VERSION} AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_SUPPORTED_CUDA_VERSION})
+    message(DEPRECATION "Support for CUDA verisons <= ${MINIMUM_SUPPORTED_CUDA_VERSION} is deprecated and will be removed in a future release.")
 endif()
 
 # If CUDA is not available, or the minimum version is too low only build the docs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 # CMake 3.15+ for Thrust/Cub support
 cmake_minimum_required(VERSION VERSION 3.15 FATAL_ERROR)
 
+# Emit a deprecation warning if CMAKE < 3.18 which is required for c++17 in the future.
+set(CMAKE_MINIMUM_SUPPORTED_VERSION 3.18)
+if(${CMAKE_VERSION} VERSION_LESS ${CMAKE_MINIMUM_SUPPORTED_VERSION})
+    message(DEPRECATION "Support for CMake < ${CMAKE_MINIMUM_SUPPORTED_VERSION} is deprecated and will be removed in a  future release.")
+endif()
+
+
 project(FLAMEGPU LANGUAGES NONE)
 
 # Don't create installation scripts (and hide CMAKE_INSTALL_PREFIX from cmake-gui)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -116,12 +116,22 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DJITIFY_PRINT_LOG")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJITIFY_PRINT_LOG")
 
 # Set the minimum supported cuda version, if not already set. Currently duplicated due to docs only build logic.
-if(NOT DEFINED MINIMUM_SUPPORTED_CUDA_VERSION)
-    set(MINIMUM_SUPPORTED_CUDA_VERSION 10.0)
+# CUDA 10.0 is the current minimum working but deprecated verison, which will be removed.
+if(NOT DEFINED MINIMUM_CUDA_VERSION)
+    set(MINIMUM_CUDA_VERSION 10.0)
+    # Require a minimum cuda version
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_CUDA_VERSION})
+        message(FATAL_ERROR "CUDA version must be at least ${MINIMUM_CUDA_VERSION}")
+    endif()
 endif()
-# Require a minimum cuda version
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_SUPPORTED_CUDA_VERSION})
-    message(FATAL_ERROR "CUDA version must be at least ${MINIMUM_SUPPORTED_CUDA_VERSION}")
+# CUDA 11.0 is the current minimum supported version.
+if(NOT DEFINED MINIMUM_SUPPORTED_CUDA_VERSION)
+    set(MINIMUM_SUPPORTED_CUDA_VERSION 11.0)
+    # Warn on deprecated cuda version.
+    # If the CUDA compiler is atleast the minimum deprecated version, but less than the minimum actually supported version, issue a dev warning.
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL ${MINIMUM_CUDA_VERSION} AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS ${MINIMUM_SUPPORTED_CUDA_VERSION})
+        message(DEPRECATION "Support for CUDA verisons <= ${MINIMUM_SUPPORTED_CUDA_VERSION} is deprecated and will be removed in a future release.")
+    endif()
 endif()
 
 # Specify some additional compiler flags

--- a/cmake/cxxstd.cmake
+++ b/cmake/cxxstd.cmake
@@ -9,6 +9,7 @@ if(NOT FLAMEGPU_CXX_STD)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
         # 17 OK
     elseif(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
+        # No need for deprecation warning here, already warning about CMAKE < 3.18 being deprecated elsewhere.
         set(CXX17_SUPPORTED OFF)
     else()
         message(FATAL_ERROR "CMAKE ${CMAKE_VERSION} does not support -std=c++14")
@@ -19,6 +20,7 @@ if(NOT FLAMEGPU_CXX_STD)
         # 17 is ok.
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0.0)
         # 14 is ok, 17 is not.
+        # no need for an extra deprecation warning here, already warning in common about CUDA version.
         set(CXX17_SUPPORTED OFF)
     else()
         # Fatal Error.
@@ -37,6 +39,8 @@ if(NOT FLAMEGPU_CXX_STD)
         elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.11)
             # 17 available?
         elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
+            # Emit a deprecation warning for VS20XX that is not c++17 supporting. I think this is VS2017 which will be broken anyway with CUDA 
+            message(DEPRECATION "Use of MSVC ${CMAKE_CXX_COMPILER_VERSION} is deprecated. A C++17 compiler (>= 19.11) will be required in a future release.")
             set(CXX17_SUPPORTED OFF)
         else()
             message(FATAL_ERROR "MSVC ${CMAKE_CXX_COMPILER_VERSION} does not support -std=c++14")


### PR DESCRIPTION
This just emits a depreaction message at cmake configure time if the CUDA version  is >= 10.0 && < 11.0

I.e. 

```
CMake Deprecation Warning at CMakeLists.txt:59 (message):
  Support for CUDA verisons <= 11.0 is deprecated and will be removed in a
  future release.
````


Part of #611 