### PR TITLE
Python 3.10 CI Builds

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -293,6 +293,7 @@ jobs:
             hostcxx: devtoolset-8
             os: ubuntu-20.04
         python: 
+          - "3.10"
           - "3.9"
           - "3.8"
           - "3.7"
@@ -450,6 +451,7 @@ jobs:
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
+          - "3.10"
           - "3.9"
           - "3.8"
           - "3.7"

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -38,7 +38,7 @@ jobs:
             hostcxx: devtoolset-9
             os: ubuntu-20.04
         python: 
-          - "3.8"
+          - "3.10"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -38,7 +38,7 @@ jobs:
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
-          - "3.8"
+          - "3.10"
         config:
           - name: "Release"
             config: "Release"


### PR DESCRIPTION
Adds Python 3.10 builds to CI for:

+ Manylinux per-push CI
+ Windows per-push CI
+ Draft Release, in the python wheel build matrix for manylinux and Windows wheels.