### PR TITLE
Suppress note emitted by GCC >= 10 on ppc64le about changes since GCC 5

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -118,6 +118,11 @@ function(SuppressSomeCompilerWarnings)
     endif()
     # Suppress nodiscard warnings from the cuda frontend
     target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
+    # Suppress Power9 + GCC >= 10 note re: ABI changes in GCC >= 5
+    # "Note: the layout of aggregates containing vectors with x-byte allignment has changed in GCC 5
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:>-Wno-psabi")
+    endif()
 endfunction()
 
 # Function to promote warnings to errors, controlled by the WARNINGS_AS_ERRORS CMake option.


### PR DESCRIPTION
On RHEL 8 on a PPC64LE system, GCC 10 emits notes which were not emitted by GCC 8.4.0 (the previously tested version of GCC on PPC64LE). 

This PR suppresses these additional notes. The full test suite passed with this compiler configuration on PPC64LE with CUDA 11.4, executed on an T4 GPU.