### PR TITLE
Bump version pre-release to alpha.2

### DIFF
--- a/include/flamegpu/version.h
+++ b/include/flamegpu/version.h
@@ -42,7 +42,7 @@ static constexpr unsigned int VERSION_PATCH = flamegpu::VERSION % 1000;
  * Namespaced FLAME GPU version Prerelease component
  * A set of . separated pre-release components as a string, following the semver rules for comparison.
  */
-static constexpr char VERSION_PRERELEASE[] = "alpha.1";
+static constexpr char VERSION_PRERELEASE[] = "alpha.2";
 
 /**
  * Namespaced FLAME GPU version build metadata component


### PR DESCRIPTION
To be merged immediately after the `2.0.0-alpha.1` release is published