### PR TITLE
Add missing message getVariableLength method

### DIFF
--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
@@ -236,15 +236,21 @@ class MessageBruteForce::Description {
     /**
      * @param variable_name Name used to refer to the desired variable
      * @return The type of the named variable
-     * @throws exception::InvalidAgentVar If a variable with the name does not exist within the message
+     * @throws exception::InvalidMessageVar If a variable with the name does not exist within the message
      */
     const std::type_index& getVariableType(const std::string &variable_name) const;
     /**
      * @param variable_name Name used to refer to the desired variable
      * @return The size of the named variable's type
-     * @throws exception::InvalidAgentVar If a variable with the name does not exist within the message
+     * @throws exception::InvalidMessageVar If a variable with the name does not exist within the message
      */
     size_t getVariableSize(const std::string &variable_name) const;
+    /**
+     * @param variable_name Name used to refer to the desired variable
+     * @return The number of elements in the name variable (1 if it isn't an array)
+     * @throws exception::InvalidMessageVar If a variable with the name does not exist within the agent
+     */
+    size_type getVariableLength(const std::string &variable_name) const;
     /**
      * @return The total number of variables within the message
      */

--- a/src/flamegpu/runtime/messaging/MessageBruteForce.cu
+++ b/src/flamegpu/runtime/messaging/MessageBruteForce.cu
@@ -117,9 +117,18 @@ size_t MessageBruteForce::Description::getVariableSize(const std::string &variab
         "in MessageDescription::getVariableSize().",
         message->name.c_str(), variable_name.c_str());
 }
-ModelData::size_type MessageBruteForce::Description::getVariablesCount() const {
+MessageBruteForce::size_type MessageBruteForce::Description::getVariableLength(const std::string &variable_name) const {
+    auto f = message->variables.find(variable_name);
+    if (f != message->variables.end()) {
+        return f->second.elements;
+    }
+    THROW exception::InvalidAgentVar("Message ('%s') does not contain variable '%s', "
+        "in MessageBruteForce::getVariableLength().",
+        message->name.c_str(), variable_name.c_str());
+}
+MessageBruteForce::size_type MessageBruteForce::Description::getVariablesCount() const {
     // Downcast, will never have more than UINT_MAX variables
-    return static_cast<ModelData::size_type>(message->variables.size());
+    return static_cast<MessageBruteForce::size_type>(message->variables.size());
 }
 bool MessageBruteForce::Description::hasVariable(const std::string &variable_name) const {
     return message->variables.find(variable_name) != message->variables.end();

--- a/tests/test_cases/model/test_message.cu
+++ b/tests/test_cases/model/test_message.cu
@@ -30,8 +30,10 @@ TEST(MessageDescriptionTest, variables) {
     // Returned variable data is same
     EXPECT_EQ(sizeof(float), m.getVariableSize(VARIABLE_NAME1));
     EXPECT_EQ(std::type_index(typeid(float)), m.getVariableType(VARIABLE_NAME1));
+    EXPECT_EQ(1, m.getVariableLength(VARIABLE_NAME1));
     EXPECT_EQ(sizeof(int16_t), m.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(int16_t)), m.getVariableType(VARIABLE_NAME2));
+    EXPECT_EQ(1, m.getVariableLength(VARIABLE_NAME2));
 }
 TEST(MessageDescriptionTest, variables_array) {
     ModelDescription _m(MODEL_NAME);
@@ -39,14 +41,14 @@ TEST(MessageDescriptionTest, variables_array) {
     EXPECT_FALSE(m.hasVariable(VARIABLE_NAME1));
     EXPECT_FALSE(m.hasVariable(VARIABLE_NAME2));
     EXPECT_EQ(m.getVariablesCount(), 0u);
-    m.newVariable<float>(VARIABLE_NAME1);
+    m.newVariable<float, 2>(VARIABLE_NAME1);
     EXPECT_EQ(m.getVariablesCount(), 1u);
-    m.newVariable<int16_t>(VARIABLE_NAME3);
+    m.newVariable<int16_t, 2>(VARIABLE_NAME3);
     EXPECT_EQ(m.getVariablesCount(), 2u);
-    m.newVariable<int16_t>(VARIABLE_NAME2);
+    m.newVariable<int16_t, 2>(VARIABLE_NAME2);
     EXPECT_EQ(m.getVariablesCount(), 3u);
     // Cannot create variable with same name
-    EXPECT_THROW(m.newVariable<int64_t>(VARIABLE_NAME1), exception::InvalidMessageVar);
+    EXPECT_THROW((m.newVariable<int64_t, 2>(VARIABLE_NAME1)), exception::InvalidMessageVar);
     // Cannot create array of length 0 (disabled, blocked at compilation with static_assert)
     // auto newVarArray0 = &MessageDescription::newVariable<int64_t, 0>;  // Use function ptr, can't do more than 1 template arg inside macro
     // EXPECT_THROW((m.*newVarArray0)(VARIABLE_NAME4), exception::InvalidMessageVar);
@@ -58,6 +60,8 @@ TEST(MessageDescriptionTest, variables_array) {
     EXPECT_EQ(sizeof(int16_t), m.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(float)), m.getVariableType(VARIABLE_NAME1));
     EXPECT_EQ(std::type_index(typeid(int16_t)), m.getVariableType(VARIABLE_NAME2));
+    EXPECT_EQ(2, m.getVariableLength(VARIABLE_NAME1));
+    EXPECT_EQ(2, m.getVariableLength(VARIABLE_NAME2));
 }
 
 FLAMEGPU_AGENT_FUNCTION(NoInput, MessageNone, MessageSpatial3D) {


### PR DESCRIPTION
This is for partiy with agent variable array length checking, and is useful for testing that newVariable<T, L> worked as intended.

~In practice this might actually be useful to have on the device too? So that message arrays can be dynamically iterated on the device if requried, rather than requiring hardcoding?~
Not useful on the device, needed at compile time in template parameters.

+ [x] Implement for the host and test
+ ~Implement this for the device too?~
+ [x] Fix some docblocks / types that were copy-pasted but not modified