### PR TITLE
Avoid CUDA 11.0 + GCC 9 + --std=c++17 compilation segfault

### DIFF
--- a/cmake/cxxstd.cmake
+++ b/cmake/cxxstd.cmake
@@ -60,6 +60,20 @@ if(NOT FLAMEGPU_CXX_STD)
     #     # Forward to the parent scope so it persists between calls.
     #     set(FLAMEGPU_CXX_STD ${FLAMEGPU_CXX_STD} PARENT_SCOPE)
     # endif()
+
+    # Emit a developer warning if using CUDA 11.0 and GCC 9 in c++17 mode re std::vector<std::tuple<...>>::push_back
+    if( CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0"
+        AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.1"
+        AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9"
+        AND CMAKE_CXX_COMILER_VERSION VERSION_LESS "10"
+        AND (FLAMEGPU_CXX_STD EQUAL 17 OR CMAKE_CUDA_STANDARD EQUAL 17))
+        # https://github.com/FLAMEGPU/FLAMEGPU2/issues/650
+        message(AUTHOR_WARNING 
+            "CUDA 11.0 with g++ 9 in c++17 mode may encounter compiler segmentation faults with 'std::vector<std::tuple<...>>::push_back'.\n"
+            "Consider using CUDA 11.1+ or gcc 8 to avoid potential issues.\n"
+            "See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650 for more information.")
+    endif()
 endif()
 
 # @future - set this on a per target basis using set_target_properties?

--- a/examples/sugarscape/src/main.cu
+++ b/examples/sugarscape/src/main.cu
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <array>
 
 #include "flamegpu/flamegpu.h"
 
@@ -396,7 +397,7 @@ int main(int argc, const char ** argv) {
     if (cudaSimulation.getSimulationConfig().input_file.empty()) {
         std::default_random_engine rng;
         // Pre init, decide the sugar hotspots
-        std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>> sugar_hotspots;
+        std::vector<std::array<unsigned int, 4>> sugar_hotspots;
         {
             std::uniform_int_distribution<unsigned int> width_dist(0, GRID_WIDTH-1);
             std::uniform_int_distribution<unsigned int> height_dist(0, GRID_HEIGHT-1);
@@ -406,7 +407,7 @@ int main(int argc, const char ** argv) {
             float hotspot_area = 0;
             while (hotspot_area < GRID_WIDTH * GRID_HEIGHT) {
                 unsigned int rad = radius_dist(rng);
-                std::tuple<int, int, unsigned int, unsigned int> hs = {width_dist(rng), height_dist(rng), rad, SUGAR_MAX_CAPACITY };
+                std::array<unsigned int, 4> hs = {width_dist(rng), height_dist(rng), rad, SUGAR_MAX_CAPACITY };
                 sugar_hotspots.push_back(hs);
                 hotspot_area += 3.141f * rad * rad;
             }
@@ -444,8 +445,8 @@ int main(int argc, const char ** argv) {
                 const int hotspot_core_size = 5;
                 for (auto &hs : sugar_hotspots) {
                     // Workout the highest sugar lvl from a nearby hotspot
-                    int hs_x = std::get<0>(hs);
-                    int hs_y = std::get<1>(hs);
+                    int hs_x = static_cast<int>(std::get<0>(hs));
+                    int hs_y = static_cast<int>(std::get<1>(hs));
                     unsigned int hs_rad = std::get<2>(hs);
                     unsigned int hs_level = std::get<3>(hs);
                     float hs_dist = static_cast<float>(sqrt(pow(hs_x-static_cast<int>(x), 2.0) + pow(hs_y-static_cast<int>(y), 2.0)));

--- a/tests/test_cases/runtime/test_agent_random.cu
+++ b/tests/test_cases/runtime/test_agent_random.cu
@@ -56,7 +56,8 @@ TEST(AgentRandomTest, AgentRandomCheck) {
     const char *args_1[5] = { "process.exe", "-r", "0", "-s", "1" };
     const char *args_2[5] = { "process.exe", "-r", "1", "-s", "1" };
     std::string _t_unused = std::string();
-    std::vector<std::tuple<float, float, float>> results1, results2;
+    // Not using std::vector<std::tuple<float, float, float>> due to an NVCC 11.0 + GCC 9 bug in C++17 mode. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650
+    std::vector<std::array<float, 3>> results1, results2;
     {
         /**
         * Test Model 1
@@ -82,7 +83,7 @@ TEST(AgentRandomTest, AgentRandomCheck) {
             a1 = instance.getVariable<float>("a");
             b1 = instance.getVariable<float>("b");
             c1 = instance.getVariable<float>("c");
-            results1.push_back(std::make_tuple(a1, b1, c1));
+            results1.push_back({a1, b1, c1});
             if (i != 0) {
                 // Different agents get different random numbers
                 EXPECT_TRUE(a1 != a2);
@@ -111,10 +112,10 @@ TEST(AgentRandomTest, AgentRandomCheck) {
 
         for (unsigned int i = 0; i < population.size(); i++) {
             AgentVector::Agent instance = population[i];
-            results2.push_back(std::make_tuple(
+            results2.push_back({
                 instance.getVariable<float>("a"),
                 instance.getVariable<float>("b"),
-                instance.getVariable<float>("c")));
+                instance.getVariable<float>("c")});
         }
         EXPECT_TRUE(results2.size() == AGENT_COUNT);
 
@@ -139,10 +140,10 @@ TEST(AgentRandomTest, AgentRandomCheck) {
 
         for (unsigned int i = 0; i < population.size(); i++) {
             AgentVector::Agent instance = population[i];
-            results2.push_back(std::make_tuple(
+            results2.push_back({
                 instance.getVariable<float>("a"),
                 instance.getVariable<float>("b"),
-                instance.getVariable<float>("c")));
+                instance.getVariable<float>("c")});
         }
         EXPECT_EQ(results2.size(), AGENT_COUNT);
 


### PR DESCRIPTION
 `std::vector<std::tuple<>>::push_back()` leads to compiler segmentation faults when using CUDA 11.0 with gcc-9 and the `--std=c++17` flag.

This is fixed by using a newer CUDA version, older GCC, or lower `--std`, so not worth a CUDA bug report.

+ [x] Uses `std::vector<std::array<>>` as a hacky workaround
+ [x]  Add a CMake dev warning about this compiler combination, but do not prevent it's use. 

Closes #650

Separately, new CI has been adjusted to not enable this bad compiler combination.
