### PR TITLE
Bugfix: CUDAEnsemble would always output both step/exit files.

### DIFF
--- a/include/flamegpu/sim/SimLogger.h
+++ b/include/flamegpu/sim/SimLogger.h
@@ -28,6 +28,8 @@ class SimLogger {
      * @param log_export_queue The queue of logs to exported to disk
      * @param log_export_queue_mutex This mutex must be locked to access log_export_queue
      * @param log_export_queue_cdn The condition is notified every time a log has been added to the queue
+     * @param _export_step If true step logs will be exported
+     * @param _export_exit If true exit logs will be exported
      */
     SimLogger(const std::vector<RunLog> &run_logs,
         const RunPlanVector &run_plans,
@@ -35,7 +37,9 @@ class SimLogger {
         const std::string &out_format,
         std::queue<unsigned int> &log_export_queue,
         std::mutex &log_export_queue_mutex,
-        std::condition_variable &log_export_queue_cdn);
+        std::condition_variable &log_export_queue_cdn,
+        bool _export_step,
+        bool _export_exit);
     /**
      * The thread which the logger is executing on, created by the constructor
      */
@@ -73,6 +77,14 @@ class SimLogger {
      * The condition is notified every time a log has been added to the queue
      */
     std::condition_variable &log_export_queue_cdn;
+    /**
+     * If true step log files will be exported
+     */
+    bool export_step;
+    /**
+     * If true exit log files will be exported
+     */
+    bool export_exit;
 };
 
 }  // namespace flamegpu

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -127,7 +127,7 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
     // Init log worker
     SimLogger *log_worker = nullptr;
     if (!config.out_directory.empty() && !config.out_format.empty()) {
-        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn);
+        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, step_log_config.get(), exit_log_config.get());
     } else if (!config.out_directory.empty() ^ !config.out_format.empty())  {
         fprintf(stderr, "Warning: Only 1 of out_directory and out_format is set, both must be set for logging to commence to file.\n");
     }

--- a/src/flamegpu/sim/SimLogger.cu
+++ b/src/flamegpu/sim/SimLogger.cu
@@ -32,14 +32,18 @@ SimLogger::SimLogger(const std::vector<RunLog> &_run_logs,
         const std::string &_out_format,
         std::queue<unsigned int> &_log_export_queue,
         std::mutex &_log_export_queue_mutex,
-        std::condition_variable &_log_export_queue_cdn)
+        std::condition_variable &_log_export_queue_cdn,
+        bool _export_step,
+        bool _export_exit)
     : run_logs(_run_logs)
     , run_plans(_run_plans)
     , out_directory(_out_directory)
     , out_format(_out_format)
     , log_export_queue(_log_export_queue)
     , log_export_queue_mutex(_log_export_queue_mutex)
-    , log_export_queue_cdn(_log_export_queue_cdn) {
+    , log_export_queue_cdn(_log_export_queue_cdn)
+    , export_step(_export_step)
+    , export_exit(_export_exit) {
     this->thread = std::thread(&SimLogger::start, this);
     // Attempt to name the thread
 #ifdef _MSC_VER
@@ -78,13 +82,16 @@ void SimLogger::start() {
                 break;
             }
             // Log items
-            const path exit_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path("exit." + out_format);
-            const auto exit_logger = io::LoggerFactory::createLogger(exit_path.generic_string(), false, false);
-            exit_logger->log(run_logs[target_log], true, false, true);
-            const path step_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path(std::to_string(target_log)+"."+out_format);
-            const auto step_logger = io::LoggerFactory::createLogger(step_path.generic_string(), false, false);
-            step_logger->log(run_logs[target_log], true, true, false);
-
+            if (export_exit) {
+                const path exit_path = p_out_directory / path(run_plans[target_log].getOutputSubdirectory()) / path("exit." + out_format);
+                const auto exit_logger = io::LoggerFactory::createLogger(exit_path.generic_string(), false, false);
+                exit_logger->log(run_logs[target_log], true, false, true);
+            }
+            if (export_step) {
+                const path step_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path(std::to_string(target_log)+"."+out_format);
+                const auto step_logger = io::LoggerFactory::createLogger(step_path.generic_string(), false, false);
+                step_logger->log(run_logs[target_log], true, true, false);
+            }
             // Continue
             ++logs_processed;
             lock.lock();

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -1,3 +1,19 @@
+// If earlier than VS 2019
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#include <filesystem>
+using std::tr2::sys::exists;
+using std::tr2::sys::path;
+using std::tr2::sys::remove;
+using std::tr2::sys::remove_all;
+#else
+// VS2019 requires this macro, as building pre c++17 cant use std::filesystem
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
+using std::experimental::filesystem::v1::exists;
+using std::experimental::filesystem::v1::path;
+using std::experimental::filesystem::v1::remove;
+using std::experimental::filesystem::v1::remove_all;
+#endif
 #include "gtest/gtest.h"
 
 #include "flamegpu/flamegpu.h"
@@ -202,7 +218,7 @@ TEST(LoggingTest, CUDASimulationSimulate) {
     // Run model
     CUDASimulation sim(m);
     sim.SimulationConfig().steps = 10;
-    // sim.SimulationConfig().common_log_file = "commmon.json";
+    // sim.SimulationConfig().common_log_file = "common.json";
     // sim.SimulationConfig().step_log_file = "step.json";
     // sim.SimulationConfig().exit_log_file = "exit.json";
     sim.SimulationConfig().steps = 10;
@@ -493,6 +509,432 @@ TEST(LoggingTest, CUDAEnsembleSimulate) {
         }
     }
 }
+TEST(TestLogging, Simulation_ToFile_Step) {
+    // Test that if we request a step log file to disk, we only get a step log file to disk
+    // Note, it does not test the contents of the output file
+    const path step_file = "step.json";
+    const path exit_file = "exit.json";
+    const path common_file = "common.json";
+    ASSERT_FALSE(::exists(step_file));
+    ASSERT_FALSE(::exists(exit_file));
+    ASSERT_FALSE(::exists(common_file));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Create agent population
+    AgentVector pop(a, 101);
+    for (int i = 0; i < 101; ++i) {
+        auto instance = pop[i];
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i + 1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i + 2));
+    }
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 10;
+    // sim.SimulationConfig().common_log_file = "common.json";
+    sim.SimulationConfig().step_log_file = "step.json";
+    // sim.SimulationConfig().exit_log_file = "exit.json";
+    sim.SimulationConfig().steps = 10;
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    sim.setPopulationData(pop);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate();
+    // Check
+    ASSERT_TRUE(::exists(step_file));
+    EXPECT_FALSE(::exists(exit_file));
+    EXPECT_FALSE(::exists(common_file));
+    // Cleanup
+    ASSERT_TRUE(::remove(step_file));
+    ::remove(exit_file);
+    ::remove(common_file);
+}
+TEST(TestLogging, Simulation_ToFile_Exit) {
+    // Test that if we request a exit log file to disk, we only get a exit log file to disk
+    // Note, it does not test the contents of the output file
+    const path step_file = "step.json";
+    const path exit_file = "exit.json";
+    const path common_file = "common.json";
+    ASSERT_FALSE(::exists(step_file));
+    ASSERT_FALSE(::exists(exit_file));
+    ASSERT_FALSE(::exists(common_file));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Create agent population
+    AgentVector pop(a, 101);
+    for (int i = 0; i < 101; ++i) {
+        auto instance = pop[i];
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i + 1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i + 2));
+    }
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 10;
+    // sim.SimulationConfig().common_log_file = "common.json";
+    // sim.SimulationConfig().step_log_file = "step.json";
+    sim.SimulationConfig().exit_log_file = "exit.json";
+    sim.SimulationConfig().steps = 10;
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    sim.setPopulationData(pop);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate();
+    // Check
+    ASSERT_TRUE(::exists(exit_file));
+    EXPECT_FALSE(::exists(step_file));
+    EXPECT_FALSE(::exists(common_file));
+    // Cleanup
+    ASSERT_TRUE(::remove(exit_file));
+    ::remove(step_file);
+    ::remove(common_file);
+}
+TEST(TestLogging, Simulation_ToFile_Common) {
+    // Test that if we request a common log file to disk, we only get a common log file to disk
+    // Note, it does not test the contents of the output file
+    const path step_file = "step.json";
+    const path exit_file = "exit.json";
+    const path common_file = "common.json";
+    ASSERT_FALSE(::exists(step_file));
+    ASSERT_FALSE(::exists(exit_file));
+    ASSERT_FALSE(::exists(common_file));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Create agent population
+    AgentVector pop(a, 101);
+    for (int i = 0; i < 101; ++i) {
+        auto instance = pop[i];
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i + 1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i + 2));
+    }
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 10;
+    sim.SimulationConfig().common_log_file = "common.json";
+    // sim.SimulationConfig().step_log_file = "step.json";
+    // sim.SimulationConfig().exit_log_file = "exit.json";
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    sim.setPopulationData(pop);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate();
+    // Check
+    ASSERT_TRUE(::exists(common_file));
+    EXPECT_FALSE(::exists(step_file));
+    EXPECT_FALSE(::exists(exit_file));
+    // Cleanup
+    ASSERT_TRUE(::remove(common_file));
+    ::remove(step_file);
+    ::remove(exit_file);
+}
+TEST(TestLogging, Simulation_ToFile_All) {
+    // Test that if we request a all log files to disk, we only get a all log file to disk
+    // Note, it does not test the contents of the output file
+    const path step_file = "step.json";
+    const path exit_file = "exit.json";
+    const path common_file = "common.json";
+    ASSERT_FALSE(::exists(step_file));
+    ASSERT_FALSE(::exists(exit_file));
+    ASSERT_FALSE(::exists(common_file));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Create agent population
+    AgentVector pop(a, 101);
+    for (int i = 0; i < 101; ++i) {
+        auto instance = pop[i];
+        instance.setVariable<float>("float_var", static_cast<float>(i));
+        instance.setVariable<int>("int_var", static_cast<int>(i + 1));
+        instance.setVariable<unsigned int>("uint_var", static_cast<unsigned int>(i + 2));
+    }
+
+    // Run model
+    CUDASimulation sim(m);
+    sim.SimulationConfig().steps = 10;
+    sim.SimulationConfig().common_log_file = "common.json";
+    sim.SimulationConfig().step_log_file = "step.json";
+    sim.SimulationConfig().exit_log_file = "exit.json";
+    sim.SimulationConfig().steps = 10;
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    sim.setPopulationData(pop);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate();
+    // Check
+    ASSERT_TRUE(::exists(common_file));
+    ASSERT_TRUE(::exists(step_file));
+    ASSERT_TRUE(::exists(exit_file));
+    // Cleanup
+    ASSERT_TRUE(::remove(common_file));
+    ASSERT_TRUE(::remove(step_file));
+    ASSERT_TRUE(::remove(exit_file));
+}
+TEST(TestLogging, Ensemble_ToFile_Step) {
+    // Test that if we request a common log file to disk, we only get a common log file to disk
+    // Note, it does not test the contents of the output file
+    const path step_file1 = "out/0.json";
+    const path step_file2 = "out/1.json";
+    const path exit_file = "out/exit.json";
+    ASSERT_FALSE(::exists(step_file1));
+    ASSERT_FALSE(::exists(step_file2));
+    ASSERT_FALSE(::exists(exit_file));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+    m.addInitFunction(logging_ensemble_init);
+    m.Environment().newProperty<int>("instance_id", 0);  // This will act as the modifier for ensemble instances, only impacting the init fn
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Set up the runplan
+    RunPlanVector plan(m, 2);
+    int i_id = 0;
+    for (auto& p : plan) {
+        p.setSteps(10);
+        p.setProperty<int>("instance_id", i_id++);
+        // p.setOutputSubdirectory(i_id%2 == 0 ? "a" : "b");
+    }
+
+    // Run model
+    CUDAEnsemble sim(m);
+    sim.Config().concurrent_runs = 5;
+    sim.Config().quiet = true;
+    sim.Config().timing = false;
+    sim.Config().out_directory = "out";
+    sim.Config().out_format = "json";
+    sim.setStepLog(slcfg);
+    // sim.setExitLog(lcfg);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate(plan);
+
+    // Check
+    ASSERT_TRUE(::exists(step_file1));
+    ASSERT_TRUE(::exists(step_file2));
+    EXPECT_FALSE(::exists(exit_file));
+    // Cleanup
+    ::remove_all("out");
+}
+TEST(TestLogging, Ensemble_ToFile_Exit) {
+    // Test that if we request a common log file to disk, we only get a common log file to disk
+    // Note, it does not test the contents of the output file
+    const path step_file1 = "out/0.json";
+    const path step_file2 = "out/1.json";
+    const path exit_file = "out/exit.json";
+    ASSERT_FALSE(::exists(step_file1));
+    ASSERT_FALSE(::exists(step_file2));
+    ASSERT_FALSE(::exists(exit_file));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+    m.addInitFunction(logging_ensemble_init);
+    m.Environment().newProperty<int>("instance_id", 0);  // This will act as the modifier for ensemble instances, only impacting the init fn
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Set up the runplan
+    RunPlanVector plan(m, 2);
+    int i_id = 0;
+    for (auto& p : plan) {
+        p.setSteps(10);
+        p.setProperty<int>("instance_id", i_id++);
+        // p.setOutputSubdirectory(i_id%2 == 0 ? "a" : "b");
+    }
+
+    // Run model
+    CUDAEnsemble sim(m);
+    sim.Config().concurrent_runs = 5;
+    sim.Config().quiet = true;
+    sim.Config().timing = false;
+    sim.Config().out_directory = "out";
+    sim.Config().out_format = "json";
+    // sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate(plan);
+
+    // Check
+    ASSERT_TRUE(::exists(exit_file));
+    ASSERT_FALSE(::exists(step_file1));
+    ASSERT_FALSE(::exists(step_file2));
+    ASSERT_TRUE(::remove(exit_file));
+    // Cleanup
+    ::remove_all("out");
+}
+TEST(TestLogging, Ensemble_ToFile_All) {
+    // Test that if we request a common log file to disk, we only get a common log file to disk
+    // Note, it does not test the contents of the output file
+    // This test also checks the subdirectory splitting feature
+    const path step_file1 = "out/b/0.json";
+    const path step_file2 = "out/a/1.json";
+    const path exit_file1 = "out/a/exit.json";
+    const path exit_file2 = "out/b/exit.json";
+    ASSERT_FALSE(::exists(step_file1));
+    ASSERT_FALSE(::exists(step_file2));
+    ASSERT_FALSE(::exists(exit_file1));
+    ASSERT_FALSE(::exists(exit_file2));
+    ASSERT_FALSE(::exists("out"));
+
+    // Define model
+    ModelDescription m(MODEL_NAME);
+    AgentDescription& a = m.newAgent(AGENT_NAME1);
+    a.newVariable<float>("float_var");
+    a.newVariable<int>("int_var");
+    a.newVariable<unsigned int>("uint_var");
+    AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
+    m.newLayer().addAgentFunction(f1);
+    m.addInitFunction(logging_ensemble_init);
+    m.Environment().newProperty<int>("instance_id", 0);  // This will act as the modifier for ensemble instances, only impacting the init fn
+
+    // Define logging configs
+    LoggingConfig lcfg(m);
+    AgentLoggingConfig alcfg = lcfg.agent(AGENT_NAME1);
+    alcfg.logCount();
+    logAllAgent<float>(alcfg, "float_var");
+    logAllAgent<int>(alcfg, "int_var");
+    logAllAgent<unsigned int>(alcfg, "uint_var");
+
+    StepLoggingConfig slcfg(lcfg);
+    slcfg.setFrequency(2);
+
+    // Set up the runplan
+    RunPlanVector plan(m, 2);
+    int i_id = 0;
+    for (auto& p : plan) {
+        p.setSteps(10);
+        p.setProperty<int>("instance_id", i_id++);
+        p.setOutputSubdirectory(i_id%2 == 0 ? "a" : "b");
+    }
+
+    // Run model
+    CUDAEnsemble sim(m);
+    sim.Config().concurrent_runs = 5;
+    sim.Config().quiet = true;
+    sim.Config().timing = false;
+    sim.Config().out_directory = "out";
+    sim.Config().out_format = "json";
+    sim.setStepLog(slcfg);
+    sim.setExitLog(lcfg);
+    // Call simulate(), and check step and exit logs match expectations
+    sim.simulate(plan);
+
+    // Check
+    ASSERT_TRUE(::exists(exit_file1));
+    ASSERT_TRUE(::exists(exit_file2));
+    ASSERT_TRUE(::exists(step_file1));
+    ASSERT_TRUE(::exists(step_file2));
+    // Cleanup
+    ::remove_all("out");
+}
+
 
 }  // namespace test_logging
 }  // namespace flamegpu


### PR DESCRIPTION
Very minor bug. If a user requests step log files from a `CUDAEnsemble`, basically empty exit log files would always be created too. I presume the opposite is also true (or rather specifying an output dir gets you log files).

Closes #731