### PR TITLE
Switch to https for nvidia apt key/repo uri's

### DIFF
--- a/.github/scripts/install_cuda_ubuntu.sh
+++ b/.github/scripts/install_cuda_ubuntu.sh
@@ -107,8 +107,8 @@ echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
 
 PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
 PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
-APT_KEY_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
-REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+APT_KEY_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
 
 echo "PIN_FILENAME ${PIN_FILENAME}"
 echo "PIN_URL ${PIN_URL}"

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   doxygen:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       # Define constants
       BUILD_DIR: "build"

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -39,12 +39,12 @@ jobs:
         cudacxx:
           - cuda: "11.4"
             cuda_arch: "35 60 80"
-            hostcxx: gcc-8
-            os: ubuntu-18.04
+            hostcxx: gcc-9
+            os: ubuntu-20.04
           - cuda: "11.0"
             cuda_arch: "35 60 80"
             hostcxx: gcc-8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
         python:
           - "3.8"
         config:
@@ -264,11 +264,11 @@ jobs:
           - cuda: "11.2"
             cuda_arch: "35 52 60 70 80"
             hostcxx: devtoolset-9
-            os: ubuntu-18.04
+            os: ubuntu-20.04
           - cuda: "11.0"
             cuda_arch: "35 52 60 70 80"
             hostcxx: devtoolset-8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
         python: 
           - "3.9"
           - "3.8"
@@ -314,7 +314,7 @@ jobs:
 
     # Downgrade the devtoolset in the image based on the build matrix, using:
     # gcc-10 for CUDA >= 11.2. Unclear if devtoolset-10 will upgrade to unpatched 11.3 which breaks CUDA builds that use <chrono>. 
-    # gcc-8 for CUDA >= 11.0
+    # gcc-9 for CUDA >= 11.0
     # gcc-8 for CUDA >= 10.1
     # gcc-7 for CUDA >= 10.0 (and probably 9.x).
     # these are not the officially supported toolset on centos by cuda, but it's what works.
@@ -520,7 +520,7 @@ jobs:
       - wheel-manylinux2014
       - wheel-windows
     if: ${{ success() && startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         cudacxx:
           - cuda: "11.4"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
     env:
       # Define constants
       BUILD_DIR: "build"

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -36,7 +36,7 @@ jobs:
           - cuda: "11.2"
             cuda_arch: "35"
             hostcxx: devtoolset-9
-            os: ubuntu-18.04
+            os: ubuntu-20.04
         python: 
           - "3.8"
         config:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -31,12 +31,12 @@ jobs:
         cudacxx:
           - cuda: "11.4"
             cuda_arch: "35"
-            hostcxx: gcc-8
-            os: ubuntu-18.04
+            hostcxx: gcc-9
+            os: ubuntu-20.04
           - cuda: "11.0"
             cuda_arch: "35"
             hostcxx: gcc-8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
           - cuda: "10.0"
             cuda_arch: "35"
             hostcxx: gcc-7


### PR DESCRIPTION
This fixes 20.04 installs

Also reverts "Drop all CI Ubuntu runners to 18.04 and GCC < 9 as a workaround" (6c594fa2f85012bc55cd89119ebc9e6e9697301f)

Closes #669 