### PR TITLE
CMake: Ensure all target_link_libraries specify public/private/interface

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -308,12 +308,12 @@ function(add_flamegpu_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
     set_property(TARGET ${NAME} PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
     # Link against the flamegpu static library target.
-    target_link_libraries(${NAME} flamegpu)
+    target_link_libraries(${NAME} PRIVATE flamegpu)
     # Workaround for incremental rebuilds on MSVC, where device link was not being performed.
     # https://github.com/FLAMEGPU/FLAMEGPU2/issues/483
     if(MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.1")
         # Provide the absolute path to the lib file, rather than the relative version cmake provides.
-        target_link_libraries(${NAME} "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE:flamegpu>")
+        target_link_libraries(${NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE:flamegpu>")
     endif()
         
     # Activate visualisation if requested

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,8 +120,7 @@ if(BUILD_TESTS)
     # Add the tests directory to the include path,
     target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     # Add the targets we depend on (this does link and include)
-    target_link_libraries("${PROJECT_NAME}" GTest::gtest)
-    # target_link_libraries("${PROJECT_NAME}" gmock) # Currently unused
+    target_link_libraries("${PROJECT_NAME}" PRIVATE GTest::gtest)
     # Put Within Tests filter
     CMAKE_SET_TARGET_FOLDER("${PROJECT_NAME}" "Tests")
     # Also set as startup project (if top level project)
@@ -155,8 +154,8 @@ if(BUILD_TESTS_DEV)
     # Add the tests directory to the include path,
     target_include_directories("${PROJECT_NAME}" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     # Add the targets we depend on (this does link and include)
-    target_link_libraries("${PROJECT_NAME}" GTest::gtest)
-    # target_link_libraries("${PROJECT_NAME}" gmock) # Currently unused
+    target_link_libraries("${PROJECT_NAME}" PRIVATE GTest::gtest)
+    # Put Within Tests filter
     CMAKE_SET_TARGET_FOLDER("${PROJECT_NAME}" "Tests")
     # Set the default (visual studio) debugger configure_file
     set_target_properties("${PROJECT_NAME}" PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
Closes #701

Also minor tweak to make tests_dev and tests cmake logic more similar.