### PR TITLE
Fix range-loop-construct warnings which are part of Wall from GCC 11.

### DIFF
--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -299,7 +299,7 @@ class CUDAAgent : public AgentInterface {
      */
     static size_t calcTotalVarSize(const AgentData &agent) {
         size_t rtn = 0;
-        for (const auto v : agent.variables) {
+        for (const auto &v : agent.variables) {
             rtn += v.second.type_size * v.second.elements;
         }
         return rtn;

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -559,7 +559,7 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, bool f
         // Scope the mutex
         auto lock = EnvironmentManager::getInstance().getSharedLock();
         const auto &prop_map = EnvironmentManager::getInstance().getPropertiesMap();
-        for (auto p : prop_map) {
+        for (const auto &p : prop_map) {
             if (p.first.first == cudaSimulation.getInstanceID()) {
                 const char* variableName = p.first.second.c_str();
                 const char* type = p.second.type.name();
@@ -569,7 +569,7 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, bool f
             }
         }
         // Set mapped environment variables in curve
-        for (const auto mp : EnvironmentManager::getInstance().getMappedProperties()) {
+        for (const auto &mp : EnvironmentManager::getInstance().getMappedProperties()) {
             if (mp.first.first == cudaSimulation.getInstanceID()) {
                 auto p = prop_map.at(mp.second.masterProp);
                 const char* variableName = mp.second.masterProp.second.c_str();

--- a/src/flamegpu/gpu/CUDAMessageList.cu
+++ b/src/flamegpu/gpu/CUDAMessageList.cu
@@ -77,7 +77,7 @@ void CUDAMessageList::allocateDeviceMessageList(CUDAMessageMap &memory_map) {
 
 void CUDAMessageList::releaseDeviceMessageList(CUDAMessageMap& memory_map) {
     // for each device pointer in the cuda memory map we need to free these
-    for (const CUDAMessageMapPair& mm : memory_map) {
+    for (const auto &mm : memory_map) {
         // free the memory on the device
         gpuErrchk(cudaFree(mm.second));
     }
@@ -85,7 +85,7 @@ void CUDAMessageList::releaseDeviceMessageList(CUDAMessageMap& memory_map) {
 
 void CUDAMessageList::zeroDeviceMessageList(CUDAMessageMap& memory_map) {
     // for each device pointer in the cuda memory map set the values to 0
-    for (const CUDAMessageMapPair& mm : memory_map) {
+    for (const auto &mm : memory_map) {
         // get the variable size from message description
         const auto var = message.getMessageDescription().variables.at(mm.first);
         const size_t var_size = var.type_size * var.elements;

--- a/src/flamegpu/model/AgentData.cpp
+++ b/src/flamegpu/model/AgentData.cpp
@@ -20,7 +20,7 @@ AgentData::AgentData(std::shared_ptr<const ModelData> model, const std::string &
 std::shared_ptr<const AgentData> AgentData::clone() const {
     std::shared_ptr<AgentData> b = std::shared_ptr<AgentData>(new AgentData(nullptr, *this));
     // Manually copy construct maps of shared ptr
-    for (const auto f : functions) {
+    for (const auto &f : functions) {
         // Passing model is risky here, as the weak_ptr for agent output will point here
         b->functions.emplace(f.first, std::shared_ptr<AgentFunctionData>(new AgentFunctionData(description->model.lock(), b, *f.second)));
     }

--- a/tests/test_cases/model/test_environment_description.cu
+++ b/tests/test_cases/model/test_environment_description.cu
@@ -119,7 +119,7 @@ template<typename T>
 void ExceptionPropertyLength_test() {
     EnvironmentDescription ed;
     std::array<T, ARRAY_TEST_LEN> b;
-    std::array<T, 1> _b1;
+    std::array<T, 1> _b1 = {};
     std::array<T, ARRAY_TEST_LEN + 1> _b2;
     std::array<T, ARRAY_TEST_LEN * 2> _b3;
     ed.newProperty<T, ARRAY_TEST_LEN>("a", b);

--- a/tests/test_cases/runtime/test_environment_manager.cu
+++ b/tests/test_cases/runtime/test_environment_manager.cu
@@ -108,7 +108,7 @@ TEST_F(EnvironmentManagerTest, Alignment) {
 
 // Test bounds limit
 TEST_F(EnvironmentManagerTest, OutOfMemory1) {
-    std::array<char, EnvironmentManager::MAX_BUFFER_SIZE / 2> char_5kb_a;
+    std::array<char, EnvironmentManager::MAX_BUFFER_SIZE / 2> char_5kb_a = {};
     std::array<char, EnvironmentManager::MAX_BUFFER_SIZE / 2> char_5kb_b;
     std::array<char, EnvironmentManager::MAX_BUFFER_SIZE / 2> char_5kb_c;
     ms->env.newProperty<char, EnvironmentManager::MAX_BUFFER_SIZE / 2>("char_5kb_a", char_5kb_a);

--- a/tests/test_cases/runtime/test_host_environment.cu
+++ b/tests/test_cases/runtime/test_host_environment.cu
@@ -598,7 +598,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_uint64_t) {
 
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_float) {
     std::array<float, TEST_ARRAY_LEN> b;
-    std::array<float, 1> _b1;
+    std::array<float, 1> _b1 = {};
     std::array<float, TEST_ARRAY_LEN + 1> _b2;
     std::array<float, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -616,7 +616,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_float) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_double) {
     std::array<double, TEST_ARRAY_LEN> b;
-    std::array<double, 1> _b1;
+    std::array<double, 1> _b1 = {};
     std::array<double, TEST_ARRAY_LEN + 1> _b2;
     std::array<double, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -634,7 +634,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_double) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int8_t) {
     std::array<int8_t, TEST_ARRAY_LEN> b;
-    std::array<int8_t, 1> _b1;
+    std::array<int8_t, 1> _b1 = {};
     std::array<int8_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<int8_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -652,7 +652,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int8_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint8_t) {
     std::array<uint8_t, TEST_ARRAY_LEN> b;
-    std::array<uint8_t, 1> _b1;
+    std::array<uint8_t, 1> _b1 = {};
     std::array<uint8_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<uint8_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -670,7 +670,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint8_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int16_t) {
     std::array<int16_t, TEST_ARRAY_LEN> b;
-    std::array<int16_t, 1> _b1;
+    std::array<int16_t, 1> _b1 = {};
     std::array<int16_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<int16_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -688,7 +688,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int16_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint16_t) {
     std::array<uint16_t, TEST_ARRAY_LEN> b;
-    std::array<uint16_t, 1> _b1;
+    std::array<uint16_t, 1> _b1 = {};
     std::array<uint16_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<uint16_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -706,7 +706,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint16_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int32_t) {
     std::array<int32_t, TEST_ARRAY_LEN> b;
-    std::array<int32_t, 1> _b1;
+    std::array<int32_t, 1> _b1 = {};
     std::array<int32_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<int32_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -724,7 +724,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int32_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint32_t) {
     std::array<uint32_t, TEST_ARRAY_LEN> b;
-    std::array<uint32_t, 1> _b1;
+    std::array<uint32_t, 1> _b1 = {};
     std::array<uint32_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<uint32_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -742,7 +742,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint32_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int64_t) {
     std::array<int64_t, TEST_ARRAY_LEN> b;
-    std::array<int64_t, 1> _b1;
+    std::array<int64_t, 1> _b1 = {};
     std::array<int64_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<int64_t, TEST_ARRAY_LEN * 2> _b3;
     /**
@@ -760,7 +760,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_int64_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_uint64_t) {
     std::array<uint64_t, TEST_ARRAY_LEN> b;
-    std::array<uint64_t, 1> _b1;
+    std::array<uint64_t, 1> _b1 = {};
     std::array<uint64_t, TEST_ARRAY_LEN + 1> _b2;
     std::array<uint64_t, TEST_ARRAY_LEN * 2> _b3;
     /**


### PR DESCRIPTION
This avoids (potentially) expensive copies of const objects (and possible bugs due to modifying copies rather than in-place) 