### PR TITLE
NVHPC Support

### DIFF
--- a/cmake/dependencies/patches/rapidjson-nvhpc.patch
+++ b/cmake/dependencies/patches/rapidjson-nvhpc.patch
@@ -1,0 +1,26 @@
+diff --git a/include/rapidjson/internal/biginteger.h b/include/rapidjson/internal/biginteger.h
+index 8eb87c7c..5db5a2eb 100644
+--- a/include/rapidjson/internal/biginteger.h
++++ b/include/rapidjson/internal/biginteger.h
+@@ -252,7 +252,7 @@ private:
+         if (low < k)
+             (*outHigh)++;
+         return low;
+-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__)
++#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__) && !defined(__NVCOMPILER)
+         __extension__ typedef unsigned __int128 uint128;
+         uint128 p = static_cast<uint128>(a) * static_cast<uint128>(b);
+         p += k;
+diff --git a/include/rapidjson/internal/diyfp.h b/include/rapidjson/internal/diyfp.h
+index 8f7d853a..68039c23 100644
+--- a/include/rapidjson/internal/diyfp.h
++++ b/include/rapidjson/internal/diyfp.h
+@@ -75,7 +75,7 @@ struct DiyFp {
+         if (l & (uint64_t(1) << 63)) // rounding
+             h++;
+         return DiyFp(h, e + rhs.e + 64);
+-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__)
++#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__x86_64__) && !defined(__NVCOMPILER)
+         __extension__ typedef unsigned __int128 uint128;
+         uint128 p = static_cast<uint128>(f) * static_cast<uint128>(rhs.f);
+         uint64_t h = static_cast<uint64_t>(p >> 64);

--- a/cmake/dependencies/rapidjson.cmake
+++ b/cmake/dependencies/rapidjson.cmake
@@ -7,14 +7,27 @@ include(FetchContent)
 include(ExternalProject)
 cmake_policy(SET CMP0079 NEW)
 
+# Define some variables to allow condiitoanl fetch content declarations
+set(RapidJSON_GIT_REMOTE "https://github.com/Tencent/rapidjson.git")
+set(RapidJSON_GIT_TAG "f56928de85d56add3ca6ae7cf7f119a42ee1585b")
+
 # Head of master as of 2020-07-14, as last release is ~500 commits behind head
-FetchContent_Declare(
-    rapidjson
-    GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-    GIT_TAG        f56928de85d56add3ca6ae7cf7f119a42ee1585b
-    GIT_PROGRESS   ON
-    # UPDATE_DISCONNECTED   ON
-)
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+    FetchContent_Declare(
+        rapidjson
+        GIT_REPOSITORY ${RapidJSON_GIT_REMOTE}
+        GIT_TAG ${RapidJSON_GIT_TAG}
+        GIT_PROGRESS   OFF
+    )
+else()
+    FetchContent_Declare(
+        rapidjson
+        GIT_REPOSITORY ${RapidJSON_GIT_REMOTE}
+        GIT_TAG ${RapidJSON_GIT_TAG}
+        GIT_PROGRESS   OFF
+        PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patches/rapidjson-nvhpc.patch || true
+    )
+endif()
 FetchContent_GetProperties(rapidjson)
 if(NOT rapidjson_POPULATED)
     FetchContent_Populate(rapidjson)
@@ -32,5 +45,4 @@ if(NOT rapidjson_POPULATED)
     if(TARGET rapidjson)
         add_library(RapidJSON::rapidjson ALIAS rapidjson)
     endif()
-
 endif()

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -41,7 +41,6 @@ function(SetHighWarningLevel)
     elseif(NOT TARGET ${SHWL_TARGET})
         message(FATAL_ERROR "SetHighWarningLevel: TARGET '${SHWL_TARGET}' is not a valid target")
     endif()
-    
     # Per host-compiler settings for high warning levels and opt-in warnings.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
@@ -53,7 +52,10 @@ function(SetHighWarningLevel)
         target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
         target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
         # CUB 1.9.10 prevents Wreorder being usable on windows, so linux only. Cannot suppress via diag_suppress pragmas.
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
+        # Non nvhpc only.
+        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
+        endif()
         # Add warnings which suggest the use of override
         # Disabled, as cpplint occasionally disagrees with gcc concerning override
         # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wsuggest-override>")
@@ -102,6 +104,10 @@ function(SuppressSomeCompilerWarnings)
         endif()
         # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
         target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+        # nvc++ etc do not appear to have an equivalent to -isystem. Rather than more pragma warning soup, just tone down warnings when using nvc++ as appropriate. 
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=code_is_unreachable>")
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:--diag_suppress=code_is_unreachable>")
     else()
         # Linux specific warning suppressions
     endif()
@@ -154,8 +160,10 @@ function(EnableWarningsAsErrors)
             target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler -Werror>")
             # Add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
             target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call>")
-            # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
+            # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas. Cannot be used with nvhpc
+            if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
+            endif()
         endif()
         # Platform/host-compiler indifferent options:
         # Generic WError settings for nvcc


### PR DESCRIPTION
+ [x] Patch RapidJSON if using nvhpc
+ [x] Change warning levels / suppressions if using nvhpc. It does not support isystem unfortunately.
+ [ ] Fix `std::experimental::filesystem` linker errors.
    + This may require C++ 17 support only / may be a blocking issue.
+ [ ] NVHPC CI?
    + This might not be viable, as an NVHPC install is > 8GB, and unsure on the licencing. Using a container may be an option, but this might want to be a less-regular CI job? 