### PR TITLE
Bump version to 2.0.0-alpha.1

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -3,7 +3,7 @@ set(FLAMEGPU_VERSION_MAJOR 2)
 set(FLAMEGPU_VERSION_MINOR 0)
 set(FLAMEGPU_VERSION_PATCH 0)
 # Prerelease must be empty, alpha[.N], beta[.N] or rc[.N] for python version compatibility
-set(FLAMEGPU_VERSION_PRERELEASE "alpha") 
+set(FLAMEGPU_VERSION_PRERELEASE "alpha.1") 
 
 
 # Validate the major version


### PR DESCRIPTION
The current versioning plan is to bump the version number for the first commit after a release, so that any version comparisons not including build metadata show it as a newer build. 

The version number used may not end up being a released version, as it can only be an estimate, so probably best to always keep it a pre-release version (-alpha.N, -beta.N, -rc.N). 

This should not be merged until after the tagged release has been made.