### PR TITLE
Drop all CI Ubuntu runners to 18.04 and GCC < 9 as a workaround

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   doxygen:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       # Define constants
       BUILD_DIR: "build"

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -39,12 +39,12 @@ jobs:
         cudacxx:
           - cuda: "11.4"
             cuda_arch: "35 60 80"
-            hostcxx: gcc-9
-            os: ubuntu-20.04
+            hostcxx: gcc-8
+            os: ubuntu-18.04
           - cuda: "11.0"
             cuda_arch: "35 60 80"
             hostcxx: gcc-8
-            os: ubuntu-20.04
+            os: ubuntu-18.04
         python:
           - "3.8"
         config:
@@ -264,11 +264,11 @@ jobs:
           - cuda: "11.2"
             cuda_arch: "35 52 60 70 80"
             hostcxx: devtoolset-9
-            os: ubuntu-20.04
+            os: ubuntu-18.04
           - cuda: "11.0"
             cuda_arch: "35 52 60 70 80"
             hostcxx: devtoolset-8
-            os: ubuntu-20.04
+            os: ubuntu-18.04
         python: 
           - "3.9"
           - "3.8"
@@ -314,7 +314,7 @@ jobs:
 
     # Downgrade the devtoolset in the image based on the build matrix, using:
     # gcc-10 for CUDA >= 11.2. Unclear if devtoolset-10 will upgrade to unpatched 11.3 which breaks CUDA builds that use <chrono>. 
-    # gcc-9 for CUDA >= 11.0
+    # gcc-8 for CUDA >= 11.0
     # gcc-8 for CUDA >= 10.1
     # gcc-7 for CUDA >= 10.0 (and probably 9.x).
     # these are not the officially supported toolset on centos by cuda, but it's what works.
@@ -520,7 +520,7 @@ jobs:
       - wheel-manylinux2014
       - wheel-windows
     if: ${{ success() && startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         cudacxx:
           - cuda: "11.4"
-            os: ubuntu-20.04
+            os: ubuntu-18.04
     env:
       # Define constants
       BUILD_DIR: "build"

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -36,7 +36,7 @@ jobs:
           - cuda: "11.2"
             cuda_arch: "35"
             hostcxx: devtoolset-9
-            os: ubuntu-20.04
+            os: ubuntu-18.04
         python: 
           - "3.8"
         config:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -31,12 +31,12 @@ jobs:
         cudacxx:
           - cuda: "11.4"
             cuda_arch: "35"
-            hostcxx: gcc-9
-            os: ubuntu-20.04
+            hostcxx: gcc-8
+            os: ubuntu-18.04
           - cuda: "11.0"
             cuda_arch: "35"
             hostcxx: gcc-8
-            os: ubuntu-20.04
+            os: ubuntu-18.04
           - cuda: "10.0"
             cuda_arch: "35"
             hostcxx: gcc-7


### PR DESCRIPTION
Ubuntu 20.04 CUDA installs started failing on CI, unable to find and index file by hash:
https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/by-hash/SHA256/751939d95516afc289908a19e447f0acc1506367f72ed356431a2b1a469cc8ca

Installing via essentially the same method locally is fine, although not tested the exact script locally.