### PR TITLE
BugFix: SubModelDescription::(get)SubEnvironment(true)

### DIFF
--- a/include/flamegpu/model/SubModelDescription.h
+++ b/include/flamegpu/model/SubModelDescription.h
@@ -84,14 +84,14 @@ class SubModelDescription : public DependencyNode {
     const SubAgentDescription &getSubAgent(const std::string &sub_agent_name) const;
     /**
      * Returns an interface for configuring mapped environment properties
-     * @param auto_map_props If true is passed, all properties with matching name, type and length between models will be mapped
+     * @param auto_map If true is passed, all properties and macro properties with matching name, type and length between models will be mapped
      */
-    SubEnvironmentDescription &SubEnvironment(bool auto_map_props = false);
+    SubEnvironmentDescription &SubEnvironment(bool auto_map = false);
     /**
      * Returns an immutable interface for viewing the configuration of mapped environment properties
-     * @param auto_map_props If true is passed, all properties with matching name, type and length between models will be mapped
+     * @param auto_map If true is passed, all properties and macro properties with matching name, type and length between models will be mapped
      */
-    const SubEnvironmentDescription &getSubEnvironment(bool auto_map_props = false) const;
+    const SubEnvironmentDescription &getSubEnvironment(bool auto_map = false) const;
     /**
      * Set the maximum number of steps per execution of the submodel
      * If 0 (default), unlimited however an exit condition is required

--- a/src/flamegpu/model/SubModelDescription.cpp
+++ b/src/flamegpu/model/SubModelDescription.cpp
@@ -98,7 +98,7 @@ const SubAgentDescription &SubModelDescription::getSubAgent(const std::string &s
 }
 
 
-SubEnvironmentDescription &SubModelDescription::SubEnvironment(bool auto_map_props) {
+SubEnvironmentDescription &SubModelDescription::SubEnvironment(bool auto_map) {
     if (!data->subenvironment) {
         auto mdl = model.lock();
         if (!mdl) {
@@ -106,11 +106,13 @@ SubEnvironmentDescription &SubModelDescription::SubEnvironment(bool auto_map_pro
         }
         data->subenvironment = std::shared_ptr<SubEnvironmentData>(new SubEnvironmentData(mdl, data->shared_from_this(), data->submodel->environment));
     }
-    if (auto_map_props)
+    if (auto_map) {
         data->subenvironment->description->autoMapProperties();
+        data->subenvironment->description->autoMapMacroProperties();
+    }
     return *data->subenvironment->description;
 }
-const SubEnvironmentDescription &SubModelDescription::getSubEnvironment(bool auto_map_props) const {
+const SubEnvironmentDescription &SubModelDescription::getSubEnvironment(bool auto_map) const {
     if (!data->subenvironment) {
         auto mdl = model.lock();
         if (!mdl) {
@@ -118,8 +120,10 @@ const SubEnvironmentDescription &SubModelDescription::getSubEnvironment(bool aut
         }
         data->subenvironment = std::shared_ptr<SubEnvironmentData>(new SubEnvironmentData(mdl, data->shared_from_this(), data->submodel->environment));
     }
-    if (auto_map_props)
+    if (auto_map) {
         data->subenvironment->description->autoMapProperties();
+        data->subenvironment->description->autoMapMacroProperties();
+    }
     return *data->subenvironment->description;
 }
 

--- a/tests/test_cases/gpu/test_cuda_submacroenvironment.cu
+++ b/tests/test_cases/gpu/test_cuda_submacroenvironment.cu
@@ -107,8 +107,7 @@ TEST(SubCUDAMacroEnvironmentTest, MasterWriteSubReadHost) {
     }
     auto& agt = m.newAgent("test");
     auto& sm = m.newSubModel("sub", m2);
-    auto& senv = sm.SubEnvironment();
-    senv.autoMap();
+    auto& senv = sm.SubEnvironment(true);
     m.newLayer().addHostFunction(Host_Write_5);
     m.newLayer().addSubModel(sm);
     AgentVector pop(agt, 1);

--- a/tests/test_cases/runtime/test_subenvironment_manager.cu
+++ b/tests/test_cases/runtime/test_subenvironment_manager.cu
@@ -176,7 +176,7 @@ TEST(SubEnvironmentManagerTest, SubHostAPISetSub) {
     }
     // Setup submodel bindings
     auto &sm = m.newSubModel("sub", m2);
-    sm.SubEnvironment(true);
+    sm.SubEnvironment().autoMap();
     // Construct model layers
     m.newLayer().addSubModel(sm);  // HostAPISetFn
     m.newLayer().addHostFunction(HostAPIGetFn);
@@ -213,7 +213,7 @@ TEST(SubEnvironmentManagerTest, SubHostAPISetConstSub) {
     // Setup submodel bindings
     auto &sm = m.newSubModel("sub", m2);
     sm.bindAgent("agent", "agent", true, true);
-    sm.SubEnvironment(true);
+    sm.SubEnvironment().autoMapProperties();
     // Construct model layers
     m.newLayer().addSubModel(sm);  // HostAPISetIsConstFn
     m.newLayer().addHostFunction(HostAPIGetFn);


### PR DESCRIPTION
When calling `SubModelDescription::(get)SubEnvironment(true)` macro properties would not be automatically mapped.

Also tweaked a few tests to ensure all ways to auto map are covered implicitly.