### PR TITLE
Ensemble, RunPlan(Vector) testing and RNG Changes

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -64,7 +64,8 @@ jobs:
       ARTIFACT_NAME: wheel-windows-${{ matrix.cudacxx.cuda }}-${{matrix.python}}-${{ matrix.VISUALISATION }}-${{ matrix.config.name }}-${{ matrix.cudacxx.os }}
       # Define constants
       BUILD_DIR: "build"
-      BUILD_TESTS: "OFF"
+      # Tests are off for regular builds, but if initiated by a workflow dispatch then they are enabled. Horribly json terriarry to achieve
+      BUILD_TESTS: ${{ fromJSON('{true:"ON",false:"OFF"}')[github.event_name == 'workflow_dispatch' && matrix.VISUALISATION == 'OFF'] }}
       # Conditional based on matrix via awkward almost ternary
       BUILD_SWIG_PYTHON: ${{ fromJSON('{true:"ON",false:"OFF"}')[matrix.python != ''] }}
       # Port matrix options to environment, for more portability.

--- a/examples/boids_bruteforce/src/main.cu
+++ b/examples/boids_bruteforce/src/main.cu
@@ -390,7 +390,7 @@ int main(int argc, const char ** argv) {
     if (cudaSimulation.getSimulationConfig().input_file.empty()) {
         flamegpu::EnvironmentDescription &env = model.Environment();
         // Uniformly distribute agents within space, with uniformly distributed initial velocity.
-        std::mt19937 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
+        std::mt19937_64 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
         std::uniform_real_distribution<float> position_distribution(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MAX_POSITION"));
         std::uniform_real_distribution<float> velocity_distribution(-1, 1);
         std::uniform_real_distribution<float> velocity_magnitude_distribution(env.getProperty<float>("MIN_INITIAL_SPEED"), env.getProperty<float>("MAX_INITIAL_SPEED"));

--- a/examples/boids_bruteforce_dependency_graph/src/main.cu
+++ b/examples/boids_bruteforce_dependency_graph/src/main.cu
@@ -382,7 +382,7 @@ int main(int argc, const char ** argv) {
     if (cudaSimulation.getSimulationConfig().input_file.empty()) {
         flamegpu::EnvironmentDescription &env = model.Environment();
         // Uniformly distribute agents within space, with uniformly distributed initial velocity.
-        std::mt19937 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
+        std::mt19937_64 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
         std::uniform_real_distribution<float> position_distribution(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MAX_POSITION"));
         std::uniform_real_distribution<float> velocity_distribution(-1, 1);
         std::uniform_real_distribution<float> velocity_magnitude_distribution(env.getProperty<float>("MIN_INITIAL_SPEED"), env.getProperty<float>("MAX_INITIAL_SPEED"));

--- a/examples/boids_rtc_bruteforce/src/main.cu
+++ b/examples/boids_rtc_bruteforce/src/main.cu
@@ -435,7 +435,7 @@ int main(int argc, const char ** argv) {
     if (cudaSimulation.getSimulationConfig().input_file.empty()) {
         flamegpu::EnvironmentDescription &env = model.Environment();
         // Uniformly distribute agents within space, with uniformly distributed initial velocity.
-        std::mt19937 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
+        std::mt19937_64 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
         std::uniform_real_distribution<float> position_distribution(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MAX_POSITION"));
         std::uniform_real_distribution<float> velocity_distribution(-1, 1);
         std::uniform_real_distribution<float> velocity_magnitude_distribution(env.getProperty<float>("MIN_INITIAL_SPEED"), env.getProperty<float>("MAX_INITIAL_SPEED"));

--- a/examples/boids_rtc_spatial3D/src/main.cu
+++ b/examples/boids_rtc_spatial3D/src/main.cu
@@ -436,7 +436,7 @@ int main(int argc, const char ** argv) {
     // If no xml model file was is provided, generate a population.
     if (cudaSimulation.getSimulationConfig().input_file.empty()) {
         // Uniformly distribute agents within space, with uniformly distributed initial velocity.
-        std::mt19937 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
+        std::mt19937_64 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
         std::uniform_real_distribution<float> position_distribution(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MAX_POSITION"));
         std::uniform_real_distribution<float> velocity_distribution(-1, 1);
         std::uniform_real_distribution<float> velocity_magnitude_distribution(env.getProperty<float>("MIN_INITIAL_SPEED"), env.getProperty<float>("MAX_INITIAL_SPEED"));

--- a/examples/boids_spatial3D/src/main.cu
+++ b/examples/boids_spatial3D/src/main.cu
@@ -401,7 +401,7 @@ int main(int argc, const char ** argv) {
         flamegpu::EnvironmentDescription &env = model.Environment();
         // Uniformly distribute agents within space, with uniformly distributed initial velocity.
         // c++ random number generator engine
-        std::mt19937 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
+        std::mt19937_64 rngEngine(cudaSimulation.getSimulationConfig().random_seed);
         // Uniform distribution for agent position components
         std::uniform_real_distribution<float> position_distribution(env.getProperty<float>("MIN_POSITION"), env.getProperty<float>("MAX_POSITION"));
         // Uniform distribution of velocity direction components

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -77,7 +77,6 @@ class CUDAEnsemble {
 
     /**
      * @return A mutable reference to the ensemble configuration struct
-     * @see CUDAEnsemble::applyConfig() Should be called afterwards to apply changes
      */
     EnsembleConfig &Config() { return config; }
     /**

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -298,7 +298,7 @@ class CUDASimulation : public Simulation {
      * Reinitalises random generation for this model and all submodels
      * @param seed New random seed (this updates stored seed in config)
      */
-    void reseed(const unsigned int &seed);
+    void reseed(const uint64_t &seed);
     /**
      * Number of times step() has been called since sim was last reset/init
      */

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -139,7 +139,7 @@ struct NewAgentStorage {
         }
         const auto t_type = std::type_index(typeid(T));
         if (var->second.type != std::type_index(typeid(T))) {
-            THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
+            THROW exception::InvalidVarType("Variable '%s' has type '%s', incorrect  type '%s' was requested, "
                 "in NewAgentStorage.setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -50,11 +50,11 @@ class HostRandom {
      * Change the seed used for random generation
      * @param seed New random seed
      */
-    void setSeed(const unsigned int &seed);
+    void setSeed(const uint64_t &seed);
     /**
      * Returns the last value used to seed random generation
      */
-    unsigned int getSeed() const;
+    uint64_t getSeed() const;
 
  private:
     explicit HostRandom(RandomManager &_rng) : rng(_rng) { }

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -53,7 +53,7 @@ class RandomManager {
      * Reseeds all owned random generators
      * @note Can be called multiple times to reseed, doing so releases existing memory allocations
      */
-    void reseed(const unsigned int &seed);
+    void reseed(const uint64_t &seed);
     /**
      * Resizes random array according to the rules:
      *   while(length<_length)
@@ -95,7 +95,7 @@ class RandomManager {
     /**
      * Random seed used to initialise all currently allocated curand states
      */
-    unsigned int mSeed = 0;
+    uint64_t mSeed = 0;
     /**
      * Local copy of the length of d_random_state
      */
@@ -135,9 +135,9 @@ class RandomManager {
     /**
      * Seeded host random generator
      * Don't believe this to be thread-safe!
-     * @note - std::default_random_engine is platform (compiler) specific. GCC (7.4) defaults to a linear_congruential_engine, which returns the same sequence for seeds 0 and 1. mt19937 is the default in MSVC and generally seems more sane.
+     * @note - std::default_random_engine is platform (compiler) specific. GCC (7.4) defaults to a linear_congruential_engine, which returns the same sequence for seeds 0 and 1. mt19937 is the default in MSVC and generally seems more sane (but using the 64 bit variant).
      */
-    std::mt19937 host_rng;
+    std::mt19937_64 host_rng;
 
     /**
      * Flag indicating that the device memory has been initialised, and therefore might need resetting

--- a/include/flamegpu/sim/LogFrame.h
+++ b/include/flamegpu/sim/LogFrame.h
@@ -107,7 +107,7 @@ struct RunLog {
     /**
      * Returns the random seed used for this run
      */
-    unsigned int getRandomSeed() const { return random_seed; }
+    uint64_t getRandomSeed() const { return random_seed; }
     /**
      * Returns the frequency that steps were logged
      * @note This value is configured via StepLoggingConfig::setFrequency()
@@ -126,7 +126,7 @@ struct RunLog {
     /**
      * Random seed
      */
-    unsigned int random_seed = 0;
+    uint64_t random_seed = 0;
     /**
      * Step log frequency
      */

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -44,7 +44,7 @@ class RunPlan {
      * Set the random seed passed to this run of the simulation
      * @param random_seed Seed for random generation during execution
      */
-    void setRandomSimulationSeed(const unsigned int &random_seed);
+    void setRandomSimulationSeed(const uint64_t &random_seed);
     /**
      * Set the number of steps for this instance of the simulation
      * A steps value of 0 requires the ModelDescription to have atleast 1 exit condition
@@ -110,7 +110,7 @@ class RunPlan {
     /**
      * Returns the random seed used for this simulation run
      */
-    unsigned int getRandomSimulationSeed() const;
+    uint64_t getRandomSimulationSeed() const;
     /**
      * Returns the number of steps to be executed for this simulation run
      * 0 means unlimited, and is only available if the model description has an exit condition
@@ -173,7 +173,7 @@ class RunPlan {
 
  private:
     explicit RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, const bool &allow_0);
-    unsigned int random_seed;
+    uint64_t random_seed;
     unsigned int steps;
     std::string output_subdirectory;
     std::unordered_map<std::string, util::Any> property_overrides;

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -246,7 +246,7 @@ void RunPlan::setProperty(const std::string &name, const EnvironmentManager::siz
             "in RunPlan::setProperty()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (it->second.data.elements >= index) {
+    if (index >= it->second.data.elements) {
         throw std::out_of_range("Environment property array index out of bounds "
             "in RunPlan::setProperty()\n");
     }
@@ -266,22 +266,22 @@ void RunPlan::setPropertyArray(const std::string &name, const EnvironmentManager
     const auto it = environment->find(name);
     if (it == environment->end()) {
         THROW exception::InvalidEnvProperty("Environment description does not contain property '%s', "
-            "in RunPlan::setProperty()\n",
+            "in RunPlan::setPropertyArray()\n",
             name.c_str());
     }
     if (it->second.data.type != std::type_index(typeid(T))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
-            "in RunPlan::setProperty()\n",
+            "in RunPlan::setPropertyArray()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
     if (it->second.data.elements != N) {
         THROW exception::InvalidEnvProperty("Environment property array '%s' length mismatch %u != %u, "
-            "in RunPlan::setProperty()\n",
+            "in RunPlan::setPropertyArray()\n",
             name.c_str(), it->second.data.elements, N);
     }
     if (value.size() != N) {
         THROW exception::InvalidEnvProperty("Environment property array length does not match the value provided, %u != %llu,"
-            "in RunPlan::setProperty()\n",
+            "in RunPlan::setPropertyArray()\n",
             name.c_str(), value.size(), N);
     }
     // Store property
@@ -363,7 +363,7 @@ T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_t
             "in RunPlan::getProperty()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (it->second.data.elements >= index) {
+    if (index >= it->second.data.elements) {
         throw std::out_of_range("Environment property array index out of bounds "
             "in RunPlan::getProperty()\n");
     }

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -310,9 +310,13 @@ T RunPlan::getProperty(const std::string &name) const {
     }
     // Check whether property already exists in property overrides
     const auto it2 = property_overrides.find(name);
-    if (it2 == property_overrides.end())
-      return *static_cast<T *>(it2->second.ptr);
-    return *static_cast<T *>(it->second.data.ptr);
+    if (it2 != property_overrides.end()) {
+        // The property has been overridden, return the value from the override.
+        return *static_cast<T *>(it2->second.ptr);
+    } else {
+        // The property has not been overridden, so return the value from the environment
+        return *static_cast<T *>(it->second.data.ptr);
+    }
 }
 template<typename T, EnvironmentManager::size_type N>
 std::array<T, N> RunPlan::getProperty(const std::string &name) const {
@@ -336,9 +340,11 @@ std::array<T, N> RunPlan::getProperty(const std::string &name) const {
     // Check whether array already exists in property overrides
     const auto it2 = property_overrides.find(name);
     std::array<T, N> rtn;
-    if (it2 == property_overrides.end()) {
+    if (it2 != property_overrides.end()) {
+        // The property has been overridden, return the override
         memcpy(rtn.data(), it2->second.ptr, it2->second.length);
     } else {
+        // The property has not been overridden, return the environment property
         memcpy(rtn.data(), it->second.data.ptr, it->second.data.length);
     }
     return rtn;
@@ -363,9 +369,13 @@ T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_t
     }
     // Check whether property already exists in property overrides
     const auto it2 = property_overrides.find(name);
-    if (it2 == property_overrides.end())
-      return static_cast<T *>(it2->second.ptr)[index];
-    return static_cast<T *>(it->second.data.ptr)[index];
+    if (it2 != property_overrides.end()) {
+        // The property has been overridden, return the override
+        return static_cast<T *>(it2->second.ptr)[index];
+    } else {
+        // The property has not been overridden, return the environment property
+        return static_cast<T *>(it->second.data.ptr)[index];
+    }
 }
 #ifdef SWIG
 /**
@@ -391,9 +401,11 @@ std::vector<T> RunPlan::getPropertyArray(const std::string &name) {
     // Check whether array already exists in property overrides
     const auto it2 = property_overrides.find(name);
     std::vector<T> rtn(it->second.data.elements);
-    if (it2 == property_overrides.end()) {
+    if (it2 != property_overrides.end()) {
+        // The property has been overridden, return the override
         memcpy(rtn.data(), it2->second.ptr, it2->second.length);
     } else {
+        // The property has not been overridden, return the environment property
         memcpy(rtn.data(), it->second.data.ptr, it->second.data.length);
     }
     return rtn;

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -275,12 +275,12 @@ void RunPlan::setPropertyArray(const std::string &name, const EnvironmentManager
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
     if (it->second.data.elements != N) {
-        THROW exception::InvalidEnvProperty("Environment property array '%s' length mismatch %u != %u, "
+        THROW exception::InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u, "
             "in RunPlan::setPropertyArray()\n",
             name.c_str(), it->second.data.elements, N);
     }
     if (value.size() != N) {
-        THROW exception::InvalidEnvProperty("Environment property array length does not match the value provided, %u != %llu,"
+        THROW exception::InvalidEnvPropertyType("Environment property array length does not match the value provided, %u != %llu,"
             "in RunPlan::setPropertyArray()\n",
             name.c_str(), value.size(), N);
     }

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -341,7 +341,7 @@ void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> 
     }
     if (it->second.data.elements != N) {
         THROW exception::InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
-            "in RunPlan::setProperty()\n",
+            "in RunPlanVector::setProperty()\n",
             name.c_str(), it->second.data.elements, N);
     }
     for (auto &i : *this) {
@@ -362,9 +362,9 @@ void RunPlanVector::setProperty(const std::string &name, const EnvironmentManage
             "in RunPlanVector::setProperty()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (it->second.data.elements >= index) {
+    if (index > it->second.data.elements) {
         throw std::out_of_range("Environment property array index out of bounds "
-            "in RunPlan::setProperty()\n");
+            "in RunPlanVector::setProperty()\n");
     }
     for (auto &i : *this) {
         i.setProperty<T>(name, index, value);
@@ -377,22 +377,22 @@ void RunPlanVector::setPropertyArray(const std::string &name, const EnvironmentM
     const auto it = environment->find(name);
     if (it == environment->end()) {
         THROW exception::InvalidEnvProperty("Environment description does not contain property '%s', "
-            "in RunPlanVector::setProperty()\n",
+            "in RunPlanVector::setPropertyArray()\n",
             name.c_str());
     }
     if (it->second.data.type != std::type_index(typeid(T))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
-            "in RunPlanVector::setProperty()\n",
+            "in RunPlanVector::setPropertyArray()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
     if (it->second.data.elements != N) {
         THROW exception::InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
-            "in RunPlanVector::setProperty()\n",
+            "in RunPlanVector::setPropertyArray()\n",
             name.c_str(), it->second.data.elements, N);
     }
     if (value.size() != N) {
         THROW exception::InvalidEnvProperty("Environment property array length does not match the value provided, %u != %llu,"
-            "in RunPlanVector::setProperty()\n",
+            "in RunPlanVector::setPropertyArray()\n",
             name.c_str(), value.size(), N);
     }
     for (auto &i : *this) {
@@ -449,9 +449,9 @@ void RunPlanVector::setPropertyUniformDistribution(const std::string &name, cons
             "in RunPlanVector::setPropertyUniformDistribution()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (it->second.data.elements >= index) {
+    if (index > it->second.data.elements) {
         throw std::out_of_range("Environment property array index out of bounds "
-            "in RunPlan::setPropertyUniformDistribution()\n");
+            "in RunPlanVector::setPropertyUniformDistribution()\n");
     }
     unsigned int ct = 0;
     for (auto &i : *this) {
@@ -466,22 +466,22 @@ void RunPlanVector::setPropertyRandom(const std::string &name, rand_dist &distri
     // Validation
     if (this->size() < 2) {
         THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
-            "in RunPlanVector::setPropertyUniformDistribution()\n");
+            "in RunPlanVector::setPropertyRandom()\n");
     }
     const auto it = environment->find(name);
     if (it == environment->end()) {
         THROW exception::InvalidEnvProperty("Environment description does not contain property '%s', "
-            "in RunPlanVector::setPropertyUniformDistribution()\n",
+            "in RunPlanVector::setPropertyRandom()\n",
             name.c_str());
     }
     if (it->second.data.type != std::type_index(typeid(T))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
-            "in RunPlanVector::setPropertyUniformDistribution()\n",
+            "in RunPlanVector::setPropertyRandom()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
     if (it->second.data.elements != 1) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
-            "in RunPlanVector::setPropertyUniformDistribution()\n",
+            "in RunPlanVector::setPropertyRandom()\n",
             name.c_str(), it->second.data.elements);
     }
     for (auto &i : *this) {
@@ -493,22 +493,22 @@ void RunPlanVector::setPropertyRandom(const std::string &name, const Environment
     // Validation
     if (this->size() < 2) {
         THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
-            "in RunPlanVector::setPropertyUniformDistribution()\n");
+            "in RunPlanVector::setPropertyRandom()\n");
     }
     const auto it = environment->find(name);
     if (it == environment->end()) {
         THROW exception::InvalidEnvProperty("Environment description does not contain property '%s', "
-            "in RunPlanVector::setPropertyUniformDistribution()\n",
+            "in RunPlanVector::setPropertyRandom()\n",
             name.c_str());
     }
     if (it->second.data.type != std::type_index(typeid(T))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
-            "in RunPlanVector::setPropertyUniformDistribution()\n",
+            "in RunPlanVector::setPropertyRandom()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (it->second.data.elements >= index) {
+    if (index > it->second.data.elements) {
         throw std::out_of_range("Environment property array index out of bounds "
-            "in RunPlan::setPropertyUniformDistribution()\n");
+            "in RunPlanVector::setPropertyRandom()\n");
     }
     for (auto &i : *this) {
         i.setProperty<T>(name, index, static_cast<T>(distribution(this->rand)));

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -316,7 +316,7 @@ void RunPlanVector::setProperty(const std::string &name, const T &value) {
             "in RunPlanVector::setProperty()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (it->second.data.elements == 1) {
+    if (it->second.data.elements != 1) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
             "in RunPlanVector::setProperty()\n",
             name.c_str(), it->second.data.elements);

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -37,7 +37,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @param step The value added to the previous seed to calculate the next seed
      * @note A step of 0, will give the exact same seed to all RunPlans
      */
-    void setRandomSimulationSeed(const unsigned int &initial_seed, const unsigned int &step = 0);
+    void setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int &step = 0);
     /**
      * Set the steps of each RunPlan currently within this vector
      * @param steps The number of steps to be executed
@@ -135,7 +135,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * This will only affect subsequent calls to setPropertyRandom()
      * @param seed The random seed to be used
      */
-    void setRandomPropertySeed(const unsigned int &seed);
+    void setRandomPropertySeed(const uint64_t &seed);
     /**
      * Sweep named environment property over a uniform random distribution
      * Integer types have a range [min, max]
@@ -287,7 +287,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * Random distribution used by setPropertyRandom()
      * Initially set to a random seed with std::random_device (which is a platform specific source of random integers)
      */
-    std::mt19937 rand;
+    std::mt19937_64 rand;
     std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> environment;
     const bool allow_0_steps;
 };

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -137,6 +137,12 @@ class RunPlanVector : private std::vector<RunPlan>  {
      */
     void setRandomPropertySeed(const uint64_t &seed);
     /**
+     * Get the seed used for the internal random generator used for random property distributions
+     * This will only valid for calls to setPropertyRandom() since the last call toSetRandomPropertySeed
+     * @return the seed used for random properties since the last call to setPropertyRandom
+     */
+    uint64_t getRandomPropertySeed();
+    /**
      * Sweep named environment property over a uniform random distribution
      * Integer types have a range [min, max]
      * Floating point types have a range [min, max)
@@ -283,6 +289,10 @@ class RunPlanVector : private std::vector<RunPlan>  {
 
  private:
     RunPlanVector(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, const bool &allow_0_steps);
+    /**
+     * Seed used for the current `rand` instance, which is only valid for elements generated since the last call to setRandomPropertySeed
+     */
+    uint64_t randomPropertySeed;
     /**
      * Random distribution used by setPropertyRandom()
      * Initially set to a random seed with std::random_device (which is a platform specific source of random integers)

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -30,7 +30,7 @@ class Simulation {
      * General simulation runner specific config
      */
     struct Config {
-        Config() : random_seed(static_cast<unsigned int>(time(nullptr))) {
+        Config() : random_seed(static_cast<uint64_t>(time(nullptr))) {
         }
         void operator=(const Config &other) {
             input_file = other.input_file;
@@ -47,7 +47,7 @@ class Simulation {
         std::string exit_log_file;
         std::string common_log_file;
         bool truncate_log_files = true;
-        unsigned int random_seed;
+        uint64_t random_seed;
         unsigned int steps = 1;
         bool verbose = false;
         bool timing = false;

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -171,10 +171,12 @@ void CUDAEnsemble::initialise(int argc, const char** argv) {
     if (!checkArgs(argc, argv)) {
         exit(EXIT_FAILURE);
     }
+    /* Disabled as this is printed prior to quiet being accessible 
     // If verbsoe, output the flamegpu version.
     if (!config.quiet) {
         fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
     }
+    */
 }
 int CUDAEnsemble::checkArgs(int argc, const char** argv) {
     // Parse optional args

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1240,7 +1240,7 @@ void CUDASimulation::applyConfig_derived() {
     reseed(getSimulationConfig().random_seed);
 }
 
-void CUDASimulation::reseed(const unsigned int &seed) {
+void CUDASimulation::reseed(const uint64_t &seed) {
     SimulationConfig().random_seed = seed;
     singletons->rng.reseed(seed);
 

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1636,12 +1636,12 @@ void CUDASimulation::processExitLog() {
         return;
     // Iterate members of step log to build the step log frame
     std::map<std::string, util::Any> environment_log;
-    for (const auto &prop_name : step_log_config->environment) {
+    for (const auto &prop_name : exit_log_config->environment) {
         // Fetch the named environment prop
         environment_log.emplace(prop_name, singletons->environment.getPropertyAny(instance_id, prop_name));
     }
     std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>> agents_log;
-    for (const auto &name_state : step_log_config->agents) {
+    for (const auto &name_state : exit_log_config->agents) {
         // Create the named sub map
         const std::string &agent_name = name_state.first.first;
         const std::string &agent_state = name_state.first.second;

--- a/src/flamegpu/io/JSONLogger.cu
+++ b/src/flamegpu/io/JSONLogger.cu
@@ -152,7 +152,7 @@ void JSONLogger::logConfig(T &writer, const RunLog &log) const {
     writer.StartObject();
     {
         writer.Key("random_seed");
-        writer.Uint(log.getRandomSeed());
+        writer.Uint64(log.getRandomSeed());
     }
     writer.EndObject();
 }
@@ -163,7 +163,7 @@ void JSONLogger::logConfig(T &writer, const RunPlan &plan) const {
     {
         // Add static items
         writer.Key("random_seed");
-        writer.Uint(plan.getRandomSimulationSeed());
+        writer.Uint64(plan.getRandomSimulationSeed());
         writer.Key("steps");
         writer.Uint(plan.getSteps());
         // Add dynamic environment overrides

--- a/src/flamegpu/io/JSONStateReader.cpp
+++ b/src/flamegpu/io/JSONStateReader.cpp
@@ -290,7 +290,7 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
         if (mode.top() == SimCfg) {
             if (sim_instance) {
                 if (lastKey == "random_seed") {
-                    sim_instance->SimulationConfig().random_seed = static_cast<unsigned int>(val);
+                    sim_instance->SimulationConfig().random_seed = static_cast<uint64_t>(val);
                 } else if (lastKey == "steps") {
                     sim_instance->SimulationConfig().steps = static_cast<unsigned int>(val);
                 } else if (lastKey == "timing") {

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -51,7 +51,7 @@ void JSONStateWriter::doWrite(T &writer) {
                 writer.Bool(sim_cfg.timing);
                 // Random seed
                 writer.Key("random_seed");
-                writer.Uint(sim_cfg.random_seed);
+                writer.Uint64(sim_cfg.random_seed);
                 // Verbose output
                 writer.Key("verbose");
                 writer.Bool(sim_cfg.verbose);

--- a/src/flamegpu/io/XMLStateReader.cpp
+++ b/src/flamegpu/io/XMLStateReader.cpp
@@ -129,7 +129,7 @@ int XMLStateReader::parse() {
                         sim_instance->SimulationConfig().timing = static_cast<bool>(stoll(val));
                     }
                 } else if (key == "random_seed") {
-                    sim_instance->SimulationConfig().random_seed = static_cast<unsigned int>(stoull(val));
+                    sim_instance->SimulationConfig().random_seed = static_cast<uint64_t>(stoull(val));
                 } else if (key == "verbose") {
                     for (auto& c : val)
                         c = static_cast<char>(::tolower(c));

--- a/src/flamegpu/runtime/utility/HostRandom.cu
+++ b/src/flamegpu/runtime/utility/HostRandom.cu
@@ -2,11 +2,11 @@
 
 namespace flamegpu {
 
-void HostRandom::setSeed(const unsigned int &seed) {
+void HostRandom::setSeed(const uint64_t &seed) {
     rng.reseed(seed);
 }
-unsigned int HostRandom::getSeed() const {
-    return static_cast<unsigned int>(rng.seed());
+uint64_t HostRandom::getSeed() const {
+    return static_cast<uint64_t>(rng.seed());
 }
 
 }  // namespace flamegpu

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -17,7 +17,7 @@ namespace flamegpu {
 
 RandomManager::RandomManager() :
     deviceInitialised(false) {
-    reseed(static_cast<unsigned int>(seedFromTime() % UINT_MAX));
+    reseed(static_cast<uint64_t>(seedFromTime() % UINT_MAX));
 }
 RandomManager::~RandomManager() {
     free();  // @todo call free/freeDevice not in the constructor! instead just log that?
@@ -35,7 +35,7 @@ uint64_t RandomManager::seedFromTime() {
 
 void RandomManager::reseedHost() {
     freeHost();
-    host_rng = std::mt19937();
+    host_rng = std::mt19937_64();
     // Reset host random generator/s
     host_rng.seed(mSeed);
 }
@@ -45,7 +45,7 @@ void RandomManager::reseedDevice() {
     // curand is initialised on access if length does not match. This would need a second device length?
 }
 
-void RandomManager::reseed(const unsigned int &seed) {
+void RandomManager::reseed(const uint64_t &seed) {
     // Set the instance's seed to the new value
     mSeed = seed;
 

--- a/src/flamegpu/sim/RunPlan.cpp
+++ b/src/flamegpu/sim/RunPlan.cpp
@@ -25,7 +25,9 @@ RunPlan& RunPlan::operator=(const RunPlan& other) {
         this->property_overrides.emplace(i.first, util::Any(i.second));
     return *this;
 }
-void RunPlan::setRandomSimulationSeed(const unsigned int &_random_seed) { random_seed = _random_seed; }
+void RunPlan::setRandomSimulationSeed(const uint64_t &_random_seed) {
+    random_seed = _random_seed;
+}
 void RunPlan::setSteps(const unsigned int &_steps) {
     if (_steps == 0 && !allow_0_steps) {
         throw std::out_of_range("Model description requires atleast 1 exit condition to have unlimited steps, "
@@ -37,7 +39,7 @@ void RunPlan::setOutputSubdirectory(const std::string &subdir) {
     output_subdirectory = subdir;
 }
 
-unsigned int RunPlan::getRandomSimulationSeed() const {
+uint64_t RunPlan::getRandomSimulationSeed() const {
     return random_seed;
 }
 unsigned int RunPlan::getSteps() const {

--- a/src/flamegpu/sim/RunPlan.cpp
+++ b/src/flamegpu/sim/RunPlan.cpp
@@ -10,7 +10,7 @@ RunPlan::RunPlan(const ModelDescription &model)
       model.model->exitConditions.size() + model.model->exitConditionCallbacks.size() > 0) { }
 RunPlan::RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>>  &environment, const bool &allow_0)
     : random_seed(0)
-    , steps(0)
+    , steps(1)
     , environment(environment)
     , allow_0_steps(allow_0) { }
 

--- a/src/flamegpu/sim/RunPlanVector.cpp
+++ b/src/flamegpu/sim/RunPlanVector.cpp
@@ -125,7 +125,7 @@ RunPlanVector RunPlanVector::operator*(const unsigned int& rhs) const {
             rtn.push_back(j);
         }
     }
-    return *this;
+    return rtn;
 }
 
 }  // namespace flamegpu

--- a/src/flamegpu/sim/RunPlanVector.cpp
+++ b/src/flamegpu/sim/RunPlanVector.cpp
@@ -4,16 +4,18 @@
 namespace flamegpu {
 
 RunPlanVector::RunPlanVector(const ModelDescription &model, unsigned int initial_length)
-    : std::vector<RunPlan>(initial_length, RunPlan(model)),
-      rand(std::random_device()())
+    : std::vector<RunPlan>(initial_length, RunPlan(model))
+    , randomPropertySeed(std::random_device()())
+    , rand(randomPropertySeed)
     , environment(std::make_shared<std::unordered_map<std::string, EnvironmentDescription::PropData> const>(model.model->environment->getPropertiesMap()))
     , allow_0_steps(model.model->exitConditions.size() + model.model->exitConditionCallbacks.size() > 0) {
     this->resize(initial_length, RunPlan(environment, allow_0_steps));
 }
 
 RunPlanVector::RunPlanVector(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &_environment, const bool &_allow_0_steps)
-    : std::vector<RunPlan>(),
-      rand(std::random_device()())
+    : std::vector<RunPlan>()
+    , randomPropertySeed(std::random_device()())
+    , rand(randomPropertySeed)
     , environment(_environment)
     , allow_0_steps(_allow_0_steps) { }
 void RunPlanVector::setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int &step) {
@@ -38,7 +40,12 @@ void RunPlanVector::setOutputSubdirectory(const std::string &subdir) {
     }
 }
 void RunPlanVector::setRandomPropertySeed(const uint64_t &seed) {
-    rand.seed(seed);
+    randomPropertySeed = seed;
+    rand.seed(randomPropertySeed);
+}
+
+uint64_t RunPlanVector::getRandomPropertySeed() {
+    return randomPropertySeed;
 }
 
 RunPlanVector RunPlanVector::operator+(const RunPlan& rhs) const {

--- a/src/flamegpu/sim/RunPlanVector.cpp
+++ b/src/flamegpu/sim/RunPlanVector.cpp
@@ -16,8 +16,8 @@ RunPlanVector::RunPlanVector(const std::shared_ptr<const std::unordered_map<std:
       rand(std::random_device()())
     , environment(_environment)
     , allow_0_steps(_allow_0_steps) { }
-void RunPlanVector::setRandomSimulationSeed(const unsigned int &initial_seed, const unsigned int &step) {
-    unsigned int current_seed = initial_seed;
+void RunPlanVector::setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int &step) {
+    uint64_t current_seed = initial_seed;
     for (auto &i : *this) {
         i.setRandomSimulationSeed(current_seed);
         current_seed += step;
@@ -37,7 +37,7 @@ void RunPlanVector::setOutputSubdirectory(const std::string &subdir) {
         i.setOutputSubdirectory(subdir);
     }
 }
-void RunPlanVector::setRandomPropertySeed(const unsigned int &seed) {
+void RunPlanVector::setRandomPropertySeed(const uint64_t &seed) {
     rand.seed(seed);
 }
 

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -212,7 +212,7 @@ int Simulation::checkArgs(int argc, const char** argv) {
                 return false;
             }
             // Reinitialise RandomManager state
-            config.random_seed = static_cast<unsigned int>(strtoul(argv[++i], nullptr, 0));
+            config.random_seed = static_cast<uint64_t>(strtoul(argv[++i], nullptr, 0));
             continue;
         }
         // -v/--verbose, Verbose FLAME GPU output.

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -61,7 +61,7 @@ using namespace flamegpu; // @todo - is this required? Ideally it shouldn't be, 
 %include "exception.i"
 
 // Enable the use of argc/argv
-%apply (int ARGC, char **ARGV) { (int argc, const char **) }   
+%apply (int ARGC, char **ARGV) { (int argc, const char **) }
 
 
 // Macros and Templates replated to types.
@@ -684,9 +684,9 @@ TEMPLATE_VARIABLE_INSTANTIATE_ID(getPropertyArray, flamegpu::RunPlan::getPropert
 TEMPLATE_VARIABLE_INSTANTIATE_ID(setProperty, flamegpu::RunPlanVector::setProperty)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(setPropertyArray, flamegpu::RunPlanVector::setPropertyArray)
 TEMPLATE_VARIABLE_INSTANTIATE(setPropertyUniformDistribution, flamegpu::RunPlanVector::setPropertyUniformDistribution)
-TEMPLATE_VARIABLE_INSTANTIATE(setPropertyUniformRandomDistribution, flamegpu::RunPlanVector::setPropertyUniformRandom)
-TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(setPropertyNormalRandomDistribution, flamegpu::RunPlanVector::setPropertyNormalRandom)
-TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(setPropertyLogNormalRandomDistribution, flamegpu::RunPlanVector::setPropertyLogNormalRandom)
+TEMPLATE_VARIABLE_INSTANTIATE(setPropertyUniformRandom, flamegpu::RunPlanVector::setPropertyUniformRandom)
+TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(setPropertyNormalRandom, flamegpu::RunPlanVector::setPropertyNormalRandom)
+TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(setPropertyLogNormalRandom, flamegpu::RunPlanVector::setPropertyLogNormalRandom)
 
 // Instantiate template versions of AgentLoggingConfig functions from the API
 TEMPLATE_VARIABLE_INSTANTIATE(logMean, flamegpu::AgentLoggingConfig::logMean)

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -353,6 +353,9 @@ class FLAMEGPURuntimeException : public std::exception {
 
 %ignore flamegpu::HostRandom::uniform;
 
+// RunPlanVector::SetPropertyRandom takes a c++ std::distribution as an argument, so not appropriate for wrapping.
+%ignore flamegpu::RunPlanVector::setPropertyRandom;
+
 // Ignore const'd accessors for configuration structs, which were mutable in python.
 %ignore flamegpu::CUDASimulation::getCUDAConfig;
 %ignore flamegpu::CUDAEnsemble::getConfig;

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -353,6 +353,12 @@ class FLAMEGPURuntimeException : public std::exception {
 
 %ignore flamegpu::HostRandom::uniform;
 
+// Ignore const'd accessors for configuration structs, which were mutable in python.
+%ignore flamegpu::CUDASimulation::getCUDAConfig;
+%ignore flamegpu::CUDAEnsemble::getConfig;
+// %ignore flamegpu::Simulation::getConfig; // This doesn't currently exist
+
+// Ignore the detail namespace, as it's not intended to be user-facing
 %ignore flamegpu::detail;
 
 // Do not provide the FLAMEGPU_VERSION macro, instead just the pyflamegpu.VERSION* variants.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_device_exception.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_simulation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_simulation_concurrency.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_ensemble.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_gpu_validation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_subagent.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/io/test_io.cu
@@ -31,6 +32,8 @@ SET(TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/pop/test_agent_instance.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/pop/test_device_agent_vector.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_host_functions.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_RunPlan.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_RunPlanVector.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_agent_environment.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_agent_function_conditions.cu    
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_agent_random.cu
@@ -78,9 +81,6 @@ SET(TESTS_SRC
 )
 # Source files for the tests_dev target 
 SET(TESTS_DEV_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_ensemble.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_RunPlan.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_RunPlanVector.cu
 )
 # Common source files for tests and test_dev
 SET(HELPERS_SRC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,9 @@ SET(TESTS_SRC
 )
 # Source files for the tests_dev target 
 SET(TESTS_DEV_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/gpu/test_cuda_ensemble.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_RunPlan.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/sim/test_RunPlanVector.cu
 )
 # Common source files for tests and test_dev
 SET(HELPERS_SRC

--- a/tests/swig/python/gpu/test_cuda_ensemble.py
+++ b/tests/swig/python/gpu/test_cuda_ensemble.py
@@ -1,0 +1,367 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+from random import randint
+import time
+
+
+# Global var needed in several classes
+sleepDurationMilliseconds = 500
+
+class simulateInit(pyflamegpu.HostFunctionCallback):
+    # Init should always be 0th iteration/step
+    def __init__(self):
+        super().__init__()
+
+    def run(self, FLAMEGPU):
+        # Generate a basic pop
+        POPULATION_TO_GENERATE = FLAMEGPU.environment.getPropertyUInt("POPULATION_TO_GENERATE")
+        agent = FLAMEGPU.agent("Agent")
+        for i in range(POPULATION_TO_GENERATE):
+            agent.newAgent().setVariableUint("counter", 0)
+class simulateExit(pyflamegpu.HostFunctionCallback):
+    def __init__(self):
+        super().__init__()
+
+    def run(self, FLAMEGPU):
+        totalCounters = FLAMEGPU.agent("Agent").sumUInt("counter")
+        # Add to the  file scoped atomic sum of sums. @todo
+        # testSimulateSumOfSums += totalCounters
+class elapsedInit(pyflamegpu.HostFunctionCallback):
+    # Init should always be 0th iteration/step
+    def __init__(self):
+        super().__init__()
+
+    def run(self, FLAMEGPU):
+        pass
+        # Generate a basic pop
+        POPULATION_TO_GENERATE = FLAMEGPU.environment.getPropertyUInt("POPULATION_TO_GENERATE")
+        agent = FLAMEGPU.agent("Agent")
+        for i in range(POPULATION_TO_GENERATE):
+            agent.newAgent().setVariableUint("counter", 0)
+class elapsedStep(pyflamegpu.HostFunctionCallback):
+    def __init__(self):
+        super().__init__()
+
+    def run(self, FLAMEGPU):
+        # Sleep each thread for a duration of time.
+        seconds = sleepDurationMilliseconds / 1000.0
+        time.sleep(seconds)
+
+class TestCUDAEnsemble(TestCase):
+
+    def test_constructor(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Declare a pointer
+        ensemble = None
+        # Use the ctor
+        # explicit CUDAEnsemble(const ModelDescription& model, int argc = 0, const char** argv = None)
+        ensemble = pyflamegpu.CUDAEnsemble(model, [])
+        assert ensemble != None
+        # Check a property
+        assert ensemble.Config().timing == False
+        # Run the destructor ~CUDAEnsemble
+        ensemble = None
+        # Check with simple argparsing.
+        argv = ["ensemble.exe", "--timing"]
+        ensemble = pyflamegpu.CUDAEnsemble(model, argv)
+        assert ensemble.Config().timing == True
+        ensemble = None
+
+    def test_EnsembleConfig(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+
+        # Verify that the getConfig method doesn't exist, as it is ignored.
+        with pytest.raises(AttributeError):
+            ensemble.getConfig()
+
+        # Get a config object.
+        # EnsembleConfig &Config()
+        ensemble.Config()
+        mutableConfig = ensemble.Config()
+
+        # Check the default values are correct.
+        assert mutableConfig.out_directory == ""
+        assert mutableConfig.out_format == "json"
+        assert mutableConfig.concurrent_runs == 4
+        # assert mutableConfig.devices == std::set<int>()  # @todo - this will need to change
+        assert mutableConfig.quiet == False
+        assert mutableConfig.timing == False
+        # Mutate the configuration
+        mutableConfig.out_directory = "test"
+        mutableConfig.out_format = "xml"
+        mutableConfig.concurrent_runs = 1
+        # mutableConfig.devices = std::set<int>({0}) # @todo - this will need to change.
+        mutableConfig.quiet = True
+        mutableConfig.timing = True
+        # Check via the const ref, this should show the same value as config was a reference, not a copy.
+        assert mutableConfig.out_directory == "test"
+        assert mutableConfig.out_format == "xml"
+        assert mutableConfig.concurrent_runs == 1
+        # assert mutableConfig.devices == std::set<int>({0})  # @todo - this will need to change
+        assert mutableConfig.quiet == True
+        assert mutableConfig.timing == True
+
+    @pytest.mark.skip(reason="--help cannot be tested due to exit()")
+    def test_initialise_help(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        argv = ["ensemble.exe", "--help"]
+        ensemble.initialise(argv)
+
+    def test_initialise_out(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().out_directory == ""
+        assert ensemble.Config().out_format == "json"
+        argv = ["ensemble.exe", "--out", "test", "xml"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().out_directory == "test"
+        assert ensemble.Config().out_format == "xml"
+
+    def test_initialise_concurrent_runs(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().concurrent_runs == 4
+        argv = ["ensemble.exe", "--concurrent", "2"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().concurrent_runs == 2
+
+    @pytest.mark.skip(reason="EnsembleConfig::devices is not currently swig-usable")
+    def test_initialise_devices(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().devices == () # @todo
+        argv = ["ensemble.exe", "--devices", "0"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().devices == (0) # @todo
+
+    def test_initialise_quiet(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().quiet == False
+        argv = ["ensemble.exe", "--quiet"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().quiet == True
+
+    def test_initialise_timing(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().timing == False
+        argv = ["ensemble.exe", "--timing"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().timing == True
+
+    # Agent function used to check the ensemble runs.
+    simulateAgentFn = """
+    FLAMEGPU_AGENT_FUNCTION(simulateAgentFn, flamegpu::MessageNone, flamegpu::MessageNone) {
+        // Increment agent's counter by 1.
+        FLAMEGPU->setVariable<int>("counter", FLAMEGPU->getVariable<int>("counter") + 1);
+        return flamegpu::ALIVE;
+    }
+    """
+    def test_simulate(self):
+        # Number of simulations to run.
+        planCount = 2
+        populationSize = 32
+        # Create a model containing atleast one agent type and function.
+        model = pyflamegpu.ModelDescription("test")
+        # Environmental constant for initial population
+        model.Environment().newPropertyUInt("POPULATION_TO_GENERATE", populationSize, True)
+        # Agent(s)
+        agent = model.newAgent("Agent")
+        agent.newVariableUInt("counter", 0)
+        afn = agent.newRTCFunction("simulateAgentFn", self.simulateAgentFn)
+        # Control flow
+        model.newLayer().addAgentFunction(afn)
+        init = simulateInit()
+        model.addInitFunctionCallback(init)
+        exitfn = simulateExit()
+        model.addExitFunctionCallback(exitfn)
+        # Crete a small runplan, using a different number of steps per sim.
+        expectedResult = 0
+        plans = pyflamegpu.RunPlanVector(model, planCount)
+        for idx in range(plans.size()):
+            plan = plans[idx]
+            plan.setSteps(idx + 1)  # Can't have 0 steps without exit condition
+            # Increment the expected result based on the number of steps.
+            expectedResult += (idx + 1) * populationSize
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Make it quiet to avoid outputting during the test suite
+        ensemble.Config().quiet = True
+        ensemble.Config().out_format = ""  # Suppress warning
+        # Simulate the ensemble,
+        ensemble.simulate(plans)
+
+        # @todo - actually check the simulations did execute. Can't abuse atomics like in c++. 
+
+        # An exception should be thrown if the Plan and Ensemble are for different models.
+        modelTwo = pyflamegpu.ModelDescription("two")
+        modelTwoPlans = pyflamegpu.RunPlanVector(modelTwo, 1)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            ensemble.simulate(modelTwoPlans)
+        assert e.value.type() == "InvalidArgument"
+        # Exceptions can also be thrown if output_directory cannot be created, but I'm unsure how to reliably test this cross platform.
+
+    # Logging is more thoroughly tested in Logging. Here just make sure the methods work
+    def test_setStepLog(self):
+        # Create a model containing atleast one agent type and function.
+        model = pyflamegpu.ModelDescription("test")
+        # Environmental constant for initial population
+        model.Environment().newPropertyFloat("f", 0)
+        # Add an agent so that the simulation can be ran, to check for presence of logs
+        agent = model.newAgent("Agent")
+        agent.newVariableUInt("counter", 0)
+        # Define the logging configuraiton.
+        lcfg = pyflamegpu.LoggingConfig(model)
+        lcfg.logEnvironment("f")
+        slcfg = pyflamegpu.StepLoggingConfig(lcfg)
+        slcfg.setFrequency(1)
+        # Create a single run.
+        plans = pyflamegpu.RunPlanVector(model, 1)
+        plans[0].setSteps(1)
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Make it quiet to avoid outputting during the test suite
+        ensemble.Config().quiet = True
+        ensemble.Config().out_format = ""  # Suppress warning
+        # Set the StepLog config.
+        ensemble.setStepLog(slcfg)
+        # Run the ensemble, generating logs
+        ensemble.simulate(plans)
+        # Get the logs, checking the correct number are present.
+        runLogs = ensemble.getLogs()
+        assert runLogs.size() == plans.size()
+        for log in runLogs:
+            stepLogs = log.getStepLog()
+            assert stepLogs.size() == 1 + 1  # This is 1 + 1 due to the always present init log.
+            expectedStepCount = 0
+            for stepLog in stepLogs:
+                assert stepLog.getStepCount() == expectedStepCount
+                expectedStepCount += 1
+
+        # An exception will be thrown if the step log config is for a different model.
+        modelTwo = pyflamegpu.ModelDescription("two")
+        lcfgTwo = pyflamegpu.LoggingConfig(modelTwo)
+        slcfgTwo = pyflamegpu.StepLoggingConfig(lcfgTwo)
+        slcfgTwo.setFrequency(1)
+        modelTwoPlans = pyflamegpu.RunPlanVector(modelTwo, 1)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            ensemble.setStepLog(slcfgTwo)
+        assert e.value.type() == "InvalidArgument"
+
+    def test_setExitLog(self):
+        # Create a model containing at least one agent type and function.
+        model = pyflamegpu.ModelDescription("test")
+        # Environmental constant for initial population
+        model.Environment().newPropertyFloat("f", 0)
+        # Add an agent so that the simulation can be ran, to check for presence of logs
+        agent = model.newAgent("Agent")
+        agent.newVariableUInt("counter", 0)
+        # Define the logging configuration.
+        lcfg = pyflamegpu.LoggingConfig(model)
+        lcfg.logEnvironment("f")
+        # Create a single run.
+        plans = pyflamegpu.RunPlanVector(model, 1)
+        plans[0].setSteps(1)
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Make it quiet to avoid outputting during the test suite
+        ensemble.Config().quiet = True
+        ensemble.Config().out_format = ""  # Suppress warning
+        # Set the StepLog config.
+        ensemble.setExitLog(lcfg)
+        # Run the ensemble, generating logs
+        ensemble.simulate(plans)
+        # Get the logs, checking the correct number are present.
+        runLogs = ensemble.getLogs()
+        assert runLogs.size() == plans.size()
+        for log in runLogs:
+            exitLog = log.getExitLog()
+            assert exitLog.getStepCount() == 1
+
+        # An exception will be thrown if the step log config is for a different model.
+        modelTwo = pyflamegpu.ModelDescription("two")
+        lcfgTwo = pyflamegpu.LoggingConfig(modelTwo)
+        modelTwoPlans = pyflamegpu.RunPlanVector(modelTwo, 1)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            ensemble.setExitLog(lcfgTwo)
+        assert e.value.type() == "InvalidArgument"
+
+    def test_getLogs(self):
+        # Create an ensemble with no logging enabled, but call getLogs
+        # Create a model containing atleast one agent type and function.
+        model = pyflamegpu.ModelDescription("test")
+        plans = pyflamegpu.RunPlanVector(model, 1)
+        plans[0].setSteps(1)
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        ensemble.getLogs()
+        runLogs = ensemble.getLogs()
+        assert runLogs.size() == 0
+
+    # Agent function used to check the ensemble runs.
+    elapsedAgentFn = """
+    FLAMEGPU_AGENT_FUNCTION(elapsedAgentFn, flamegpu::MessageNone, flamegpu::MessageNone) {
+        // Increment agent's counter by 1.
+        FLAMEGPU->setVariable<int>("counter", FLAMEGPU->getVariable<int>("counter") + 1);
+        return flamegpu::ALIVE;
+    }
+    """
+    def test_getEnsembleElapsedTime(self):
+        # Create a model containing at least one agent type and function.
+        model = pyflamegpu.ModelDescription("test")
+        # Environmental constant for initial population
+        model.Environment().newPropertyUInt("POPULATION_TO_GENERATE", 1, True)
+        # Agent(s)
+        agent = model.newAgent("Agent")
+        agent.newVariableUInt("counter", 0)
+        afn = agent.newRTCFunction("elapsedAgentFn", self.elapsedAgentFn)
+        # Control flow
+        model.newLayer().addAgentFunction(afn)
+        init = elapsedInit()
+        model.addInitFunctionCallback(init)
+        step = elapsedStep()
+        model.addStepFunctionCallback(step)
+        # Create a single run.
+        plans = pyflamegpu.RunPlanVector(model, 1)
+        plans[0].setSteps(1)
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Make it quiet to avoid outputting during the test suite
+        ensemble.Config().quiet = True
+        ensemble.Config().out_format = ""  # Suppress warning
+        # Get the elapsed seconds before the sim has been executed
+        ensemble.getEnsembleElapsedTime()
+        # Assert that it is LE zero.
+        assert ensemble.getEnsembleElapsedTime() <= 0.
+        # Simulate the ensemble,
+        ensemble.simulate(plans)
+        # Get the elapsed seconds before the sim has been executed
+        elapsedMillis = ensemble.getEnsembleElapsedTime()
+        # Ensure the elapsedMillis is larger than a threshold.
+        # Sleep accuracy via callback seems very poor.
+        assert elapsedMillis > 0.0

--- a/tests/swig/python/io/test_io.py
+++ b/tests/swig/python/io/test_io.py
@@ -232,7 +232,7 @@ def io_test_fixture(IO_FILENAME):
     assert am.getSimulationConfig().timing == True
     assert am.getSimulationConfig().verbose == False
     assert am.getSimulationConfig().input_file == IO_FILENAME
-    assert am.getCUDAConfig().device_id == 0;
+    assert am.CUDAConfig().device_id == 0;
     pop_a_in = pyflamegpu.AgentVector(a)
     pop_b_in = pyflamegpu.AgentVector(b)
     am.getPopulationData(pop_a_in)

--- a/tests/swig/python/sim/test_RunPlan.py
+++ b/tests/swig/python/sim/test_RunPlan.py
@@ -1,0 +1,313 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+from random import randint
+
+# Test the RunPlan interface
+class TestRunPlan(TestCase):
+    def test_constructor(self):
+        # Create a model 
+        model = pyflamegpu.ModelDescription("test")
+        plan = None
+        plan = pyflamegpu.RunPlan(model)
+        assert plan != None
+        plan = None
+
+    def test_setRandomSimulationSeed(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Get the original simulation seed. Cannot compare for an expected value as any uint64_t is potentially legitimate.
+        plan.getRandomSimulationSeed()
+        # Set to max 32 bit value +1
+        uint32_max = 2 ** 32 - 1
+        newSimulationSeed = uint32_max + 1
+        plan.setRandomSimulationSeed(newSimulationSeed)
+        # Get the value again, and expect it to be the set value. It is not guaranteed to not be the original random value.
+        simulationSeedUpdated = plan.getRandomSimulationSeed()
+        assert newSimulationSeed == simulationSeedUpdated
+        # Set it again, this time passing a narrower number.
+        # @todo - ensure this is actually using a 32 bit integer if possible?
+        narrowSimulationSeed = 12
+        plan.setRandomSimulationSeed(narrowSimulationSeed)
+        # Get the seed again, into a narrow value
+        narrowSimulationSeedUpdated = plan.getRandomSimulationSeed()
+        assert narrowSimulationSeed == narrowSimulationSeedUpdated
+
+    def test_setSteps(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Get the default value
+        steps = plan.getSteps()
+        assert steps == 1
+        # Set a new value
+        newSteps = 12
+        plan.setSteps(newSteps)
+        # Get the updated value and compare
+        updatedSteps = plan.getSteps()
+        assert updatedSteps == newSteps
+
+        # Expected exception tests
+        with pytest.raises(RuntimeError) as e: # std::out_of_range == Runtimeerror
+            plan.setSteps(0)
+
+    def test_setOutputSubdirectory(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Set the subdirectory to a non empty string
+        newSubdir = "test"
+        plan.setOutputSubdirectory(newSubdir)
+        # Get the original value
+        updatedSubdir = plan.getOutputSubdirectory()
+        # By default this is an empty string
+        assert updatedSubdir == newSubdir
+
+    def test_setProperty(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Add some properties to the model, using a range of types.
+        environment = model.Environment()
+        environment.newPropertyFloat("f", 1.0)
+        environment.newPropertyInt("i", -1)
+        environment.newPropertyUInt("u", 1)
+        environment.newPropertyArrayFloat("f_a", 3, (-1.0, 0.0, 1.0))
+        environment.newPropertyArrayInt("i_a", 3, (-1, 0, 1))
+        environment.newPropertyArrayUInt("u_a", 3, (0, 1, 2))
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Set properties to new values
+        # Compare the old and new values, to ensure that thy do not match
+        # RunPlan::setProperty(const std::string &name, const T&value)
+        plan.setPropertyFloat("f", 2.0)
+        plan.setPropertyInt("i", 2)
+        plan.setPropertyUInt("u", 2)
+        # Set arrays at once
+        # RunPlan::setProperty(const std::string &name, const std::array<T, N> &value)
+        plan.setPropertyArrayFloat("f_a", 3, (-2.0, 0.0, 2.0))
+        plan.setPropertyArrayInt("i_a", 3, (-2, 0, 2))
+        # Set individual elements at a time
+        # RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+        plan.setPropertyUInt("u_a", 0, 3)
+        plan.setPropertyUInt("u_a", 1, 4)
+        plan.setPropertyUInt("u_a", 2, 5)
+
+        assert plan.getPropertyFloat("f") != environment.getPropertyFloat("f")
+        assert plan.getPropertyInt("i") != environment.getPropertyInt("i")
+        assert plan.getPropertyUInt("u") != environment.getPropertyUInt("u")
+        assert plan.getPropertyArrayFloat("f_a") != environment.getPropertyArrayFloat("f_a")
+        assert plan.getPropertyArrayInt("i_a") != environment.getPropertyArrayInt("i_a")
+        assert plan.getPropertyArrayUInt("u_a") != environment.getPropertyArrayUInt("u_a")
+
+        # Tests for exceptions
+        # --------------------
+        # Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+        # RunPlan::getProperty(const std::string &name) const
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyFloat("does_not_exist")
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyFloat("i")
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyUInt("u_a")
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # std::array<T, N> RunPlan::getProperty(const std::string &name) const
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyArrayFloat("does_not_exist")
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyArrayFloat("u_a")
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # Not a valid test when using getpropertyArray*
+        # with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+        #     plan.getPropertyArrayInt("i_a")
+        # assert e.value.type() == "InvalidEnvPropertyType"
+        # with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+        #     plan.getPropertyArrayInt("i_a")
+        # assert e.value.type() == "InvalidEnvPropertyType"
+        # T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index) const
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyFloat("does_not_exist", 0)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.getPropertyFloat("u_a", 0)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            minus_one_uint32_t = -1 & 0xffffffff
+            plan.getPropertyInt("i_a", minus_one_uint32_t)
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            plan.getPropertyInt("i_a", 4)
+
+    def test_getRandomSimulationSeed(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Get the Simulation seed
+        # As this is random, it could be any value. So get it twice, and make sure the same thing was returned?
+        simulationSeed = plan.getRandomSimulationSeed()
+        simulationSeedAgain = plan.getRandomSimulationSeed()
+        assert simulationSeed == simulationSeedAgain
+    def test_getSteps(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Get the default value
+        steps = plan.getSteps()
+        assert steps == 1
+
+    def test_getOutputSubdirectory(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Get the default value
+        subdir = plan.getOutputSubdirectory()
+        # By default this is an empty string
+        assert subdir == ""
+
+    def test_getProperty(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Add some properties to the model, using a range of types.
+        environment = model.Environment()
+        environment.newPropertyFloat("f", 1.0)
+        environment.newPropertyInt("i", -1)
+        environment.newPropertyUInt("u", 1)
+        environment.newPropertyArrayFloat("f_a", 3, (-1.0, 0.0, 1.0))
+        environment.newPropertyArrayInt("i_a", 3, (-1, 0, 1))
+        environment.newPropertyArrayUInt("u_a", 3, (0, 1, 2))
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Check that they match the original value when no overrides have been set.
+        assert plan.getPropertyFloat("f") == environment.getPropertyFloat("f")
+        assert plan.getPropertyInt("i") == environment.getPropertyInt("i")
+        assert plan.getPropertyUInt("u") == environment.getPropertyUInt("u")
+        assert plan.getPropertyArrayFloat("f_a") == environment.getPropertyArrayFloat("f_a")
+        assert plan.getPropertyArrayInt("i_a") == environment.getPropertyArrayInt("i_a")
+        assert plan.getPropertyArrayUInt("u_a") == environment.getPropertyArrayUInt("u_a")
+
+        # Tests for exceptions
+        # --------------------
+        # Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+        # RunPlan::setProperty(const std::string &name, const T&value)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyFloat("does_not_exist", 1.)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyFloat("i", 1.)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyUInt("u_a", 1)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyArrayFloat("does_not_exist", 3, (2.0, 2.0, 2.0))
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyArrayFloat("u_a", 3, (2.0, 2.0, 2.0))
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyArrayInt("i_a", 2, (-2, 0))
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyArrayInt("i_a", 4, (-2, 0, 2, 2))
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyFloat("does_not_exist", 0, 3.)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan.setPropertyFloat("u_a", 0, 3.)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            minus_one_uint32_t = -1 & 0xffffffff
+            plan.setPropertyInt("i_a", minus_one_uint32_t, 3)
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            plan.setPropertyInt("i_a", 4, 3)
+
+    def test_operatorAssignment(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create two separate RunPlans with unique values
+        plan1 = pyflamegpu.RunPlan(model)
+        seed1 = 1
+        plan1.setRandomSimulationSeed(seed1)
+        plan2 = pyflamegpu.RunPlan(model)
+        seedB = 2
+        plan1.setRandomSimulationSeed(seedB)
+        # Verify properties are unique
+        assert plan1.getRandomSimulationSeed() != plan2.getRandomSimulationSeed()
+        # use the assignment operator to set plan1=plan2, then check the unique value(s) are correct.
+        plan1 = plan2
+        assert plan1.getRandomSimulationSeed() == plan2.getRandomSimulationSeed()
+
+    @pytest.mark.skip(reason="operator+ not currently wrapped")
+    def test_operatorAddition(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create multiple run plans and set unique values on each
+        plan1 = pyflamegpu.RunPlan(model)
+        seed1 = 1
+        plan1.setRandomSimulationSeed(seed1)
+        plan2 = pyflamegpu.RunPlan(model)
+        seed2 = 2
+        plan2.setRandomSimulationSeed(seed2)
+        plan3 = pyflamegpu.RunPlan(model)
+        seed3 = 3
+        plan3.setRandomSimulationSeed(seed3)
+
+        # RunPlanVector = RunPlan + RunPlan
+        vec12 = plan1 + plan2
+        assert vec12.size(), 2
+        assert vec12[0].getRandomSimulationSeed() == seed1
+        assert vec12[1].getRandomSimulationSeed() == seed2
+
+        # Try with operators in the other order.
+        # As an append.
+        vec123 = vec12 + plan3
+        assert vec123.size(), 3
+        assert vec123[0].getRandomSimulationSeed() == seed1
+        assert vec123[1].getRandomSimulationSeed() == seed2
+        assert vec123[2].getRandomSimulationSeed() == seed3
+
+        # Expected exceptions
+        # -------------------
+        # Adding runplans together which are not for the same model (actually environment) should throw.
+        otherModel = pyflamegpu.ModelDescription("other")
+        otherModel.Environment().newPropertyFloat("f", 1.0)  # If both models have null environments they are compatible
+        otherPlan = pyflamegpu.RunPlan(otherModel)
+        otherPlanVector = pyflamegpu.RunPlanVector(otherModel, 1)
+
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            _ = plan1 + otherPlan
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            _ = plan1 + otherPlanVector
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            _ = otherPlan + plan1
+        assert e.value.type() == "InvalidArgument"
+
+    # RunPLanVector = RunPlan * uint32_t
+    def test_operatorMultiplication(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an individual run plan.
+        plan = pyflamegpu.RunPlan(model)
+        # Set a value to a non default value to allow comparison
+        newSimulationSeed = 12
+        plan.setRandomSimulationSeed(newSimulationSeed)
+        # Create a RunPlanVector of N elemets
+        N = 4
+        plans = plan * N
+        assert plans.size(), N
+        # Compare each element
+        for p in plans:
+            assert p.getRandomSimulationSeed() == newSimulationSeed

--- a/tests/swig/python/sim/test_RunPlanVector.py
+++ b/tests/swig/python/sim/test_RunPlanVector.py
@@ -1,0 +1,602 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+from random import randint
+
+# Test the RunPlan interface
+#     @pytest.mark.skip(reason="Not yet implemented")
+
+    # Exit function condition which leads to 0 steps being allowed for plans within a vector.
+class exitcond(pyflamegpu.HostFunctionConditionCallback):
+    def test___init__(self):
+        super().__init__()
+
+    def test_run(self, FLAMEGPU):
+        return pyflamegpu.EXIT
+
+class TestRunPlanVector(TestCase):   
+    def test_constructor(self): 
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Declare a pointer
+        plans = None
+        # Use New
+        initialLength = 4
+        plans = pyflamegpu.RunPlanVector(model, initialLength)
+        assert plans != None
+        assert plans.size() == initialLength
+        # Run the destructor
+        plans = None
+    
+    # Test setting the random property seed
+    def test_setRandomPropertySeed(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Create a vector of plans
+        totalPlans = 2
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Get the current random property seed. No sensible options to check this is an expected value.
+        plans.getRandomPropertySeed()
+        # Set the seed to a new value, and check that it was applied.
+        newPropertySeed = 12
+        plans.setRandomPropertySeed(newPropertySeed)
+        # Check the new seed was applied correctly.
+        assert plans.getRandomPropertySeed() == newPropertySeed
+    
+    def test_setSteps(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Get the original value of steps, storing them for later.
+        originalValues = [1] * totalPlans
+        for idx in range(totalPlans):
+            plan = plans[idx]
+            originalValues[idx] = plan.getSteps()
+        
+        # Set the number of steps
+        newSteps = 12
+        plans.setSteps(newSteps)
+        # For Check each plan against the previous value(s)
+        for idx in range(totalPlans):
+            plan = plans[idx]
+            assert plan.getSteps() == newSteps
+            assert plan.getSteps() != originalValues[idx]
+        
+        # Expect an exception if setting the value to 0?
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            plans.setSteps(0)
+
+        # If the model has an exit condition, then it will not throw.
+        modelWithExit = pyflamegpu.ModelDescription("modelWithExit")
+        f = exitcond()
+        modelWithExit.addExitConditionCallback(f)
+        plansWithExit = pyflamegpu.RunPlanVector(modelWithExit, 1)
+        # Do not expect an exception iff allow_o_steps is set.
+        plansWithExit.setSteps(0)
+    
+    def test_setOutputSubdirectory(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Set the new value
+        newSubdir = "test"
+        plans.setOutputSubdirectory(newSubdir)
+        # For Check each plan against the previous value(s)
+        for idx in range(totalPlans):
+            plan = plans[idx]
+            assert plan.getOutputSubdirectory() == newSubdir
+            assert plan.getOutputSubdirectory() != ""
+        
+
+    def test_setProperty(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Add a few environment properties to the model.
+        environment = model.Environment()
+        fOriginal = 1.0
+        iOriginal = 1
+        u3Original = (0, 1, 2)
+        d3Original = (0., 1., 2.)
+        environment.newPropertyFloat("f", fOriginal)
+        environment.newPropertyInt("i", iOriginal)
+        environment.newPropertyArrayUInt("u3", 3, u3Original)
+        environment.newPropertyArrayDouble("d3", 3, d3Original)
+        # Create a vector of plans
+        totalPlans = 2
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Uniformly set each property to a new value, then check it has been applied correctly.
+        fNew = 2.0
+        iNew = 2
+        u3New = (3, 4, 5)
+        d3New = (3., 4., 5.)
+        # void RunPlanVector::setProperty(const std::string &name, const T &value) 
+        plans.setPropertyFloat("f", fNew)
+        plans.setPropertyInt("i", iNew)
+        # Check setting full arrays
+        # void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> &value) 
+        # Explicit type is required, to coerce the std::array. Might need partial template specialisation for  where the value is a stdarray of T?
+        plans.setPropertyArrayUInt("u3", 3, u3New)
+        # Check setting individual array elements
+        # void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) 
+        plans.setPropertyDouble("d3", 0, d3New[0])
+        plans.setPropertyDouble("d3", 1, d3New[1])
+        plans.setPropertyDouble("d3", 2, d3New[2])
+        # Check values are as expected by accessing the properties from each plan
+        for plan in plans:
+            assert plan.getPropertyFloat("f") == fNew
+            assert plan.getPropertyInt("i") == iNew
+            assert plan.getPropertyArrayUInt("u3") == u3New
+            assert plan.getPropertyArrayDouble("d3") == d3New
+        
+
+        # Tests for exceptions
+        # --------------------
+        # Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+        # void RunPlanVector::setProperty(const std::string &name, const T &value)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyFloat("does_not_exist", 1.)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyFloat("i", 1.)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyUInt("u3", 1)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> &value)
+        # Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyArrayFloat("does_not_exist", 3, (2., 2., 2.))
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyArrayFloat("u3", 3, (2., 2., 2.))
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyArrayDouble("d3", 2, (-2, 0))
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyArrayDouble("d3", 4, (-2, 0, 2, 2))
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyFloat("does_not_exist", 0, 3)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyFloat("u3", 0, 3)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            minus_one_uint32_t = -1 & 0xffffffff
+            plans.setPropertyDouble("d3", minus_one_uint32_t, 3)
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            plans.setPropertyDouble("d3", 4, 3)
+    
+    # Check that all values set lie within the min and max inclusive
+    # @todo - should fp be [min, max) like when using RNG?
+    def test_setPropertyUniformDistribution(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Add a few environment properties to the model.
+        environment = model.Environment()
+        fOriginal = 0.0
+        iOriginal = 0
+        u3Original = (0, 0, 0)
+        environment.newPropertyFloat("f", fOriginal)
+        environment.newPropertyInt("i", iOriginal)
+        environment.newPropertyArrayUInt("u3", 3, u3Original)
+        # Create a vector of plans
+        totalPlans = 10
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # No need to seed the random, as this is a LERP rather than a random distribution.
+
+        # Uniformly set each property to a new value, then check it has been applied correctly.
+        fMin = 1.
+        fMax = 100.
+        iMin = 1
+        iMax = 100
+        u3Min = (1, 101, 201)
+        u3Max = (100, 200, 300)
+        # void setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
+        plans.setPropertyUniformDistributionFloat("f", fMin, fMax)
+        plans.setPropertyUniformDistributionInt("i", iMin, iMax)
+        # Check setting individual array elements
+        # void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max)
+        plans.setPropertyUniformDistributionUInt("u3", 0, u3Min[0], u3Max[0])
+        plans.setPropertyUniformDistributionUInt("u3", 1, u3Min[1], u3Max[1])
+        plans.setPropertyUniformDistributionUInt("u3", 2, u3Min[2], u3Max[2])
+        # Check values are as expected by accessing the properties from each plan
+        for plan in plans:
+            assert plan.getPropertyFloat("f") >= fMin
+            assert plan.getPropertyFloat("f") <= fMax
+            assert plan.getPropertyInt("i") >= iMin
+            assert plan.getPropertyInt("i") <= iMax
+            u3FromPlan = plan.getPropertyArrayUInt("u3")
+            assert u3FromPlan[0] >= u3Min[0]
+            assert u3FromPlan[0] <= u3Max[0]
+            assert u3FromPlan[1] >= u3Min[1]
+            assert u3FromPlan[1] <= u3Max[1]
+            assert u3FromPlan[2] >= u3Min[2]
+            assert u3FromPlan[2] <= u3Max[2]
+        
+
+        # Tests for exceptions
+        # --------------------
+        singlePlanVector = pyflamegpu.RunPlanVector(model, 1)
+        # Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+        # void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            singlePlanVector.setPropertyUniformDistributionFloat("f", 1., 100.)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyUniformDistributionFloat("does_not_exist", 1., 100.)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyUniformDistributionFloat("i", 1., 100.)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyUniformDistributionUInt("u3", 1, 100)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        # void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type
+        # Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            singlePlanVector.setPropertyUniformDistributionUInt("u3", 0, 1, 100)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyUniformDistributionFloat("does_not_exist", 0, 1., 100.)
+        assert e.value.type() == "InvalidEnvProperty"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plans.setPropertyUniformDistributionFloat("u3", 0, 1., 100.)
+        assert e.value.type() == "InvalidEnvPropertyType"
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            minus_one_uint32_t = -1 & 0xffffffff
+            plans.setPropertyUniformDistributionUInt("u3", minus_one_uint32_t, 1, 100)
+        with pytest.raises(RuntimeError) as e: # std::out_of_range
+            plans.setPropertyUniformDistributionUInt("u3", 4, 1, 100)
+    
+    # Checking for uniformity of distribution would require a very large samples size.
+    # As std:: is used, we trust the distribution is legit, and instead just check for min/max.
+    def test_setPropertyUniformRandom(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Add a few environment properties to the model.
+        environment = model.Environment()
+        fOriginal = 1.0
+        iOriginal = 1
+        u3Original = (0, 1, 2)
+        environment.newPropertyFloat("f", fOriginal)
+        environment.newPropertyInt("i", iOriginal)
+        environment.newPropertyArrayUInt("u3", 3, u3Original)
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Seed the RunPlanVector RNG for a deterministic test.
+        plans.setRandomPropertySeed(1)
+
+        # Uniformly set each property to a new value, then check it has been applied correctly.
+        fMin = 1.
+        fMax = 100.
+        iMin = 1
+        iMax = 100
+        u3Min = (1, 101, 201)
+        u3Max = (100, 200, 300)
+        # void setPropertyUniformRandom(const std::string &name, const T &min, const T &Max)
+        plans.setPropertyUniformRandomFloat("f", fMin, fMax)
+        plans.setPropertyUniformRandomInt("i", iMin, iMax)
+        # Check setting individual array elements
+        # void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &Max)
+        plans.setPropertyUniformRandomUInt("u3", 0, u3Min[0], u3Max[0])
+        plans.setPropertyUniformRandomUInt("u3", 1, u3Min[1], u3Max[1])
+        plans.setPropertyUniformRandomUInt("u3", 2, u3Min[2], u3Max[2])
+        # Check values are as expected by accessing the properties from each plan
+        for plan in plans:
+            # Floating point types are inclusive-exclusive [min, Max)
+            assert plan.getPropertyFloat("f") >= fMin
+            assert plan.getPropertyFloat("f") <  fMax
+            # Integer types are mutually inclusive [min, Max]
+            assert plan.getPropertyInt("i") >= iMin
+            assert plan.getPropertyInt("i") <= iMax
+            # Check array values are correct, Integers so mutually inclusive
+            u3FromPlan = plan.getPropertyArrayUInt("u3")
+            assert u3FromPlan[0] >= u3Min[0]
+            assert u3FromPlan[0] <= u3Max[0]
+            assert u3FromPlan[1] >= u3Min[1]
+            assert u3FromPlan[1] <= u3Max[1]
+            assert u3FromPlan[2] >= u3Min[2]
+            assert u3FromPlan[2] <= u3Max[2]
+        
+    
+    # It's non trivial to check for correct distirbutions, and we rely on std:: so we are going to trust it works as intended.
+    # Instead, just check that the value is different than the original. As this is not guaranteed due to (seeded) RNG, just check that atleast one value is different.
+    # Real property types only. Non-reals are a static assert.
+    def test_setPropertyNormalRandom(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Add a few environment properties to the model.
+        environment = model.Environment()
+        fOriginal = 1.0
+        d3Original = (0., 1., 2.)
+        environment.newPropertyFloat("f", fOriginal)
+        environment.newPropertyArrayDouble("d3", 3, d3Original)
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Seed the RunPlanVector RNG for a deterministic test.
+        plans.setRandomPropertySeed(1)
+
+        # Uniformly set each property to a new value, then check that atleast one of them is not the default.
+        fMean = 1.
+        fStddev = 100.
+        d3Mean = (1., 101., 201.)
+        d3Stddev = (100., 200., 300.)
+        # void setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
+        plans.setPropertyNormalRandomFloat("f", fMean, fStddev)
+        # Check setting individual array elements
+        # void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev)
+        plans.setPropertyNormalRandomDouble("d3", 0, d3Mean[0], d3Stddev[0])
+        plans.setPropertyNormalRandomDouble("d3", 1, d3Mean[1], d3Stddev[1])
+        plans.setPropertyNormalRandomDouble("d3", 2, d3Mean[2], d3Stddev[2])
+        fAtleastOneNonDefault = False
+        d3AtleastOneNonDefault = [False, False, False]
+        # Check values are as expected by accessing the properties from each plan
+        for plan in plans:
+            if (plan.getPropertyFloat("f") != fOriginal):
+                fAtleastOneNonDefault = True
+            d3FromPlan = plan.getPropertyArrayDouble("d3")
+            if (d3FromPlan[0] != d3Original[0]):
+                d3AtleastOneNonDefault[0] = True
+            if (d3FromPlan[1] != d3Original[1]):
+                d3AtleastOneNonDefault[1] = True
+            if (d3FromPlan[2] != d3Original[2]):
+                d3AtleastOneNonDefault[2] = True
+        
+        # assert that atleast one of each value is non-default.
+        assert fAtleastOneNonDefault
+        assert d3AtleastOneNonDefault[0]
+        assert d3AtleastOneNonDefault[1]
+        assert d3AtleastOneNonDefault[2]
+    
+    # It's non trivial to check for correct distirbutions, and we rely on std:: so we are going to trust it works as intended.
+    # Instead, just check that the value is different than the original. As this is not guaranteed due to (seeded) RNG, just check that atleast one value is different.
+    # Real property types only. Non-reals are a static assert.
+    def test_setPropertyLogNormalRandom(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Add a few environment properties to the model.
+        environment = model.Environment()
+        fOriginal = 1.0
+        d3Original = (0., 1., 2.)
+        environment.newPropertyFloat("f", fOriginal)
+        environment.newPropertyArrayDouble("d3", 3, d3Original)
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Seed the RunPlanVector RNG for a deterministic test.
+        plans.setRandomPropertySeed(1)
+
+        # Uniformly set each property to a new value, then check that atleast one of them is not the default.
+        fMean = 1.
+        fStddev = 100.
+        d3Mean = (1., 101., 201.)
+        d3Stddev = (100., 200., 300.)
+        # void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev) 
+        plans.setPropertyLogNormalRandomFloat("f", fMean, fStddev)
+        # Check setting individual array elements
+        # void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) 
+        plans.setPropertyLogNormalRandomDouble("d3", 0, d3Mean[0], d3Stddev[0])
+        plans.setPropertyLogNormalRandomDouble("d3", 1, d3Mean[1], d3Stddev[1])
+        plans.setPropertyLogNormalRandomDouble("d3", 2, d3Mean[2], d3Stddev[2])
+        fAtleastOneNonDefault = False
+        d3AtleastOneNonDefault = [False, False, False]
+        # Check values are as expected by accessing the properties from each plan
+        for plan in plans:
+            if (plan.getPropertyFloat("f") != fOriginal):
+                fAtleastOneNonDefault = True
+            d3FromPlan = plan.getPropertyArrayDouble("d3")
+            if (d3FromPlan[0] != d3Original[0]):
+                d3AtleastOneNonDefault[0] = True
+            if (d3FromPlan[1] != d3Original[1]):
+                d3AtleastOneNonDefault[1] = True
+            if (d3FromPlan[2] != d3Original[2]):
+                d3AtleastOneNonDefault[2] = True
+        
+        # assert that atleast one of each value is non-default.
+        assert fAtleastOneNonDefault
+        assert d3AtleastOneNonDefault[0]
+        assert d3AtleastOneNonDefault[1]
+        assert d3AtleastOneNonDefault[2]
+    
+    def test_setPropertyRandom(self): 
+        # @todo - test setPropertyRandom
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Add a few environment properties to the model.
+        environment = model.Environment()
+        environment.newPropertyFloat("f", 1.0)
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+    
+        # This method should be %ignored by swig - it should not exist. Expect an exception
+        with pytest.raises(AttributeError):
+            plans.setPropertyRandom
+        
+    
+    # Test getting the random property seed
+    def test_getRandomPropertySeed(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # repeatedly create run vectors, and get the property seed. Once we've found 2 that are  different, stop.
+        # If a maximum number of tries is reached, then we error.
+        maxGenerations = 8
+        prevSeed = 0
+        seed = 0
+        for i in range(maxGenerations):
+            # Create the vector
+            plans = pyflamegpu.RunPlanVector(model, 1)
+            seed = plans.getRandomPropertySeed()
+            if i > 0:
+                # the seed shouldn't be the same as the previous seed, but it might be so do not expect_.
+                if prevSeed != seed:
+                    # Break out the loop
+                    break
+            prevSeed = seed
+        
+        assert prevSeed != seed
+    
+    def test_size(self): 
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create run plan vectors of a number of sizes and check the value
+        plans0 = pyflamegpu.RunPlanVector(model, 0)
+        assert plans0.size() == 0
+        plans1 = pyflamegpu.RunPlanVector(model, 1)
+        assert plans1.size() == 1
+        plans4 = pyflamegpu.RunPlanVector(model, 4)
+        assert plans4.size() == 4
+        plans64 = pyflamegpu.RunPlanVector(model, 64)
+        assert plans64.size() == 64
+    
+    @pytest.mark.skip(reason="operator+ not currently wrapped")
+    def test_operatorAddition(self): 
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create multiple unique plans which can be used to check order of plans.
+        plan1 = pyflamegpu.RunPlan(model)
+        seed1 = 1
+        plan1.setRandomSimulationSeed(seed1)
+        plan2 = pyflamegpu.RunPlan(model)
+        seed2 = 2
+        plan2.setRandomSimulationSeed(seed2)
+        plan3 = pyflamegpu.RunPlan(model)
+        seed3 = 3
+        plan3.setRandomSimulationSeed(seed3)
+        plan4 = pyflamegpu.RunPlan(model)
+        seed4 = 4
+        plan4.setRandomSimulationSeed(seed4)
+        # RunPlanVector operator+(const RunPlan& rhs) const
+        vec12 = plan1 + plan2
+        vec123 = vec12 + plan3
+        assert vec123.size() == 3
+        assert vec123[0].getRandomSimulationSeed() == seed1
+        assert vec123[1].getRandomSimulationSeed() == seed2
+        assert vec123[2].getRandomSimulationSeed() == seed3
+        # # Disabled, as operator+ is always push_back for performance reasons.
+        # vec312 = plan3 + vec12
+        # assert vec312.size() == 3
+        # assert vec312[0].getRandomSimulationSeed() == seed3
+        # assert vec312[1].getRandomSimulationSeed() == seed1
+        # assert vec312[2].getRandomSimulationSeed() == seed2
+        
+        # RunPlanVector operator+(const RunPlanVector& rhs) const
+        vec12 = plan1 + plan2
+        vec34 = plan3 + plan4
+        vec1234 = vec12 + vec34
+        assert vec1234.size() == 4
+        assert vec1234[0].getRandomSimulationSeed() == seed1
+        assert vec1234[1].getRandomSimulationSeed() == seed2
+        assert vec1234[2].getRandomSimulationSeed() == seed3
+        assert vec1234[3].getRandomSimulationSeed() == seed4
+        # # Disabled, as operator+ is always push_back for performance reasons.
+        # pyflamegpu.RunPlanVector vec3412 = vec34 + vec12
+        # assert vec3412.size() == 4
+        # assert vec3412[0].getRandomSimulationSeed() == seed3
+        # assert vec3412[1].getRandomSimulationSeed() == seed4
+        # assert vec3412[2].getRandomSimulationSeed() == seed1
+        # assert vec3412[3].getRandomSimulationSeed() == seed2
+        
+        # RunPlanVector& operator+=(const RunPlan& rhs)
+        vec123 = plan1 + plan2
+        vec123 += plan3
+        assert vec123.size() == 3
+        assert vec123[0].getRandomSimulationSeed() == seed1
+        assert vec123[1].getRandomSimulationSeed() == seed2
+        assert vec123[2].getRandomSimulationSeed() == seed3
+        # += cannot have a plan on the lhs and a plan vector on the right.
+        
+        # RunPlanVector& operator+=(const RunPlanVector& rhs)
+        vec1234 = plan1 + plan2
+        vec1234 += (plan3 + plan4)
+        assert vec1234.size() == 4
+        assert vec1234[0].getRandomSimulationSeed() == seed1
+        assert vec1234[1].getRandomSimulationSeed() == seed2
+        assert vec1234[2].getRandomSimulationSeed() == seed3
+        assert vec1234[3].getRandomSimulationSeed() == seed4
+        
+
+        # Expected exceptions
+        # -------------------
+        # Adding runplans together which are not for the same model (actually environment) should throw.
+        planVector = pyflamegpu.RunPlanVector(model, 1)
+        otherModel = pyflamegpu.ModelDescription("other")
+        otherModel.Environment().newPropertyFloat("f", 1.0)  # If both models have null environments they are compatible
+        otherPlan = pyflamegpu.RunPlan(otherModel)
+        otherPlanVector = pyflamegpu.RunPlanVector(otherModel, 1)
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan1 + otherPlan
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            otherPlan + plan1
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            plan1 + otherPlanVector
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            otherPlanVector + plan1
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            planVector + otherPlan
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            otherPlan + planVector
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            planVector += otherPlan
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            otherPlanVector += plan1
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            planVector += otherPlanVector
+        assert e.value.type() == "InvalidArgument"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
+            otherPlanVector += planVector
+        assert e.value.type() == "InvalidArgument"
+    
+    # RunPlanVector operator*(const unsigned int& rhs) const
+    def test_operatorMultiplication(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        assert plans.size() == totalPlans
+
+        # Multiply the plan vector by a fixed size
+        # RunPlanVector operator*(const unsigned int& rhs) const
+        mult = 2
+        morePlans = plans * mult
+        expectedSize = mult * totalPlans
+        assert morePlans.size() == expectedSize
+
+        # multiply a plan in-place
+        # RunPlanVector& operator*=(const unsigned int& rhs)
+        plans *= mult
+        assert plans.size() == expectedSize
+    
+    # operator[]
+    def test_operatorSubscript(self): 
+        # Define the simple model to use
+        model = pyflamegpu.ModelDescription("test")
+        # Create a vector of plans
+        totalPlans = 4
+        plans = pyflamegpu.RunPlanVector(model, totalPlans)
+        # Check that each in-range element can be accessed
+        prev = None
+        for idx in range(totalPlans):
+            plan = plans[idx]
+            if idx > 0:
+                assert plan != prev
+            
+            prev = plan
+        
+    

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -1,0 +1,355 @@
+#include <thread>
+#include <chrono>
+
+#include "flamegpu/flamegpu.h"
+
+#include "gtest/gtest.h"
+
+namespace flamegpu {
+namespace tests {
+namespace test_cuda_ensemble {
+
+TEST(TestCUDAEnsemble, constructor) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Declare a pointer
+    flamegpu::CUDAEnsemble * ensemble = nullptr;
+    // Use the ctor
+    // explicit CUDAEnsemble(const ModelDescription& model, int argc = 0, const char** argv = nullptr);
+    EXPECT_NO_THROW(ensemble = new flamegpu::CUDAEnsemble(model, 0, nullptr));
+    EXPECT_NE(ensemble, nullptr);
+    // Check a property
+    EXPECT_EQ(ensemble->Config().timing, false);
+    // Run the destructor ~CUDAEnsemble
+    EXPECT_NO_THROW(delete ensemble);
+    ensemble = nullptr;
+    // Check with simple argparsing.
+    const char *argv[2] = { "prog.exe", "--timing" };
+    EXPECT_NO_THROW(ensemble = new flamegpu::CUDAEnsemble(model, sizeof(argv) / sizeof(char*), argv));
+    EXPECT_EQ(ensemble->Config().timing, true);
+    EXPECT_NO_THROW(delete ensemble);
+    ensemble = nullptr;
+}
+TEST(TestCUDAEnsemble, EnsembleConfig) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Get a config object.
+    // EnsembleConfig &Config()
+    EXPECT_NO_THROW(ensemble.Config());
+    auto &mutableConfig = ensemble.Config();
+    // Get a const'd version.
+    // const EnsembleConfig &getConfig()
+    EXPECT_NO_THROW(ensemble.getConfig());
+    auto &immutableConfig = ensemble.getConfig();
+    // Check the default values are correct.
+    EXPECT_EQ(immutableConfig.out_directory, "");
+    EXPECT_EQ(immutableConfig.out_format, "json");
+    EXPECT_EQ(immutableConfig.concurrent_runs, 4u);
+    EXPECT_EQ(immutableConfig.devices, std::set<int>());  // @todo - this will need to change.
+    EXPECT_EQ(immutableConfig.quiet, false);
+    EXPECT_EQ(immutableConfig.timing, false);
+    // Mutate the config. Note we cannot mutate the return from getConfig, and connot test this as it is a compialtion failure (requires ctest / standalone .cpp file)
+    mutableConfig.out_directory = std::string("test");
+    mutableConfig.out_format = std::string("xml");
+    mutableConfig.concurrent_runs = 1;
+    mutableConfig.devices = std::set<int>({0});
+    mutableConfig.quiet = true;
+    mutableConfig.timing = true;
+    // Check via the const ref, this should show the same value as config was a reference, not a copy.
+    EXPECT_EQ(immutableConfig.out_directory, "test");
+    EXPECT_EQ(immutableConfig.out_format, "xml");
+    EXPECT_EQ(immutableConfig.concurrent_runs, 1u);
+    EXPECT_EQ(immutableConfig.devices, std::set<int>({0}));  // @todo - this will need to change.
+    EXPECT_EQ(immutableConfig.quiet, true);
+    EXPECT_EQ(immutableConfig.timing, true);
+}
+// This test causes `exit` so cannot be used.
+/* TEST(TestCUDAEnsemble, DISABLED_initialise_help) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    const char *argv[2] = { "prog.exe", "--help" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+} */
+TEST(TestCUDAEnsemble, initialise_out) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().out_directory, "");
+    EXPECT_EQ(ensemble.getConfig().out_format, "json");
+    const char *argv[4] = { "prog.exe", "--out", "test", "xml" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(ensemble.getConfig().out_directory, "test");
+    EXPECT_EQ(ensemble.getConfig().out_format, "xml");
+}
+TEST(TestCUDAEnsemble, initialise_concurrent_runs) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().concurrent_runs, 4u);
+    const char *argv[3] = { "prog.exe", "--concurrent", "2" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(ensemble.getConfig().concurrent_runs, 2u);
+}
+TEST(TestCUDAEnsemble, initialise_devices) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().devices, std::set<int>({}));
+    const char *argv[3] = { "prog.exe", "--devices", "0" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(ensemble.getConfig().devices, std::set<int>({0}));
+}
+TEST(TestCUDAEnsemble, initialise_quiet) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().quiet, false);
+    const char *argv[2] = { "prog.exe", "--quiet" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(ensemble.getConfig().quiet, true);
+}
+TEST(TestCUDAEnsemble, initialise_timing) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().timing, false);
+    const char *argv[2] = { "prog.exe", "--timing" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(ensemble.getConfig().timing, true);
+}
+// Agent function used to check the ensemble runs.
+FLAMEGPU_AGENT_FUNCTION(simulateAgentFn, flamegpu::MessageNone, flamegpu::MessageNone) {
+    // Increment agent's counter by 1.
+    FLAMEGPU->setVariable<int>("counter", FLAMEGPU->getVariable<int>("counter") + 1);
+    return flamegpu::ALIVE;
+}
+FLAMEGPU_INIT_FUNCTION(simulateInit) {
+    // Generate a basic pop
+    const uint32_t POPULATION_TO_GENERATE = FLAMEGPU->environment.getProperty<uint32_t>("POPULATION_TO_GENERATE");
+    auto agent = FLAMEGPU->agent("Agent");
+    for (uint32_t i = 0; i < POPULATION_TO_GENERATE; ++i) {
+        agent.newAgent().setVariable<uint32_t>("counter", 0);
+    }
+}
+// File scoped variables to allow non-loggin based ensemble validation.
+std::atomic<uint64_t> testSimulateSumOfSums = {0};
+// File scoped atomics
+FLAMEGPU_EXIT_FUNCTION(simulateExit) {
+    uint64_t totalCounters = FLAMEGPU->agent("Agent").sum<uint32_t>("counter");
+    // Add to the  file scoped atomic sum of sums.
+    testSimulateSumOfSums += totalCounters;
+}
+TEST(TestCUDAEnsemble, simulate) {
+    // Reset the atomic sum of sums to 0. Just in case.
+    testSimulateSumOfSums = 0;
+    // Number of simulations to run.
+    constexpr uint32_t planCount = 2u;
+    constexpr uint32_t populationSize = 32u;
+    // Create a model containing atleast one agent type and function.
+    flamegpu::ModelDescription model("test");
+    // Environmental constant for initial population
+    model.Environment().newProperty<uint32_t>("POPULATION_TO_GENERATE", populationSize, true);
+    // Agent(s)
+    flamegpu::AgentDescription &agent = model.newAgent("Agent");
+    agent.newVariable<uint32_t>("counter", 0);
+    agent.newFunction("simulateAgentFn", simulateAgentFn);
+    // Control flow
+    model.newLayer().addAgentFunction(simulateAgentFn);
+    model.addInitFunction(simulateInit);
+    model.addExitFunction(simulateExit);
+    // Crete a small runplan, using a different number of steps per sim.
+    uint64_t expectedResult = 0;
+    flamegpu::RunPlanVector plans(model, planCount);
+    for (uint32_t idx = 0; idx < plans.size(); idx++) {
+        auto &plan = plans[idx];
+        plan.setSteps(idx + 1);  // Can't have 0 steps without exit condition
+        // Increment the expected result based on the number of steps.
+        expectedResult += (idx + 1) * populationSize;
+    }
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Make it quiet to avoid outputting during the test suite
+    ensemble.Config().quiet = true;
+    ensemble.Config().out_format = "";  // Suppress warning
+    // Simulate the ensemble,
+    EXPECT_NO_THROW(ensemble.simulate(plans));
+    // Get the sum of sums from the atomic.
+    uint64_t atomicResult = testSimulateSumOfSums.load();
+    // Compare against the epxected value
+    EXPECT_EQ(atomicResult, expectedResult);
+
+    // An exception should be thrown if the Plan and Ensemble are for different models.
+    flamegpu::ModelDescription modelTwo("two");
+    flamegpu::RunPlanVector modelTwoPlans(modelTwo, 1);
+    EXPECT_THROW(ensemble.simulate(modelTwoPlans), flamegpu::exception::InvalidArgument);
+    // Exceptions can also be thrown if output_directory cannot be created, but I'm unsure how to reliably test this cross platform.
+}
+// Logging is more thoroughly tested in Logging. Here just make sure the methods work
+TEST(TestCUDAEnsemble, setStepLog) {
+    // Create a model containing atleast one agent type and function.
+    flamegpu::ModelDescription model("test");
+    // Environmental constant for initial population
+    model.Environment().newProperty<float>("f", 0.f);
+    // Add an agent so that the simulation can be ran, to check for presence of logs
+    flamegpu::AgentDescription &agent = model.newAgent("Agent");
+    agent.newVariable<uint32_t>("counter", 0);
+    // Define the logging configuraiton.
+    LoggingConfig lcfg(model);
+    lcfg.logEnvironment("f");
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(1);
+    // Create a single run.
+    auto plans = flamegpu::RunPlanVector(model, 1);
+    plans[0].setSteps(1);
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Make it quiet to avoid outputting during the test suite
+    ensemble.Config().quiet = true;
+    ensemble.Config().out_format = "";  // Suppress warning
+    // Set the StepLog config.
+    EXPECT_NO_THROW(ensemble.setStepLog(slcfg));
+    // Run the ensemble, generating logs
+    ensemble.simulate(plans);
+    // Get the logs, checking the correct number are present.
+    const auto &runLogs = ensemble.getLogs();
+    EXPECT_EQ(runLogs.size(), plans.size());
+    for (auto &log : runLogs) {
+        auto &stepLogs = log.getStepLog();
+        EXPECT_EQ(stepLogs.size(), 1 + 1);  // This is 1 + 1 due to the always present init log.
+        uint32_t expectedStepCount = 0;
+        for (const auto &stepLog : stepLogs) {
+            ASSERT_EQ(stepLog.getStepCount(), expectedStepCount);
+            expectedStepCount++;
+        }
+    }
+
+    // An exception will be thrown if the step log config is for a different model.
+    flamegpu::ModelDescription modelTwo("two");
+    LoggingConfig lcfgTwo(modelTwo);
+    StepLoggingConfig slcfgTwo(lcfgTwo);
+    slcfgTwo.setFrequency(1);
+    flamegpu::RunPlanVector modelTwoPlans(modelTwo, 1);
+    EXPECT_THROW(ensemble.setStepLog(slcfgTwo), flamegpu::exception::InvalidArgument);
+}
+TEST(TestCUDAEnsemble, setExitLog) {
+    // Create a model containing atleast one agent type and function.
+    flamegpu::ModelDescription model("test");
+    // Environmental constant for initial population
+    model.Environment().newProperty<float>("f", 0.f);
+    // Add an agent so that the simulation can be ran, to check for presence of logs
+    flamegpu::AgentDescription &agent = model.newAgent("Agent");
+    agent.newVariable<uint32_t>("counter", 0u);
+    // Define the logging configuraiton.
+    LoggingConfig lcfg(model);
+    lcfg.logEnvironment("f");
+    // Create a single run.
+    auto plans = flamegpu::RunPlanVector(model, 1u);
+    plans[0].setSteps(1);
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Make it quiet to avoid outputting during the test suite
+    ensemble.Config().quiet = true;
+    ensemble.Config().out_format = "";  // Suppress warning
+    // Set the StepLog config.
+    EXPECT_NO_THROW(ensemble.setExitLog(lcfg));
+    // Run the ensemble, generating logs
+    ensemble.simulate(plans);
+    // Get the logs, checking the correct number are present.
+    const auto &runLogs = ensemble.getLogs();
+    EXPECT_EQ(runLogs.size(), plans.size());
+    for (auto &log : runLogs) {
+        const auto &exitLog = log.getExitLog();
+        ASSERT_EQ(exitLog.getStepCount(), 1u);
+    }
+
+    // An exception will be thrown if the step log config is for a different model.
+    flamegpu::ModelDescription modelTwo("two");
+    LoggingConfig lcfgTwo(modelTwo);
+    flamegpu::RunPlanVector modelTwoPlans(modelTwo, 1u);
+    EXPECT_THROW(ensemble.setExitLog(lcfgTwo), flamegpu::exception::InvalidArgument);
+}
+TEST(TestCUDAEnsemble, getLogs) {
+    // Create an ensemble with no logging enabled, but call getLogs
+    // Create a model containing atleast one agent type and function.
+    flamegpu::ModelDescription model("test");
+    auto plans = flamegpu::RunPlanVector(model, 1);
+    plans[0].setSteps(1);
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    EXPECT_NO_THROW(ensemble.getLogs());
+    const auto &runLogs = ensemble.getLogs();
+    EXPECT_EQ(runLogs.size(), 0u);
+}
+// Agent function used to check the ensemble runs.
+FLAMEGPU_AGENT_FUNCTION(elapsedAgentFn, flamegpu::MessageNone, flamegpu::MessageNone) {
+    // Increment agent's counter by 1.
+    FLAMEGPU->setVariable<int>("counter", FLAMEGPU->getVariable<int>("counter") + 1);
+    return flamegpu::ALIVE;
+}
+FLAMEGPU_INIT_FUNCTION(elapsedInit) {
+    // Generate a basic pop
+    const uint32_t POPULATION_TO_GENERATE = FLAMEGPU->environment.getProperty<uint32_t>("POPULATION_TO_GENERATE");
+    auto agent = FLAMEGPU->agent("Agent");
+    for (uint32_t i = 0; i < POPULATION_TO_GENERATE; ++i) {
+        agent.newAgent().setVariable<uint32_t>("counter", 0u);
+    }
+}
+constexpr uint64_t sleepDurationMilliseconds = 500;
+// File scoped atomics
+FLAMEGPU_STEP_FUNCTION(elapsedStep) {
+    // Sleep each thread for a duration of time.
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleepDurationMilliseconds));
+}
+TEST(TestCUDAEnsemble, getEnsembleElapsedTime) {
+    // Create a model containing atleast one agent type and function.
+    flamegpu::ModelDescription model("test");
+    // Environmental constant for initial population
+    model.Environment().newProperty<uint32_t>("POPULATION_TO_GENERATE", 1, true);
+    // Agent(s)
+    flamegpu::AgentDescription &agent = model.newAgent("Agent");
+    agent.newVariable<uint32_t>("counter", 0);
+    agent.newFunction("elapsedAgentFn", elapsedAgentFn);
+    // Control flow
+    model.newLayer().addAgentFunction(elapsedAgentFn);
+    model.addInitFunction(elapsedInit);
+    model.addStepFunction(elapsedStep);
+    // Create a single run.
+    auto plans = flamegpu::RunPlanVector(model, 1);
+    plans[0].setSteps(1);
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Make it quiet to avoid outputting during the test suite
+    ensemble.Config().quiet = true;
+    ensemble.Config().out_format = "";  // Suppress warning
+    // Get the elapsed seconds before the sim has been executed
+    EXPECT_NO_THROW(ensemble.getEnsembleElapsedTime());
+    // Assert that it is LE zero.
+    EXPECT_LE(ensemble.getEnsembleElapsedTime(), 0.);
+    // Simulate the ensemble,
+    EXPECT_NO_THROW(ensemble.simulate(plans));
+    // Get the elapsed seconds before the sim has been executed
+    float elapsedMillis = 0.f;
+    EXPECT_NO_THROW(elapsedMillis = ensemble.getEnsembleElapsedTime());
+    // Ensure the elapsedMillis is larger than a threshold.
+    double thresholdMillis = static_cast<double>(sleepDurationMilliseconds) * 0.8;
+    EXPECT_GE(elapsedMillis, thresholdMillis);
+}
+
+}  // namespace test_cuda_ensemble
+}  // namespace tests
+}  // namespace flamegpu

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -391,6 +391,37 @@ TEST(TestCUDASimulation, AgentDeath) {
     }
 }
 
+// Test setting the seed with different values/types.
+TEST(TestCUDASimulation, randomseedTypes) {
+    // Define a simple model - doesn't need to do anything other than take some time.
+    ModelDescription model(MODEL_NAME);
+    AgentDescription &a = model.newAgent(AGENT_NAME);
+    AgentVector pop(a, static_cast<unsigned int>(AGENT_COUNT));
+
+    CUDASimulation simulation(model);
+
+    simulation.SimulationConfig().random_seed = 0;
+    EXPECT_EQ(simulation.SimulationConfig().random_seed, 0);
+
+    int32_t int32_v = INT32_MAX;
+    simulation.SimulationConfig().random_seed = int32_v;
+    EXPECT_EQ(simulation.SimulationConfig().random_seed, static_cast<uint64_t>(int32_v));
+
+    uint32_t uint32_v = UINT32_MAX;
+    simulation.SimulationConfig().random_seed = uint32_v;
+    EXPECT_EQ(simulation.SimulationConfig().random_seed, static_cast<uint64_t>(uint32_v));
+
+    int64_t int64_v = INT64_MAX;
+    simulation.SimulationConfig().random_seed = int64_v;
+    EXPECT_EQ(simulation.SimulationConfig().random_seed, static_cast<uint64_t>(int64_v));
+
+    uint64_t uint64_v = UINT64_MAX;
+    simulation.SimulationConfig().random_seed = uint64_v;
+    EXPECT_EQ(simulation.SimulationConfig().random_seed, static_cast<uint64_t>(uint64_v));
+
+    // No need to check for larger values in cudac++
+}
+
 // test the programatically accessible simulation time elapsed.
 TEST(TestCUDASimulation, simulationElapsedTime) {
     // Define a simple model - doesn't need to do anything other than take some time.

--- a/tests/test_cases/runtime/host_reduction/test_count.cu
+++ b/tests/test_cases/runtime/host_reduction/test_count.cu
@@ -36,7 +36,7 @@ FLAMEGPU_STEP_FUNCTION(step_countuint64_t) {
 
 TEST_F(HostReductionTest, CountFloat) {
     ms->model.addStepFunction(step_countfloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(FLT_MIN, FLT_MAX);
     std::array<float, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -53,7 +53,7 @@ TEST_F(HostReductionTest, CountFloat) {
 }
 TEST_F(HostReductionTest, CountDouble) {
     ms->model.addStepFunction(step_countdouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(DBL_MIN, DBL_MAX);
     std::array<double, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -70,7 +70,7 @@ TEST_F(HostReductionTest, CountDouble) {
 }
 TEST_F(HostReductionTest, CountChar) {
     ms->model.addStepFunction(step_countchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(CHAR_MIN, CHAR_MAX);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -87,7 +87,7 @@ TEST_F(HostReductionTest, CountChar) {
 }
 TEST_F(HostReductionTest, CountUnsignedChar) {
     ms->model.addStepFunction(step_countuchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UCHAR_MAX);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -104,7 +104,7 @@ TEST_F(HostReductionTest, CountUnsignedChar) {
 }
 TEST_F(HostReductionTest, CountInt16) {
     ms->model.addStepFunction(step_countint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(INT16_MIN, INT16_MAX);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -121,7 +121,7 @@ TEST_F(HostReductionTest, CountInt16) {
 }
 TEST_F(HostReductionTest, CountUnsignedInt16) {
     ms->model.addStepFunction(step_countuint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UINT16_MAX);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -138,7 +138,7 @@ TEST_F(HostReductionTest, CountUnsignedInt16) {
 }
 TEST_F(HostReductionTest, CountInt32) {
     ms->model.addStepFunction(step_countint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(INT32_MIN, INT32_MAX);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -155,7 +155,7 @@ TEST_F(HostReductionTest, CountInt32) {
 }
 TEST_F(HostReductionTest, CountUnsignedInt32) {
     ms->model.addStepFunction(step_countuint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, UINT32_MAX);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -172,7 +172,7 @@ TEST_F(HostReductionTest, CountUnsignedInt32) {
 }
 TEST_F(HostReductionTest, CountInt64) {
     ms->model.addStepFunction(step_countint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(INT64_MIN, INT64_MAX);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -189,7 +189,7 @@ TEST_F(HostReductionTest, CountInt64) {
 }
 TEST_F(HostReductionTest, CountUnsignedInt64) {
     ms->model.addStepFunction(step_countuint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/host_reduction/test_histogram_even.cu
+++ b/tests/test_cases/runtime/host_reduction/test_histogram_even.cu
@@ -55,7 +55,7 @@ std::vector<OutT> histogramEven(const std::array<InT, TEST_LEN> &variables, cons
 }
 TEST_F(HostReductionTest, HistogramEvenFloat) {
     ms->model.addStepFunction(step_histogramEvenfloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(0, 20);
     std::array<float, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -71,7 +71,7 @@ TEST_F(HostReductionTest, HistogramEvenFloat) {
 }
 TEST_F(HostReductionTest, HistogramEvenDouble) {
     ms->model.addStepFunction(step_histogramEvendouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(0, 20);
     std::array<double, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -87,7 +87,7 @@ TEST_F(HostReductionTest, HistogramEvenDouble) {
 }
 TEST_F(HostReductionTest, HistogramEvenChar) {
     ms->model.addStepFunction(step_histogramEvenchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(0, 19);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -107,7 +107,7 @@ TEST_F(HostReductionTest, HistogramEvenChar) {
 }
 TEST_F(HostReductionTest, HistogramEvenUnsignedChar) {
     ms->model.addStepFunction(step_histogramEvenuchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, 19);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -123,7 +123,7 @@ TEST_F(HostReductionTest, HistogramEvenUnsignedChar) {
 }
 TEST_F(HostReductionTest, HistogramEvenInt16) {
     ms->model.addStepFunction(step_histogramEvenint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(0, 19);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -139,7 +139,7 @@ TEST_F(HostReductionTest, HistogramEvenInt16) {
 }
 TEST_F(HostReductionTest, HistogramEvenUnsignedInt16) {
     ms->model.addStepFunction(step_histogramEvenuint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, 19);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -155,7 +155,7 @@ TEST_F(HostReductionTest, HistogramEvenUnsignedInt16) {
 }
 TEST_F(HostReductionTest, HistogramEvenInt32) {
     ms->model.addStepFunction(step_histogramEvenint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(0, 19);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -171,7 +171,7 @@ TEST_F(HostReductionTest, HistogramEvenInt32) {
 }
 TEST_F(HostReductionTest, HistogramEvenUnsignedInt32) {
     ms->model.addStepFunction(step_histogramEvenuint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, 19);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -187,7 +187,7 @@ TEST_F(HostReductionTest, HistogramEvenUnsignedInt32) {
 }
 TEST_F(HostReductionTest, HistogramEvenInt64) {
     ms->model.addStepFunction(step_histogramEvenint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(0, 19);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -203,7 +203,7 @@ TEST_F(HostReductionTest, HistogramEvenInt64) {
 }
 TEST_F(HostReductionTest, HistogramEvenUnsignedInt64) {
     ms->model.addStepFunction(step_histogramEvenuint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, 19);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/host_reduction/test_max.cu
+++ b/tests/test_cases/runtime/host_reduction/test_max.cu
@@ -36,7 +36,7 @@ FLAMEGPU_STEP_FUNCTION(step_maxint64_t) {
 
 TEST_F(HostReductionTest, MaxFloat) {
     ms->model.addStepFunction(step_maxfloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(FLT_MIN, FLT_MAX);
     std::array<float, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -49,7 +49,7 @@ TEST_F(HostReductionTest, MaxFloat) {
 }
 TEST_F(HostReductionTest, MaxDouble) {
     ms->model.addStepFunction(step_maxdouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(DBL_MIN, DBL_MAX);
     std::array<double, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -62,7 +62,7 @@ TEST_F(HostReductionTest, MaxDouble) {
 }
 TEST_F(HostReductionTest, MaxChar) {
     ms->model.addStepFunction(step_maxchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(CHAR_MIN, CHAR_MAX);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -79,7 +79,7 @@ TEST_F(HostReductionTest, MaxChar) {
 }
 TEST_F(HostReductionTest, MaxUnsignedChar) {
     ms->model.addStepFunction(step_maxuchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UCHAR_MAX);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -92,7 +92,7 @@ TEST_F(HostReductionTest, MaxUnsignedChar) {
 }
 TEST_F(HostReductionTest, MaxInt16) {
     ms->model.addStepFunction(step_maxint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(INT16_MIN, INT16_MAX);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -105,7 +105,7 @@ TEST_F(HostReductionTest, MaxInt16) {
 }
 TEST_F(HostReductionTest, MaxUnsignedInt16) {
     ms->model.addStepFunction(step_maxuint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UINT16_MAX);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -118,7 +118,7 @@ TEST_F(HostReductionTest, MaxUnsignedInt16) {
 }
 TEST_F(HostReductionTest, MaxInt32) {
     ms->model.addStepFunction(step_maxint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(INT32_MIN, INT32_MAX);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -131,7 +131,7 @@ TEST_F(HostReductionTest, MaxInt32) {
 }
 TEST_F(HostReductionTest, MaxUnsignedInt32) {
     ms->model.addStepFunction(step_maxuint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, UINT32_MAX);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -144,7 +144,7 @@ TEST_F(HostReductionTest, MaxUnsignedInt32) {
 }
 TEST_F(HostReductionTest, MaxInt64) {
     ms->model.addStepFunction(step_maxint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(INT64_MIN, INT64_MAX);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -157,7 +157,7 @@ TEST_F(HostReductionTest, MaxInt64) {
 }
 TEST_F(HostReductionTest, MaxUnsignedInt64) {
     ms->model.addStepFunction(step_maxuint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/host_reduction/test_min.cu
+++ b/tests/test_cases/runtime/host_reduction/test_min.cu
@@ -36,7 +36,7 @@ FLAMEGPU_STEP_FUNCTION(step_minint64_t) {
 
 TEST_F(HostReductionTest, MinFloat) {
     ms->model.addStepFunction(step_minfloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(FLT_MIN, FLT_MAX);
     std::array<float, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -49,7 +49,7 @@ TEST_F(HostReductionTest, MinFloat) {
 }
 TEST_F(HostReductionTest, MinDouble) {
     ms->model.addStepFunction(step_mindouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(DBL_MIN, DBL_MAX);
     std::array<double, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -62,7 +62,7 @@ TEST_F(HostReductionTest, MinDouble) {
 }
 TEST_F(HostReductionTest, MinChar) {
     ms->model.addStepFunction(step_minchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(CHAR_MIN, CHAR_MAX);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -75,7 +75,7 @@ TEST_F(HostReductionTest, MinChar) {
 }
 TEST_F(HostReductionTest, MinUnsignedChar) {
     ms->model.addStepFunction(step_minuchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UCHAR_MAX);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -88,7 +88,7 @@ TEST_F(HostReductionTest, MinUnsignedChar) {
 }
 TEST_F(HostReductionTest, MinInt16) {
     ms->model.addStepFunction(step_minint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(INT16_MIN, INT16_MAX);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -101,7 +101,7 @@ TEST_F(HostReductionTest, MinInt16) {
 }
 TEST_F(HostReductionTest, MinUnsignedInt16) {
     ms->model.addStepFunction(step_minuint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UINT16_MAX);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -114,7 +114,7 @@ TEST_F(HostReductionTest, MinUnsignedInt16) {
 }
 TEST_F(HostReductionTest, MinInt32) {
     ms->model.addStepFunction(step_minint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(INT32_MIN, INT32_MAX);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -127,7 +127,7 @@ TEST_F(HostReductionTest, MinInt32) {
 }
 TEST_F(HostReductionTest, MinUnsignedInt32) {
     ms->model.addStepFunction(step_minuint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, UINT32_MAX);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -140,7 +140,7 @@ TEST_F(HostReductionTest, MinUnsignedInt32) {
 }
 TEST_F(HostReductionTest, MinInt64) {
     ms->model.addStepFunction(step_minint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(INT64_MIN, INT64_MAX);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -153,7 +153,7 @@ TEST_F(HostReductionTest, MinInt64) {
 }
 TEST_F(HostReductionTest, MinUnsignedInt64) {
     ms->model.addStepFunction(step_minuint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/host_reduction/test_reduce.cu
+++ b/tests/test_cases/runtime/host_reduction/test_reduce.cu
@@ -40,7 +40,7 @@ FLAMEGPU_STEP_FUNCTION(step_reduceint64_t) {
 
 TEST_F(HostReductionTest, CustomReduceFloat) {
     ms->model.addStepFunction(step_reducefloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(FLT_MIN, FLT_MAX);
     std::array<float, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -53,7 +53,7 @@ TEST_F(HostReductionTest, CustomReduceFloat) {
 }
 TEST_F(HostReductionTest, CustomReduceDouble) {
     ms->model.addStepFunction(step_reducedouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(DBL_MIN, DBL_MAX);
     std::array<double, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -66,7 +66,7 @@ TEST_F(HostReductionTest, CustomReduceDouble) {
 }
 TEST_F(HostReductionTest, CustomReduceChar) {
     ms->model.addStepFunction(step_reducechar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(CHAR_MIN, CHAR_MAX);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -83,7 +83,7 @@ TEST_F(HostReductionTest, CustomReduceChar) {
 }
 TEST_F(HostReductionTest, CustomReduceUnsignedChar) {
     ms->model.addStepFunction(step_reduceuchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UCHAR_MAX);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -96,7 +96,7 @@ TEST_F(HostReductionTest, CustomReduceUnsignedChar) {
 }
 TEST_F(HostReductionTest, CustomReduceInt16) {
     ms->model.addStepFunction(step_reduceint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(INT16_MIN, INT16_MAX);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -109,7 +109,7 @@ TEST_F(HostReductionTest, CustomReduceInt16) {
 }
 TEST_F(HostReductionTest, CustomReduceUnsignedInt16) {
     ms->model.addStepFunction(step_reduceuint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UINT16_MAX);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -122,7 +122,7 @@ TEST_F(HostReductionTest, CustomReduceUnsignedInt16) {
 }
 TEST_F(HostReductionTest, CustomReduceInt32) {
     ms->model.addStepFunction(step_reduceint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(INT32_MIN, INT32_MAX);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -135,7 +135,7 @@ TEST_F(HostReductionTest, CustomReduceInt32) {
 }
 TEST_F(HostReductionTest, CustomReduceUnsignedInt32) {
     ms->model.addStepFunction(step_reduceuint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, UINT32_MAX);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -148,7 +148,7 @@ TEST_F(HostReductionTest, CustomReduceUnsignedInt32) {
 }
 TEST_F(HostReductionTest, CustomReduceInt64) {
     ms->model.addStepFunction(step_reduceint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(INT64_MIN, INT64_MAX);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -161,7 +161,7 @@ TEST_F(HostReductionTest, CustomReduceInt64) {
 }
 TEST_F(HostReductionTest, CustomReduceUnsignedInt64) {
     ms->model.addStepFunction(step_reduceuint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/host_reduction/test_sum.cu
+++ b/tests/test_cases/runtime/host_reduction/test_sum.cu
@@ -42,7 +42,7 @@ FLAMEGPU_STEP_FUNCTION(step_sumint64_t) {
 
 TEST_F(HostReductionTest, SumFloat) {
     ms->model.addStepFunction(step_sumfloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(FLT_MIN, FLT_MAX);
     std::array<float, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -55,7 +55,7 @@ TEST_F(HostReductionTest, SumFloat) {
 }
 TEST_F(HostReductionTest, SumDouble) {
     ms->model.addStepFunction(step_sumdouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(DBL_MIN, DBL_MAX);
     std::array<double, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -68,7 +68,7 @@ TEST_F(HostReductionTest, SumDouble) {
 }
 TEST_F(HostReductionTest, SumChar) {
     ms->model.addStepFunction(step_sumchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(CHAR_MIN, CHAR_MAX);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -86,7 +86,7 @@ TEST_F(HostReductionTest, SumChar) {
 }
 TEST_F(HostReductionTest, SumUnsignedChar) {
     ms->model.addStepFunction(step_sumuchar);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UCHAR_MAX);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -100,7 +100,7 @@ TEST_F(HostReductionTest, SumUnsignedChar) {
 }
 TEST_F(HostReductionTest, SumInt16) {
     ms->model.addStepFunction(step_sumint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(INT16_MIN, INT16_MAX);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -114,7 +114,7 @@ TEST_F(HostReductionTest, SumInt16) {
 }
 TEST_F(HostReductionTest, SumUnsignedInt16) {
     ms->model.addStepFunction(step_sumuint16_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UINT16_MAX);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -128,7 +128,7 @@ TEST_F(HostReductionTest, SumUnsignedInt16) {
 }
 TEST_F(HostReductionTest, SumInt32) {
     ms->model.addStepFunction(step_sumint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(INT32_MIN, INT32_MAX);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -142,7 +142,7 @@ TEST_F(HostReductionTest, SumInt32) {
 }
 TEST_F(HostReductionTest, SumUnsignedInt32) {
     ms->model.addStepFunction(step_sumuint32_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, UINT32_MAX);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -156,7 +156,7 @@ TEST_F(HostReductionTest, SumUnsignedInt32) {
 }
 TEST_F(HostReductionTest, SumInt64) {
     ms->model.addStepFunction(step_sumint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(INT64_MIN, INT64_MAX);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -169,7 +169,7 @@ TEST_F(HostReductionTest, SumInt64) {
 }
 TEST_F(HostReductionTest, SumUnsignedInt64) {
     ms->model.addStepFunction(step_sumuint64_t);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/host_reduction/test_transform_reduce.cu
+++ b/tests/test_cases/runtime/host_reduction/test_transform_reduce.cu
@@ -43,7 +43,7 @@ FLAMEGPU_STEP_FUNCTION(step_transformReduceuint64_t) {
 
 TEST_F(HostReductionTest, CustomTransformReduceFloat) {
     ms->model.addStepFunction(step_transformReduceFloat);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <float> dist(FLT_MIN, FLT_MAX);
     std::array<float, TEST_LEN> in;
     std::array<int, TEST_LEN> inTransform;
@@ -58,7 +58,7 @@ TEST_F(HostReductionTest, CustomTransformReduceFloat) {
 }
 TEST_F(HostReductionTest, CustomTransformReduceDouble) {
     ms->model.addStepFunction(step_transformReduceDouble);
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_real_distribution <double> dist(DBL_MIN, DBL_MAX);
     std::array<double, TEST_LEN> in;
     std::array<int, TEST_LEN> inTransform;
@@ -74,7 +74,7 @@ TEST_F(HostReductionTest, CustomTransformReduceDouble) {
 TEST_F(HostReductionTest, CustomTransformReduceChar) {
     ms->model.addStepFunction(step_transformReducechar);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(CHAR_MIN, CHAR_MAX);
     std::array<char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -93,7 +93,7 @@ TEST_F(HostReductionTest, CustomTransformReduceChar) {
 TEST_F(HostReductionTest, CustomTransformReduceUnsignedChar) {
     ms->model.addStepFunction(step_transformReduceuchar);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UCHAR_MAX);
     std::array<unsigned char, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -108,7 +108,7 @@ TEST_F(HostReductionTest, CustomTransformReduceUnsignedChar) {
 TEST_F(HostReductionTest, CustomTransformReduceInt16) {
     ms->model.addStepFunction(step_transformReduceint16_t);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int16_t> dist(INT16_MIN, INT16_MAX);
     std::array<int16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -123,7 +123,7 @@ TEST_F(HostReductionTest, CustomTransformReduceInt16) {
 TEST_F(HostReductionTest, CustomTransformReduceUnsignedInt16) {
     ms->model.addStepFunction(step_transformReduceuint16_t);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint16_t> dist(0, UINT16_MAX);
     std::array<uint16_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -138,7 +138,7 @@ TEST_F(HostReductionTest, CustomTransformReduceUnsignedInt16) {
 TEST_F(HostReductionTest, CustomTransformReduceInt32) {
     ms->model.addStepFunction(step_transformReduceint32_t);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int32_t> dist(INT32_MIN, INT32_MAX);
     std::array<int32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -153,7 +153,7 @@ TEST_F(HostReductionTest, CustomTransformReduceInt32) {
 TEST_F(HostReductionTest, CustomTransformReduceUnsignedInt32) {
     ms->model.addStepFunction(step_transformReduceuint32_t);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint32_t> dist(0, UINT32_MAX);
     std::array<uint32_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -168,7 +168,7 @@ TEST_F(HostReductionTest, CustomTransformReduceUnsignedInt32) {
 TEST_F(HostReductionTest, CustomTransformReduceInt64) {
     ms->model.addStepFunction(step_transformReduceint64_t);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <int64_t> dist(INT64_MIN, INT64_MAX);
     std::array<int64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {
@@ -183,7 +183,7 @@ TEST_F(HostReductionTest, CustomTransformReduceInt64) {
 TEST_F(HostReductionTest, CustomTransformReduceUnsignedInt64) {
     ms->model.addStepFunction(step_transformReduceuint64_t);
     std::array<int, TEST_LEN> inTransform;
-    std::mt19937 rd;  // Seed does not matter
+    std::mt19937_64 rd;  // Seed does not matter
     std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
     std::array<uint64_t, TEST_LEN> in;
     for (unsigned int i = 0; i < TEST_LEN; i++) {

--- a/tests/test_cases/runtime/test_host_agent_sort.cu
+++ b/tests/test_cases/runtime/test_host_agent_sort.cu
@@ -28,7 +28,7 @@ TEST(HostAgentSort, Ascending_float) {
     agent.newVariable<float>("float");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort_ascending_float);
-    std::mt19937 rd(31313131);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(31313131);  // Fixed seed (at Pete's request)
     std::uniform_real_distribution <float> dist(1, 1000000);
 
     // Init pop
@@ -66,7 +66,7 @@ TEST(HostAgentSort, Descending_float) {
     agent.newVariable<float>("float");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort_descending_float);
-    std::mt19937 rd(888);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(888);  // Fixed seed (at Pete's request)
     std::uniform_real_distribution <float> dist(1, 1000000);
 
     // Init pop
@@ -104,7 +104,7 @@ TEST(HostAgentSort, Ascending_int) {
     agent.newVariable<int>("int");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort_ascending_int);
-    std::mt19937 rd(77777);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(77777);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist(0, 1000000);
 
     // Init pop
@@ -142,7 +142,7 @@ TEST(HostAgentSort, Descending_int) {
     agent.newVariable<int>("int");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort_descending_int);
-    std::mt19937 rd(12);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(12);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist(1, 1000000);
 
     // Init pop
@@ -200,7 +200,7 @@ TEST(HostAgentSort, 2x_Ascending_float) {
     agent.newVariable<float>("float2");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort2x_ascending_float);
-    std::mt19937 rd(54323);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(54323);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist1(0, 9);
     std::uniform_real_distribution <float> dist2(0, 999);
 
@@ -243,7 +243,7 @@ TEST(HostAgentSort, 2x_Descending_float) {
     agent.newVariable<float>("float2");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort2x_descending_float);
-    std::mt19937 rd(5422323);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(5422323);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist1(0, 9);
     std::uniform_real_distribution <float> dist2(0, 999);
 
@@ -286,7 +286,7 @@ TEST(HostAgentSort, 2x_Ascending_int) {
     agent.newVariable<int>("int2");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort2x_ascending_int);
-    std::mt19937 rd(123123);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(123123);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist1(0, 9);
     std::uniform_int_distribution <int> dist2(0, 999);
 
@@ -329,7 +329,7 @@ TEST(HostAgentSort, 2x_Descending_int) {
     agent.newVariable<int>("int2");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort2x_descending_int);
-    std::mt19937 rd(12333123);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(12333123);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist1(0, 9);
     std::uniform_int_distribution <int> dist2(0, 999);
 
@@ -372,7 +372,7 @@ TEST(HostAgentSort, 2x_AscDesc_int) {
     agent.newVariable<int>("int2");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort2x_ascdesc_int);
-    std::mt19937 rd(123123);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(123123);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist1(0, 9);
     std::uniform_int_distribution <int> dist2(0, 999);
 
@@ -415,7 +415,7 @@ TEST(HostAgentSort, 2x_DescAsc_int) {
     agent.newVariable<int>("int2");
     agent.newVariable<int>("spare");
     model.newLayer().addHostFunction(sort2x_descasc_int);
-    std::mt19937 rd(12333123);  // Fixed seed (at Pete's request)
+    std::mt19937_64 rd(12333123);  // Fixed seed (at Pete's request)
     std::uniform_int_distribution <int> dist1(0, 9);
     std::uniform_int_distribution <int> dist2(0, 999);
 

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -1,0 +1,295 @@
+#include "flamegpu/flamegpu.h"
+
+#include "gtest/gtest.h"
+
+namespace flamegpu {
+namespace tests {
+namespace test_runplan {
+
+TEST(TestRunPlan, constructor) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Declare a pointer
+    flamegpu::RunPlan * plan = nullptr;
+    // Use New
+    EXPECT_NO_THROW(plan = new flamegpu::RunPlan(model));
+    EXPECT_NE(plan, nullptr);
+    // Run the destructor
+    EXPECT_NO_THROW(delete plan);
+    plan = nullptr;
+}
+TEST(TestRunPlan, setRandomSimulationSeed) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Get the original simulation seed. Cannot compare for an expected value as any uint64_t is potentially legitimate.
+    EXPECT_NO_THROW(plan.getRandomSimulationSeed());
+    // Set to max 32 bit value +1
+    uint64_t newSimulationSeed = UINT_MAX + 1;
+    plan.setRandomSimulationSeed(newSimulationSeed);
+    // Get the value again, and expect it to be the set value. It is not guaranteed to not be the original random value.
+    uint64_t simulationSeedUpdated = plan.getRandomSimulationSeed();
+    EXPECT_EQ(newSimulationSeed, simulationSeedUpdated);
+    // Set it again, this time passing a narrower number.
+    uint32_t narrowSimulationSeed = 12u;
+    plan.setRandomSimulationSeed(narrowSimulationSeed);
+    // Get the seed again, into a narrow value
+    uint32_t narrowSimulationSeedUpdated = static_cast<uint32_t>(plan.getRandomSimulationSeed());
+    EXPECT_EQ(narrowSimulationSeed, narrowSimulationSeedUpdated);
+}
+TEST(TestRunPlan, setSteps) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Get the default value
+    uint32_t steps = plan.getSteps();
+    EXPECT_EQ(steps, 1u);
+    // Set a new value
+    uint32_t newSteps = 12u;
+    plan.setSteps(newSteps);
+    // Get the updated value and compare
+    uint32_t updatedSteps = plan.getSteps();
+    EXPECT_EQ(updatedSteps, newSteps);
+
+    // Expected exception tests
+    EXPECT_THROW(plan.setSteps(0u), std::out_of_range);
+}
+TEST(TestRunPlan, setOutputSubdirectory) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Set the subdirectory to a non empty string
+    std::string newSubdir("test");
+    plan.setOutputSubdirectory(newSubdir);
+    // Get the original value
+    std::string updatedSubdir = plan.getOutputSubdirectory();
+    // By default this is an empty string
+    EXPECT_EQ(updatedSubdir, newSubdir);
+}
+TEST(TestRunPlan, setProperty) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Add some properties to the model, using a range of types.
+    auto &environment = model.Environment();
+    environment.newProperty<float>("f", 1.0f);
+    environment.newProperty<int32_t>("i", -1);
+    environment.newProperty<uint32_t>("u", 1u);
+    environment.newProperty<float, 3>("f_a", {-1.0f, 0.0f, 1.0f});
+    environment.newProperty<int32_t, 3>("i_a", {-1, 0, 1 });
+    environment.newProperty<uint32_t, 3>("u_a", {0, 1, 2 });
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Set properties to new values
+    // Compare the old and new values, to ensure that thy do not match
+    // RunPlan::setProperty(const std::string &name, const T&value)
+    plan.setProperty<float>("f", 2.0f);
+    plan.setProperty<int32_t>("i", 2);
+    plan.setProperty<uint32_t>("u", 2u);
+    // Set arrays at once
+    // RunPlan::setProperty(const std::string &name, const std::array<T, N> &value)
+    plan.setProperty<float, 3>("f_a", {-2.0f, 0.0f, 2.0f});
+    plan.setProperty<int32_t, 3>("i_a", {-2, 0, 2});
+    // Set individual elements at a time
+    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    plan.setProperty<uint32_t>("u_a", 0, 3u);
+    plan.setProperty<uint32_t>("u_a", 1, 4u);
+    plan.setProperty<uint32_t>("u_a", 2, 5u);
+
+    EXPECT_NE(plan.getProperty<float>("f"), environment.getProperty<float>("f"));
+    EXPECT_NE(plan.getProperty<int32_t>("i"), environment.getProperty<int32_t>("i"));
+    EXPECT_NE(plan.getProperty<uint32_t>("u"), environment.getProperty<uint32_t>("u"));
+    // extra brackets allow commas in macros.
+    EXPECT_NE((plan.getProperty<float, 3>("f_a")), (environment.getProperty<float, 3>("f_a")));
+    EXPECT_NE((plan.getProperty<int32_t, 3>("i_a")), (environment.getProperty<int32_t, 3>("i_a")));
+    EXPECT_NE((plan.getProperty<uint32_t, 3>("u_a")), (environment.getProperty<uint32_t, 3>("u_a")));
+
+    // Tests for exceptions
+    // --------------------
+    // Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+    // RunPlan::setProperty(const std::string &name, const T&value)
+    EXPECT_THROW(plan.setProperty<float>("does_not_exist", 1.f), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW(plan.setProperty<float>("i", 1.f), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW(plan.setProperty<uint32_t>("u_a", 1u), flamegpu::exception::InvalidEnvPropertyType);
+    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+    EXPECT_THROW((plan.setProperty<float, 3>("does_not_exist", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plan.setProperty<float, 3>("u_a", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plan.setProperty<int32_t, 2>("i_a", {-2, 0})), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plan.setProperty<int32_t, 4>("i_a", {-2, 0, 2, 2})), flamegpu::exception::InvalidEnvPropertyType);
+    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    EXPECT_THROW((plan.setProperty<float>("does_not_exist", 0u, 3.f)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plan.setProperty<float>("u_a", 0u, 3.f)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plan.setProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1), 3)), std::out_of_range);
+    EXPECT_THROW((plan.setProperty<int32_t>("i_a", 4u, 3)), std::out_of_range);
+}
+TEST(TestRunPlan, getRandomSimulationSeed) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Get the Simulation seed
+    // As this is random, it could be any value. So get it twice, and make sure the same thing was returned?
+    uint64_t simulationSeed = plan.getRandomSimulationSeed();
+    uint64_t simulationSeedAgain = plan.getRandomSimulationSeed();
+    EXPECT_EQ(simulationSeed, simulationSeedAgain);
+}
+TEST(TestRunPlan, getSteps) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Get the default value
+    uint32_t steps = plan.getSteps();
+    EXPECT_EQ(steps, 1u);
+}
+TEST(TestRunPlan, getOutputSubdirectory) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Get the default value
+    std::string subdir = plan.getOutputSubdirectory();
+    // By default this is an empty string
+    EXPECT_EQ(subdir, "");
+}
+TEST(TestRunPlan, getProperty) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Add some properties to the model, using a range of types.
+    auto &environment = model.Environment();
+    environment.newProperty<float>("f", 1.0f);
+    environment.newProperty<int32_t>("i", -1);
+    environment.newProperty<uint32_t>("u", 1u);
+    environment.newProperty<float, 3>("f_a", {-1.0f, 0.0f, 1.0f});
+    environment.newProperty<int32_t, 3>("i_a", {-1, 0, 1 });
+    environment.newProperty<uint32_t, 3>("u_a", {0, 1, 2 });
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Check that they match the original value when no overrides have been set.
+    EXPECT_EQ(plan.getProperty<float>("f"), environment.getProperty<float>("f"));
+    EXPECT_EQ(plan.getProperty<int32_t>("i"), environment.getProperty<int32_t>("i"));
+    EXPECT_EQ(plan.getProperty<uint32_t>("u"), environment.getProperty<uint32_t>("u"));
+    // extra brackets allow commas in macros.
+    EXPECT_EQ((plan.getProperty<float, 3>("f_a")), (environment.getProperty<float, 3>("f_a")));
+    EXPECT_EQ((plan.getProperty<int32_t, 3>("i_a")), (environment.getProperty<int32_t, 3>("i_a")));
+    EXPECT_EQ((plan.getProperty<uint32_t, 3>("u_a")), (environment.getProperty<uint32_t, 3>("u_a")));
+
+    // Tests for exceptions
+    // --------------------
+    // Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+    // RunPlan::getProperty(const std::string &name) const
+    EXPECT_THROW(plan.getProperty<float>("does_not_exist"), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW(plan.getProperty<float>("i"), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW(plan.getProperty<uint32_t>("u_a"), flamegpu::exception::InvalidEnvPropertyType);
+    // std::array<T, N> RunPlan::getProperty(const std::string &name) const
+    // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+    EXPECT_THROW((plan.getProperty<float, 3>("does_not_exist")), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plan.getProperty<float, 3>("u_a")), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plan.getProperty<int32_t, 2>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plan.getProperty<int32_t, 4>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
+    // T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index) const
+    EXPECT_THROW((plan.getProperty<float>("does_not_exist", 0u)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plan.getProperty<float>("u_a", 0u)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1))), std::out_of_range);
+    EXPECT_THROW((plan.getProperty<int32_t>("i_a", 4u)), std::out_of_range);
+}
+// @todo - This test could be a lot more thorough.
+TEST(TestRunPlan, operatorAssignment) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create two separate RunPlans with unique values
+    flamegpu::RunPlan plan1(model);
+    const uint64_t seed1 = 1u;
+    plan1.setRandomSimulationSeed(seed1);
+    flamegpu::RunPlan plan2(model);
+    const uint64_t seedB = 2u;
+    plan1.setRandomSimulationSeed(seedB);
+    // Verify properties are unique
+    EXPECT_NE(plan1.getRandomSimulationSeed(), plan2.getRandomSimulationSeed());
+    // use the assignment operator to set plan1=plan2, then check the unique value(s) are correct.
+    plan1 = plan2;
+    EXPECT_EQ(plan1.getRandomSimulationSeed(), plan2.getRandomSimulationSeed());
+}
+TEST(TestRunPlan, operatorAddition) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create multiple run plans and set unique values on each
+    flamegpu::RunPlan plan1(model);
+    const uint64_t seed1 = 1u;
+    plan1.setRandomSimulationSeed(seed1);
+    flamegpu::RunPlan plan2(model);
+    const uint64_t seed2 = 2u;
+    plan2.setRandomSimulationSeed(seed2);
+    flamegpu::RunPlan plan3(model);
+    const uint64_t seed3 = 3u;
+    plan3.setRandomSimulationSeed(seed3);
+
+    // RunPlanVector = RunPlan + RunPlan
+    flamegpu::RunPlanVector vec12 = plan1 + plan2;
+    EXPECT_EQ(vec12.size(), 2);
+    EXPECT_EQ(vec12[0].getRandomSimulationSeed(), seed1);
+    EXPECT_EQ(vec12[1].getRandomSimulationSeed(), seed2);
+
+    /* Disabled for now, operator+ is always an append for performance reasons (currently) 
+    // RunPlanVector = RunPlan + RunPlanVector
+    // As an prepend?
+    flamegpu::RunPlanVector vec312 = plan3 + vec12;
+    EXPECT_EQ(vec312.size(), 3);
+    EXPECT_EQ(vec312[0].getRandomSimulationSeed(), seed3);
+    EXPECT_EQ(vec312[1].getRandomSimulationSeed(), seed1);
+    EXPECT_EQ(vec312[2].getRandomSimulationSeed(), seed2); 
+    */
+
+    // Try with operators in the other order.
+    // As an append.
+    flamegpu::RunPlanVector vec123 = vec12 + plan3;
+    EXPECT_EQ(vec123.size(), 3);
+    EXPECT_EQ(vec123[0].getRandomSimulationSeed(), seed1);
+    EXPECT_EQ(vec123[1].getRandomSimulationSeed(), seed2);
+    EXPECT_EQ(vec123[2].getRandomSimulationSeed(), seed3);
+
+    // Expected exceptions
+    // -------------------
+    // Adding runplans together which are not for the same model (actually environment) should throw.
+    flamegpu::ModelDescription otherModel("other");
+    otherModel.Environment().newProperty<float>("f", 1.0f);  // If both models have null environments they are compatible
+    flamegpu::RunPlan otherPlan(otherModel);
+    flamegpu::RunPlanVector otherPlanVector(otherModel, 1);
+    EXPECT_THROW((plan1 + otherPlan), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((plan1 + otherPlanVector), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((otherPlan + plan1), flamegpu::exception::InvalidArgument);
+}
+// RunPLanVector = RunPlan * uint32_t
+TEST(TestRunPlan, operatorMultiplication) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan.
+    flamegpu::RunPlan plan(model);
+    // Set a value to a non default value to allow comparison
+    const uint64_t newSimulationSeed = 12u;
+    plan.setRandomSimulationSeed(newSimulationSeed);
+    // Create a RunPlanVector of N elemets
+    const uint32_t N = 4u;
+    flamegpu::RunPlanVector plans = plan * N;
+    EXPECT_EQ(plans.size(), N);
+    // Compare each element
+    for (const auto &p : plans) {
+        EXPECT_EQ(p.getRandomSimulationSeed(),  newSimulationSeed);
+        // @todo - compare more than one part? Operator== might be easier / cleaner
+    }
+}
+/*
+getPropertyArray/setPropertyArray are only declared if SWIG is defined.
+// This is not currently the case when building the test suite, so these cannot be tested here.
+TEST(TestRunPlan, getPropertyArray) {
+}
+TEST(TestRunPlan, setPropertyArray) {
+}
+*/
+
+}  // namespace test_runplan
+}  // namespace tests
+}  // namespace flamegpu

--- a/tests/test_cases/sim/test_RunPlanVector.cu
+++ b/tests/test_cases/sim/test_RunPlanVector.cu
@@ -1,0 +1,630 @@
+#include "flamegpu/flamegpu.h"
+
+#include "gtest/gtest.h"
+
+namespace flamegpu {
+namespace tests {
+namespace test_runplanvector {
+
+TEST(TestRunPlanVector, constructor) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Declare a pointer
+    flamegpu::RunPlanVector * plans = nullptr;
+    // Use New
+    const uint32_t initialLength = 4;
+    EXPECT_NO_THROW(plans = new flamegpu::RunPlanVector(model, initialLength));
+    EXPECT_NE(plans, nullptr);
+    EXPECT_EQ(plans->size(), initialLength);
+    // Run the destructor
+    EXPECT_NO_THROW(delete plans);
+    plans = nullptr;
+}
+// Test setting the random property seed
+TEST(TestRunPlanVector, setRandomPropertySeed) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 2;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Get the current random property seed. No sensible options to check this is an expected value.
+    EXPECT_NO_THROW(plans.getRandomPropertySeed());
+    // Set the seed to a new value, and check that it was applied.
+    uint64_t newPropertySeed = 12;
+    plans.setRandomPropertySeed(newPropertySeed);
+    // Check the new seed was applied correctly.
+    EXPECT_EQ(plans.getRandomPropertySeed(), newPropertySeed);
+    // @todo - should check that the seed actually impacts the generatred random numbers. Seed, generated. Reseed the same, compare. reseed different, compare (Low risk of the same sequence being generated, so just make the sequence not trivially small)
+}
+// Exit function condition which leads to 0 steps being allowed for plans within a vector.
+FLAMEGPU_EXIT_CONDITION(exitcond) {
+    return flamegpu::EXIT;
+}
+TEST(TestRunPlanVector, setSteps) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Get the original value of steps, storing them for later.
+    std::array<uint32_t, totalPlans> originalValues = {{}};
+    for (uint32_t idx = 0; idx < totalPlans; idx++) {
+        const auto &plan = plans[idx];
+        originalValues[idx] = plan.getSteps();
+    }
+    // Set the number of steps
+    const uint32_t newSteps = 12u;
+    EXPECT_NO_THROW(plans.setSteps(newSteps));
+    // For Check each plan against the previous value(s)
+    for (uint32_t idx = 0; idx < totalPlans; idx++) {
+        const auto &plan = plans[idx];
+        EXPECT_EQ(plan.getSteps(), newSteps);
+        EXPECT_NE(plan.getSteps(), originalValues[idx]);
+    }
+    // Expect an exception if setting the value to 0?
+    EXPECT_THROW(plans.setSteps(0), std::out_of_range);
+
+    // If the model has an exit condition, then it will not throw.
+    flamegpu::ModelDescription modelWithExit("modelWithExit");
+    modelWithExit.addExitCondition(exitcond);
+    flamegpu::RunPlanVector plansWithExit(modelWithExit, 1u);
+    // Do not expect an exception iff allow_o_steps is set.
+    EXPECT_NO_THROW(plansWithExit.setSteps(0));
+}
+TEST(TestRunPlanVector, setOutputSubdirectory) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Set the new value
+    std::string newSubdir("test");
+    EXPECT_NO_THROW(plans.setOutputSubdirectory(newSubdir));
+    // For Check each plan against the previous value(s)
+    for (uint32_t idx = 0; idx < totalPlans; idx++) {
+        const auto &plan = plans[idx];
+        EXPECT_EQ(plan.getOutputSubdirectory(), newSubdir);
+        EXPECT_NE(plan.getOutputSubdirectory(), "");
+    }
+}
+
+TEST(TestRunPlanVector, setProperty) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Add a few environment properties to the model.
+    auto &environment = model.Environment();
+    const float fOriginal = 1.0f;
+    const int32_t iOriginal = 1;
+    const std::array<uint32_t, 3> u3Original = {{0, 1, 2}};
+    const std::array<double, 3> d3Original = {{0., 1., 2.}};
+    environment.newProperty<float>("f", fOriginal);
+    environment.newProperty<int32_t>("i", iOriginal);
+    environment.newProperty<uint32_t, 3>("u3", u3Original);
+    environment.newProperty<double, 3>("d3", d3Original);
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 2u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Uniformly set each property to a new value, then check it has been applied correctly.
+    const float fNew = 2.0f;
+    const int32_t iNew = 2;
+    const std::array<uint32_t, 3> u3New = {{3u, 4u, 5u}};
+    const std::array<double, 3> d3New = {{3., 4., 5.}};
+    // void RunPlanVector::setProperty(const std::string &name, const T &value) {
+    plans.setProperty("f", fNew);
+    plans.setProperty("i", iNew);
+    // Check setting full arrays
+    // void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> &value) {
+    // Explicit type is required, to coerce the std::array. Might need partial template specialisation for  where the value is a stdarray of T?
+    plans.setProperty<uint32_t, 3>("u3", u3New);
+    // Check setting individual array elements
+    // void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+    plans.setProperty<double>("d3", 0, d3New[0]);
+    plans.setProperty<double>("d3", 1, d3New[1]);
+    plans.setProperty<double>("d3", 2, d3New[2]);
+    // Check values are as expected by accessing the properties from each plan
+    for (const auto &plan : plans) {
+        EXPECT_EQ(plan.getProperty<float>("f"), fNew);
+        EXPECT_EQ(plan.getProperty<int32_t>("i"), iNew);
+        // Extra brackets allow template commas in macros.
+        EXPECT_EQ((plan.getProperty<uint32_t, 3>("u3")), u3New);
+        EXPECT_EQ((plan.getProperty<double, 3>("d3")), d3New);
+    }
+
+    // Tests for exceptions
+    // --------------------
+    // Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+    // void RunPlanVector::setProperty(const std::string &name, const T &value)
+    EXPECT_THROW(plans.setProperty<float>("does_not_exist", 1.f), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW(plans.setProperty<float>("i", 1.f), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW(plans.setProperty<uint32_t>("u3", 1u), flamegpu::exception::InvalidEnvPropertyType);
+    // void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> &value)
+    // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+    EXPECT_THROW((plans.setProperty<float, 3>("does_not_exist", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plans.setProperty<float, 3>("u3", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setProperty<double, 2>("d3", {-2, 0})), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setProperty<double, 4>("d3", {-2, 0, 2, 2})), flamegpu::exception::InvalidEnvPropertyType);
+    // void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    EXPECT_THROW((plans.setProperty<float>("does_not_exist", 0u, 3.f)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plans.setProperty<float>("u3", 0u, 3.f)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setProperty<double>("d3", static_cast<EnvironmentManager::size_type>(-1), 3)), std::out_of_range);
+    EXPECT_THROW((plans.setProperty<double>("d3", 4u, 3)), std::out_of_range);
+}
+// Check that all values set lie within the min and max inclusive
+// @todo - should fp be [min, max) like when using RNG?
+TEST(TestRunPlanVector, setPropertyUniformDistribution) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Add a few environment properties to the model.
+    auto &environment = model.Environment();
+    const float fOriginal = 0.0f;
+    const int32_t iOriginal = 0;
+    const std::array<uint32_t, 3> u3Original = {{0, 0, 0}};
+    environment.newProperty<float>("f", fOriginal);
+    environment.newProperty<int32_t>("i", iOriginal);
+    environment.newProperty<uint32_t, 3>("u3", u3Original);
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 10u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // No need to seed the random, as this is a LERP rather than a random distribution.
+
+    // Uniformly set each property to a new value, then check it has been applied correctly.
+    const float fMin = 1.f;
+    const float fMax = 100.f;
+    const int32_t iMin = 1;
+    const int32_t iMax = 100;
+    const std::array<uint32_t, 3> u3Min = {{1u, 101u, 201u}};
+    const std::array<uint32_t, 3> u3Max = {{100u, 200u, 300u}};
+    // void setPropertyUniformDistribution(const std::string &name, const T &min, const T &max);
+    plans.setPropertyUniformDistribution("f", fMin, fMax);
+    plans.setPropertyUniformDistribution("i", iMin, iMax);
+    // Check setting individual array elements
+    // void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max);
+    plans.setPropertyUniformDistribution("u3", 0, u3Min[0], u3Max[0]);
+    plans.setPropertyUniformDistribution("u3", 1, u3Min[1], u3Max[1]);
+    plans.setPropertyUniformDistribution("u3", 2, u3Min[2], u3Max[2]);
+    // Check values are as expected by accessing the properties from each plan
+    for (const auto &plan : plans) {
+        EXPECT_GE(plan.getProperty<float>("f"), fMin);
+        EXPECT_LE(plan.getProperty<float>("f"), fMax);
+        EXPECT_GE(plan.getProperty<int32_t>("i"), iMin);
+        EXPECT_LE(plan.getProperty<int32_t>("i"), iMax);
+        const std::array<uint32_t, 3> u3FromPlan = plan.getProperty<uint32_t, 3>("u3");
+        EXPECT_GE(u3FromPlan[0], u3Min[0]);
+        EXPECT_LE(u3FromPlan[0], u3Max[0]);
+        EXPECT_GE(u3FromPlan[1], u3Min[1]);
+        EXPECT_LE(u3FromPlan[1], u3Max[1]);
+        EXPECT_GE(u3FromPlan[2], u3Min[2]);
+        EXPECT_LE(u3FromPlan[2], u3Max[2]);
+    }
+
+    // Tests for exceptions
+    // --------------------
+    flamegpu::RunPlanVector singlePlanVector(model, 1);
+    // Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+    // void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
+    EXPECT_THROW((singlePlanVector.setPropertyUniformDistribution<float>("f", 1.f, 100.f)), std::out_of_range);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<float>("does_not_exist", 1.f, 100.f)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<float>("i", 1.f, 100.f)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", 1u, 100u)), flamegpu::exception::InvalidEnvPropertyType);
+    // void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type
+    // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+    EXPECT_THROW((singlePlanVector.setPropertyUniformDistribution<uint32_t>("u3", 0u, 1u, 100u)), std::out_of_range);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<float>("does_not_exist", 0u, 1.f, 100.f)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<float>("u3", 0u, 1.f, 100.f)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", static_cast<EnvironmentManager::size_type>(-1), 1u, 100u)), std::out_of_range);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", 4u, 1u, 100u)), std::out_of_range);
+}
+// Checking for uniformity of distribution would require a very large samples size.
+// As std:: is used, we trust the distribution is legit, and instead just check for min/max.
+TEST(TestRunPlanVector, setPropertyUniformRandom) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Add a few environment properties to the model.
+    auto &environment = model.Environment();
+    const float fOriginal = 1.0f;
+    const int32_t iOriginal = 1;
+    const std::array<uint32_t, 3> u3Original = {{0, 1, 2}};
+    environment.newProperty<float>("f", fOriginal);
+    environment.newProperty<int32_t>("i", iOriginal);
+    environment.newProperty<uint32_t, 3>("u3", u3Original);
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Seed the RunPlanVector RNG for a deterministic test.
+    plans.setRandomPropertySeed(1u);
+
+    // Uniformly set each property to a new value, then check it has been applied correctly.
+    const float fMin = 1.f;
+    const float fMax = 100.f;
+    const int32_t iMin = 1;
+    const int32_t iMax = 100;
+    const std::array<uint32_t, 3> u3Min = {{1u, 101u, 201u}};
+    const std::array<uint32_t, 3> u3Max = {{100u, 200u, 300u}};
+    // void setPropertyUniformRandom(const std::string &name, const T &min, const T &Max);
+    plans.setPropertyUniformRandom("f", fMin, fMax);
+    plans.setPropertyUniformRandom("i", iMin, iMax);
+    // Check setting individual array elements
+    // void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &Max);
+    plans.setPropertyUniformRandom("u3", 0, u3Min[0], u3Max[0]);
+    plans.setPropertyUniformRandom("u3", 1, u3Min[1], u3Max[1]);
+    plans.setPropertyUniformRandom("u3", 2, u3Min[2], u3Max[2]);
+    // Check values are as expected by accessing the properties from each plan
+    for (const auto &plan : plans) {
+        // Floating point types are inclusive-exclusive [min, Max)
+        EXPECT_GE(plan.getProperty<float>("f"), fMin);
+        EXPECT_LT(plan.getProperty<float>("f"), fMax);
+        // Integer types are mutually inclusive [min, Max]
+        EXPECT_GE(plan.getProperty<int32_t>("i"), iMin);
+        EXPECT_LE(plan.getProperty<int32_t>("i"), iMax);
+        // Check array values are correct, Integers so mutually inclusive
+        const std::array<uint32_t, 3> u3FromPlan = plan.getProperty<uint32_t, 3>("u3");
+        EXPECT_GE(u3FromPlan[0], u3Min[0]);
+        EXPECT_LE(u3FromPlan[0], u3Max[0]);
+        EXPECT_GE(u3FromPlan[1], u3Min[1]);
+        EXPECT_LE(u3FromPlan[1], u3Max[1]);
+        EXPECT_GE(u3FromPlan[2], u3Min[2]);
+        EXPECT_LE(u3FromPlan[2], u3Max[2]);
+    }
+}
+// It's non trivial to check for correct distirbutions, and we rely on std:: so we are going to trust it works as intended.
+// Instead, just check that the value is different than the original. As this is not guaranteed due to (seeded) RNG, just check that atleast one value is different.
+// Real property types only. Non-reals are a static assert.
+TEST(TestRunPlanVector, setPropertyNormalRandom) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Add a few environment properties to the model.
+    auto &environment = model.Environment();
+    const float fOriginal = 1.0f;
+    const std::array<double, 3> d3Original = {{0., 1., 2.}};
+    environment.newProperty<float>("f", fOriginal);
+    environment.newProperty<double, 3>("d3", d3Original);
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Seed the RunPlanVector RNG for a deterministic test.
+    plans.setRandomPropertySeed(1u);
+
+    // Uniformly set each property to a new value, then check that atleast one of them is not the default.
+    const float fMean = 1.f;
+    const float fStddev = 100.f;
+    const std::array<double, 3> d3Mean = {{1., 101., 201.}};
+    const std::array<double, 3> d3Stddev = {{100., 200., 300.}};
+    // void setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev);
+    plans.setPropertyNormalRandom("f", fMean, fStddev);
+    // Check setting individual array elements
+    // void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev);
+    plans.setPropertyNormalRandom("d3", 0, d3Mean[0], d3Stddev[0]);
+    plans.setPropertyNormalRandom("d3", 1, d3Mean[1], d3Stddev[1]);
+    plans.setPropertyNormalRandom("d3", 2, d3Mean[2], d3Stddev[2]);
+    bool fAtleastOneNonDefault = false;
+    std::array<bool, 3> d3AtleastOneNonDefault = {{false, false, false}};
+    // Check values are as expected by accessing the properties from each plan
+    for (const auto &plan : plans) {
+        if (plan.getProperty<float>("f") != fOriginal) {
+            fAtleastOneNonDefault = true;
+        }
+        const std::array<double, 3> d3FromPlan = plan.getProperty<double, 3>("d3");
+        if (d3FromPlan[0] != d3Original[0]) {
+            d3AtleastOneNonDefault[0] = true;
+        }
+        if (d3FromPlan[1] != d3Original[1]) {
+            d3AtleastOneNonDefault[1] = true;
+        }
+        if (d3FromPlan[2] != d3Original[2]) {
+            d3AtleastOneNonDefault[2] = true;
+        }
+    }
+    // assert that atleast one of each value is non-default.
+    EXPECT_TRUE(fAtleastOneNonDefault);
+    EXPECT_TRUE(d3AtleastOneNonDefault[0]);
+    EXPECT_TRUE(d3AtleastOneNonDefault[1]);
+    EXPECT_TRUE(d3AtleastOneNonDefault[2]);
+}
+// It's non trivial to check for correct distirbutions, and we rely on std:: so we are going to trust it works as intended.
+// Instead, just check that the value is different than the original. As this is not guaranteed due to (seeded) RNG, just check that atleast one value is different.
+// Real property types only. Non-reals are a static assert.
+TEST(TestRunPlanVector, setPropertyLogNormalRandom) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Add a few environment properties to the model.
+    auto &environment = model.Environment();
+    const float fOriginal = 1.0f;
+    const std::array<double, 3> d3Original = {{0., 1., 2.}};
+    environment.newProperty<float>("f", fOriginal);
+    environment.newProperty<double, 3>("d3", d3Original);
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Seed the RunPlanVector RNG for a deterministic test.
+    plans.setRandomPropertySeed(1u);
+
+    // Uniformly set each property to a new value, then check that atleast one of them is not the default.
+    const float fMean = 1.f;
+    const float fStddev = 100.f;
+    const std::array<double, 3> d3Mean = {{1., 101., 201.}};
+    const std::array<double, 3> d3Stddev = {{100., 200., 300.}};
+    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev) {
+    plans.setPropertyLogNormalRandom("f", fMean, fStddev);
+    // Check setting individual array elements
+    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) {
+    plans.setPropertyLogNormalRandom("d3", 0, d3Mean[0], d3Stddev[0]);
+    plans.setPropertyLogNormalRandom("d3", 1, d3Mean[1], d3Stddev[1]);
+    plans.setPropertyLogNormalRandom("d3", 2, d3Mean[2], d3Stddev[2]);
+    bool fAtleastOneNonDefault = false;
+    std::array<bool, 3> d3AtleastOneNonDefault = {{false, false, false}};
+    // Check values are as expected by accessing the properties from each plan
+    for (const auto &plan : plans) {
+        if (plan.getProperty<float>("f") != fOriginal) {
+            fAtleastOneNonDefault = true;
+        }
+        const std::array<double, 3> d3FromPlan = plan.getProperty<double, 3>("d3");
+        if (d3FromPlan[0] != d3Original[0]) {
+            d3AtleastOneNonDefault[0] = true;
+        }
+        if (d3FromPlan[1] != d3Original[1]) {
+            d3AtleastOneNonDefault[1] = true;
+        }
+        if (d3FromPlan[2] != d3Original[2]) {
+            d3AtleastOneNonDefault[2] = true;
+        }
+    }
+    // assert that atleast one of each value is non-default.
+    EXPECT_TRUE(fAtleastOneNonDefault);
+    EXPECT_TRUE(d3AtleastOneNonDefault[0]);
+    EXPECT_TRUE(d3AtleastOneNonDefault[1]);
+    EXPECT_TRUE(d3AtleastOneNonDefault[2]);
+}
+// It's non trivial to check for correct distirbutions, and we rely on std:: so we are going to trust it works as intended.
+// Instead, just check that the value is different than the original. As this is not guaranteed due to (seeded) RNG, just check that atleast one value is different.
+// Real property types only. Non-reals are a static assert.
+TEST(TestRunPlanVector, setPropertyRandom) {
+    // @todo - test setPropertyRandom
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Add a few environment properties to the model.
+    auto &environment = model.Environment();
+    const float fOriginal = 1.0f;
+    const std::array<double, 3> d3Original = {{0., 1., 2.}};
+    environment.newProperty<float>("f", fOriginal);
+    environment.newProperty<double, 3>("d3", d3Original);
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Seed the RunPlanVector RNG for a deterministic test.
+    plans.setRandomPropertySeed(1u);
+
+    // Uniformly set each property to a new value, then check that atleast one of them is not the default.
+    const float fMin = 1.f;
+    const float fMax = 100.f;
+    const std::array<double, 3> d3Mean = {{1., 101., 201.}};
+    const std::array<double, 3> d3Stddev = {{100., 200., 300.}};
+    // void setPropertyRandom(const std::string &name, rand_dist &distribution);
+    std::uniform_real_distribution<float> fdist(fMin, fMax);
+    plans.setPropertyRandom<float>("f", fdist);
+    // Check setting individual array elements
+    // void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution);
+    std::normal_distribution<double> d3dist0(d3Mean[0], d3Stddev[0]);
+    std::normal_distribution<double> d3dist1(d3Mean[1], d3Stddev[1]);
+    std::normal_distribution<double> d3dist2(d3Mean[2], d3Stddev[2]);
+    plans.setPropertyRandom<double>("d3", 0, d3dist0);
+    plans.setPropertyRandom<double>("d3", 1, d3dist1);
+    plans.setPropertyRandom<double>("d3", 2, d3dist2);
+    std::array<bool, 3> d3AtleastOneNonDefault = {{false, false, false}};
+    // Check values are as expected by accessing the properties from each plan
+    for (const auto &plan : plans) {
+        // Floating point types are inclusive-exclusive [min, Max)
+        EXPECT_GE(plan.getProperty<float>("f"), fMin);
+        EXPECT_LT(plan.getProperty<float>("f"), fMax);
+
+        const std::array<double, 3> d3FromPlan = plan.getProperty<double, 3>("d3");
+        if (d3FromPlan[0] != d3Original[0]) {
+            d3AtleastOneNonDefault[0] = true;
+        }
+        if (d3FromPlan[1] != d3Original[1]) {
+            d3AtleastOneNonDefault[1] = true;
+        }
+        if (d3FromPlan[2] != d3Original[2]) {
+            d3AtleastOneNonDefault[2] = true;
+        }
+    }
+    // assert that atleast one of each value is non-default.
+    EXPECT_TRUE(d3AtleastOneNonDefault[0]);
+    EXPECT_TRUE(d3AtleastOneNonDefault[1]);
+    EXPECT_TRUE(d3AtleastOneNonDefault[2]);
+
+    // Tests for exceptions
+    // --------------------
+    flamegpu::RunPlanVector singlePlanVector(model, 1);
+    // Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
+    // void RunPlanVector::setPropertyRandom(const std::string &name, rand_dist &distribution)
+    EXPECT_THROW((singlePlanVector.setPropertyRandom<float>("f", fdist)), std::out_of_range);
+    EXPECT_THROW((plans.setPropertyRandom<float>("does_not_exist", fdist)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plans.setPropertyRandom<double>("f", d3dist0)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setPropertyRandom<double>("d3", d3dist0)), flamegpu::exception::InvalidEnvPropertyType);
+    // void RunPlanVector::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution)
+    // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
+    EXPECT_THROW((singlePlanVector.setPropertyRandom<double>("d3", 0u, d3dist0)), std::out_of_range);
+    EXPECT_THROW((plans.setPropertyRandom<float>("does_not_exist", 0u, fdist)), flamegpu::exception::InvalidEnvProperty);
+    EXPECT_THROW((plans.setPropertyRandom<float>("d3", 0u, fdist)), flamegpu::exception::InvalidEnvPropertyType);
+    EXPECT_THROW((plans.setPropertyRandom<double>("d3", static_cast<EnvironmentManager::size_type>(-1), d3dist0)), std::out_of_range);
+    EXPECT_THROW((plans.setPropertyRandom<double>("d3", 4u, d3dist0)), std::out_of_range);
+}
+// Test getting the random property seed
+TEST(TestRunPlanVector, getRandomPropertySeed) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // repeatedly create run vectors, and get the property seed. Once we've found 2 that are  different, stop.
+    // If a maximum number of tries is reached, then we error.
+    const uint32_t maxGenerations = 8;
+    uint64_t prevSeed = 0;
+    uint64_t seed = 0;
+    for (uint32_t i = 0; i < maxGenerations; i++) {
+        // Create the vector
+        flamegpu::RunPlanVector plans(model, 1);
+        seed = plans.getRandomPropertySeed();
+        if (i > 0) {
+            // the seed shouldn't be the same as the previous seed, but it might be so do not expect_.
+            if (prevSeed != seed) {
+                // Break out the loop
+                break;
+            }
+        }
+        prevSeed = seed;
+    }
+    EXPECT_NE(prevSeed, seed);
+}
+TEST(TestRunPlanVector, size) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create run plan vectors of a number of sizes and check the value
+    flamegpu::RunPlanVector plans0(model, 0u);
+    EXPECT_EQ(plans0.size(), 0);
+    flamegpu::RunPlanVector plans1(model, 1u);
+    EXPECT_EQ(plans1.size(), 1);
+    flamegpu::RunPlanVector plans4(model, 4u);
+    EXPECT_EQ(plans4.size(), 4);
+    flamegpu::RunPlanVector plans64(model, 64u);
+    EXPECT_EQ(plans64.size(), 64);
+}
+TEST(TestRunPlanVector, operatorAddition) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create multiple uniqe plans which can be used to check order of plans.
+    flamegpu::RunPlan plan1(model);
+    const uint64_t seed1 = 1u;
+    plan1.setRandomSimulationSeed(seed1);
+    flamegpu::RunPlan plan2(model);
+    const uint64_t seed2 = 2u;
+    plan2.setRandomSimulationSeed(seed2);
+    flamegpu::RunPlan plan3(model);
+    const uint64_t seed3 = 3u;
+    plan3.setRandomSimulationSeed(seed3);
+    flamegpu::RunPlan plan4(model);
+    const uint64_t seed4 = 4u;
+    plan4.setRandomSimulationSeed(seed4);
+    // RunPlanVector operator+(const RunPlan& rhs) const;
+    {
+        flamegpu::RunPlanVector vec12 = plan1 + plan2;
+        flamegpu::RunPlanVector vec123 = vec12 + plan3;
+        EXPECT_EQ(vec123.size(), 3);
+        EXPECT_EQ(vec123[0].getRandomSimulationSeed(), seed1);
+        EXPECT_EQ(vec123[1].getRandomSimulationSeed(), seed2);
+        EXPECT_EQ(vec123[2].getRandomSimulationSeed(), seed3);
+        /* Disabled, as operator+ is always push_back for performance reasons.
+        flamegpu::RunPlanVector vec312 = plan3 + vec12;
+        EXPECT_EQ(vec312.size(), 3);
+        EXPECT_EQ(vec312[0].getRandomSimulationSeed(), seed3);
+        EXPECT_EQ(vec312[1].getRandomSimulationSeed(), seed1);
+        EXPECT_EQ(vec312[2].getRandomSimulationSeed(), seed2);
+        */
+    }
+    // RunPlanVector operator+(const RunPlanVector& rhs) const;
+    {
+        flamegpu::RunPlanVector vec12 = plan1 + plan2;
+        flamegpu::RunPlanVector vec34 = plan3 + plan4;
+        flamegpu::RunPlanVector vec1234 = vec12 + vec34;
+        EXPECT_EQ(vec1234.size(), 4);
+        EXPECT_EQ(vec1234[0].getRandomSimulationSeed(), seed1);
+        EXPECT_EQ(vec1234[1].getRandomSimulationSeed(), seed2);
+        EXPECT_EQ(vec1234[2].getRandomSimulationSeed(), seed3);
+        EXPECT_EQ(vec1234[3].getRandomSimulationSeed(), seed4);
+        /* Disabled, as operator+ is always push_back for performance reasons.
+        flamegpu::RunPlanVector vec3412 = vec34 + vec12;
+        EXPECT_EQ(vec3412.size(), 4);
+        EXPECT_EQ(vec3412[0].getRandomSimulationSeed(), seed3);
+        EXPECT_EQ(vec3412[1].getRandomSimulationSeed(), seed4);
+        EXPECT_EQ(vec3412[2].getRandomSimulationSeed(), seed1);
+        EXPECT_EQ(vec3412[3].getRandomSimulationSeed(), seed2);
+        */
+    }
+    // RunPlanVector& operator+=(const RunPlan& rhs);
+    {
+        flamegpu::RunPlanVector vec123 = plan1 + plan2;
+        vec123 += plan3;
+        EXPECT_EQ(vec123.size(), 3);
+        EXPECT_EQ(vec123[0].getRandomSimulationSeed(), seed1);
+        EXPECT_EQ(vec123[1].getRandomSimulationSeed(), seed2);
+        EXPECT_EQ(vec123[2].getRandomSimulationSeed(), seed3);
+        // += cannot have a plan on the lhs and a plan vector on the right.
+    }
+    // RunPlanVector& operator+=(const RunPlanVector& rhs);
+    {
+        flamegpu::RunPlanVector vec1234 = plan1 + plan2;
+        vec1234 += (plan3 + plan4);
+        EXPECT_EQ(vec1234.size(), 4);
+        EXPECT_EQ(vec1234[0].getRandomSimulationSeed(), seed1);
+        EXPECT_EQ(vec1234[1].getRandomSimulationSeed(), seed2);
+        EXPECT_EQ(vec1234[2].getRandomSimulationSeed(), seed3);
+        EXPECT_EQ(vec1234[3].getRandomSimulationSeed(), seed4);
+    }
+
+    // Expected exceptions
+    // -------------------
+    // Adding runplans together which are not for the same model (actually environment) should throw.
+    flamegpu::RunPlanVector planVector(model, 1);
+    flamegpu::ModelDescription otherModel("other");
+    otherModel.Environment().newProperty<float>("f", 1.0f);  // If both models have null environments they are compatible
+    flamegpu::RunPlan otherPlan(otherModel);
+    flamegpu::RunPlanVector otherPlanVector(otherModel, 1);
+    EXPECT_THROW((plan1 + otherPlan), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((otherPlan + plan1), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((plan1 + otherPlanVector), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((otherPlanVector + plan1), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((planVector + otherPlan), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((otherPlan + planVector), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((planVector += otherPlan), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((otherPlanVector += plan1), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((planVector += otherPlanVector), flamegpu::exception::InvalidArgument);
+    EXPECT_THROW((otherPlanVector += planVector), flamegpu::exception::InvalidArgument);
+}
+// RunPlanVector operator*(const unsigned int& rhs) const;
+TEST(TestRunPlanVector, operatorMultiplication) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    EXPECT_EQ(plans.size(), totalPlans);
+
+    // Multiply the plan vector by a fixed size
+    // RunPlanVector operator*(const unsigned int& rhs) const;
+    const uint32_t mult = 2u;
+    flamegpu::RunPlanVector morePlans = plans * mult;
+    const uint32_t expectedSize = mult * totalPlans;
+    EXPECT_EQ(morePlans.size(), expectedSize);
+
+    // multiply a plan in-place
+    // RunPlanVector& operator*=(const unsigned int& rhs);
+    plans *= mult;
+    EXPECT_EQ(plans.size(), expectedSize);
+}
+// operator[]
+TEST(TestRunPlanVector, operatorSubscript) {
+    // Define the simple model to use
+    flamegpu::ModelDescription model("test");
+    // Create a vector of plans
+    constexpr uint32_t totalPlans = 4u;
+    flamegpu::RunPlanVector plans(model, totalPlans);
+    // Check that each in-range element can be accessed
+    flamegpu::RunPlan * prevPtr = nullptr;
+    for (uint32_t idx = 0; idx < totalPlans; idx++) {
+        flamegpu::RunPlan * ptr = nullptr;
+        EXPECT_NO_THROW(ptr = &plans[idx]);
+        if (idx > 0) {
+            EXPECT_NE(ptr, prevPtr);
+        }
+        prevPtr = ptr;
+    }
+}
+
+/*
+// setPropertyArray is only declared if SWIG is defined.
+// This is not currently the case when building the test suite, so cannot be tested here.
+TEST(TestRunPlanVector, setPropertyArray) {
+}
+*/
+
+
+}  // namespace test_runplanvector
+}  // namespace tests
+}  // namespace flamegpu


### PR DESCRIPTION
### Tests:

+ [x] Add CUDA C++ tests for seed types / values of differeent sizes 
+ [x] Add CUDA C++ tests for `CUDAEnsemble`
+ [x] Add CUDA c++ tests for `RunPlan`
+ [x] Add CUDA C++ tests for `RunPlanVector`
+ [x] Add tests looking for exceptions.
+ [x] Add python tests for seed types / values of differeent sizes 
+ [x] Add python tests for `CUDAEnsemble`
+ [x] Add python tests for `RunPlan`
+ [x] Add python tests for `RunPlanVector`

### Required fixes / changes

+ [x] Change random number seeds to be `uint64_t`
+ [x] Add `uint64_t RunPlanVector::getRandomPropertySeed`
    + allows users to output the random initial seeds from `std::device_random` if required.
+ [x] Disabled the output of FLAMEGPU version when using CUDAEnsembles, it occured too early.
+ [x] `CUDAEnsemble::Config` suggests `@see CUDAEnsemble::applyConfig() Should be called afterwards to apply changes`, but `applyConfig` is not a member of CUDAEnsemble.
+ [x] `CUDAEnsemble::getConfig` result is mutable in python.

### Misc
+ Create new issues:
    + [x] Opened #679 
    + [x] Opened #681
    + [x] Opened #682
+ [x] Tidy history
    + Order it to be fixes / additions, then tests (or squash into a single commit, so that all commites atleast build / pass CI. 

### Additional Changes
+ [x] Enables CI Windows Test suite builds via manual `workflow_dispatch` events. Closes #683.

### Known issues (for the release notes)
+ `operator+` for `RunPlan` and `RunPlanVector` are not currently working in python
+ `CUDAEnsemble::EnsembleConfig::devices` is not usable other than the command line in the swig interface

Closes #656
