### PR TITLE
Silence missing reserved vars when loading from XML.

### DIFF
--- a/src/flamegpu/io/XMLStateReader.cpp
+++ b/src/flamegpu/io/XMLStateReader.cpp
@@ -328,7 +328,7 @@ int XMLStateReader::parse() {
                         agentName, variable_name.c_str(), var_data.elements, inputFile.c_str(), el);
                     hasWarnedElements = true;
                 }
-            } else if (!hasWarnedMissingVar) {
+            } else if (!hasWarnedMissingVar && variable_name.find('_', 0) != 0) {
                 fprintf(stderr, "Warning: Agent '%s' variable '%s' is missing from, input file '%s'.\n",
                     agentName, variable_name.c_str(), inputFile.c_str());
                 hasWarnedMissingVar = true;


### PR DESCRIPTION
Users may custom write an input file, and reserved vars should be automatically assigned before use if not provided

JSON loader is not affected by the same issue.

Fixes this

![image](https://user-images.githubusercontent.com/742154/145973399-c80a20c1-5608-48b7-bc44-d2ee176e3f94.png)


Doesn't have a related issue.