### PR TITLE
CMake: Re-allow MinSizeRel and RelWithDebInfo build configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ cmake --build . --target all
 
 | Option                   | Value             | Description                                                                                                |
 | ------------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------- |
-| `CMAKE_BUILD_TYPE`       | `Release`/`Debug` | Select the build configuration for single-target generators such as `make`                                 |
+| `CMAKE_BUILD_TYPE`       | `Release`/`Debug`/`MinSizeRel`/`RelWithDebInfo` | Select the build configuration for single-target generators such as `make`   |
 | `SEATBELTS`              | `ON`/`OFF`        | Enable / Disable additional runtime checks which harm performance but increase usability. Default `ON`     |
 | `CUDA_ARCH`              | `"52 60 70 80"`   | Select [CUDA Compute Capabilities](https://developer.nvidia.com/cuda-gpus) to build/optimise for, as a space or `;` separated list. Defaults to `""` |
 | `BUILD_SWIG_PYTHON`      | `ON`/`OFF`        | Enable Python target `pyflamegpu` via Swig. Default `OFF`                                                  |

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -47,14 +47,14 @@ if(${GENERATOR_IS_MULTI_CONFIG})
     # CMAKE_CONFIGURATION_TYPES defaults to something platform specific
     # Therefore can't detect if user has changed value and not reset it
     # So force "Debug;Release"
-    set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE INTERNAL
-        "Choose the types of build, options are: Debug Release." FORCE)#
+    # set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE INTERNAL
+        # "Choose the types of build, options are: Debug Release." FORCE)#
 else()
     if(NOT CMAKE_BUILD_TYPE)
         set(default_build_type "Release")
         message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
         set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING 
-            "Choose the type of build, options are: None Debug Release." FORCE)
+            "Choose the type of build, options are: Release, Debug, RelWithDebInfo, MinSizeRel or leave the value empty for the default." FORCE)
     endif()
 endif()
 


### PR DESCRIPTION
Closes #698