### PR TITLE
Bugfix, logging variable mean for an empty agent pop

### DIFF
--- a/include/flamegpu/sim/AgentLoggingConfig.h
+++ b/include/flamegpu/sim/AgentLoggingConfig.h
@@ -165,7 +165,9 @@ template <typename T> struct sum_input_t { typedef T result_t; };
  */
 template<typename T>
 util::Any getAgentVariableMeanFunc(HostAgentAPI &ai, const std::string &variable_name) {
-    return util::Any(ai.sum<T, typename sum_input_t<T>::result_t>(variable_name) / static_cast<double>(ai.count()));
+    if (ai.count() > 0)
+        return util::Any(ai.sum<T, typename sum_input_t<T>::result_t>(variable_name) / static_cast<double>(ai.count()));
+    return util::Any(static_cast<double>(0));
 }
 template<typename T>
 util::Any getAgentVariableSumFunc(HostAgentAPI &ai, const std::string &variable_name) {

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -114,8 +114,10 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
 
     // Init with placement new
     {
-        if (!config.quiet)
+        if (!config.quiet) {
             printf("\rCUDAEnsemble progress: %u/%u", 0, static_cast<unsigned int>(plans.size()));
+            fflush(stdout);
+        }
         unsigned int i = 0;
         for (auto &d : devices) {
             for (unsigned int j = 0; j < config.concurrent_runs; ++j) {


### PR DESCRIPTION
would lead to a result of NaN, which JSON exported as empty string (invalid JSON).

Also adds a simple test which checks the result is 0.