### PR TITLE
Add CUDA 11.6.0 to CI builds

### DIFF
--- a/.github/scripts/install_cuda_ubuntu.sh
+++ b/.github/scripts/install_cuda_ubuntu.sh
@@ -14,6 +14,7 @@ CUDA_PACKAGES_IN=(
     "cuda-nvtx"
     "cuda-nvrtc-dev"
     "libcurand-dev" # 11-0+
+    "cuda-cccl" # 11.4+, provides cub and thrust. On 11.3 knwon as cuda-thrust-11-3
 )
 
 ## -------------------
@@ -90,12 +91,23 @@ do :
         package="cuda-compiler"
     elif [[ "${package}" == "cuda-compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
         package="cuda-nvcc"
+    # CUB/Thrust  are packages in cuda-thrust in 11.3, but cuda-cccl in 11.4+
+    elif [[ "${package}" == "cuda-thrust" || "${package}" == "cuda-cccl" ]]; then
+        # CUDA cuda-thrust >= 11.4
+        if version_ge "$CUDA_VERSION_MAJOR_MINOR" "11.4" ; then
+            package="cuda-cccl"
+        # Use cuda-thrust > 11.2
+        elif version_ge "$CUDA_VERSION_MAJOR_MINOR" "11.3" ; then
+            package="cuda-thrust"
+        # Do not include this pacakge < 11.3
+        else
+            continue
+        fi
     fi
     # CUDA 11+ includes lib* / lib*-dev packages, which if they existed previously where cuda-cu*- / cuda-cu*-dev-
     if [[ ${package} == libcu* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
         package="${package/libcu/cuda-cu}"
     fi
-
     # Build the full package name and append to the string.
     CUDA_PACKAGES+=" ${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
 done

--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -31,10 +31,12 @@ $CUDA_KNOWN_URLS = @{
     "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe"
     "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe"
     "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe"
+    "11.6.0" = "https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
 $VISUAL_STUDIO_MIN_CUDA = @{
+    "2022" = "11.6.0";
     "2019" = "10.1";
     "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
     "2015" = "8.0"; # might support older, unsure. Depracated as of 11.1, unsupported in 11.2

--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -50,6 +50,7 @@ $CUDA_PACKAGES_IN = @(
     "curand_dev";
     "nvrtc_dev";
     "cudart";
+    "thrust";
 )
 
 
@@ -100,9 +101,11 @@ Foreach ($package in $CUDA_PACKAGES_IN) {
         $package="compiler"
     } elseif($package -eq "compiler" -and [version]$CUDA_VERSION_FULL -ge [version]"9.1") {
         $package="nvcc"
-    }
+    } elseif($package -eq "thrust" -and [version]$CUDA_VERSION_FULL -lt [version]"11.3") {
+        # Thrust is a package from CUDA 11.3, otherwise it should be skipped.
+        continue
+    } 
     $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
-
 }
 echo "$($CUDA_PACKAGES)"
 ## -----------------

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "11.5"
+          - cuda: "11.6"
             cuda_arch: "35 60 80"
             hostcxx: gcc-9
             os: ubuntu-20.04
@@ -184,7 +184,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "11.5.1"
+          - cuda: "11.6.0"
             cuda_arch: "35 60 80"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -30,7 +30,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.5"
+          - cuda: "11.6"
             os: ubuntu-20.04
     env:
       # Define constants

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.5"
+          - cuda: "11.6"
             cuda_arch: "35"
             hostcxx: gcc-9
             os: ubuntu-20.04

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "11.5.1"
+          - cuda: "11.6.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,7 +29,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.5.1"
+          - cuda: "11.6.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ The process for creating a new Release of FLAME GPU is as follows:
     * Update `CITATION.cff` if required
     * All CI jobs should have passed for the commit
     * All Tests suite should have been executed on this commit, on Windows and Linux
-    * The CMake version pinning of the visualisation repo is correct. Ideally to a tag specific to the main repo release (i.e. `flamegpu-2.0.0-alpha`)
+    * The CMake version pinning of the visualisation repo is correct. Ideally to a tag specific to the main repo release (i.e. `flamegpu-2.0.0-alpha`). Create a new tag (matching the planned FLAME GPU 2 release) if required.
 2. Optionally invoke the [Draft Release Action](https://github.com/FLAMEGPU/FLAMEGPU2/actions/workflows/Draft-Release.yml) on the master branch, to ensure that the thoroguh build CI will pass.
     * When this CI is manually triggered, it will not create a draft release
     * This will take some time to complete.

--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 # @todo - If the git version has changed in this file, fetch again? 
-set(DEFAULT_VISUALISATION_GIT_VERSION "flamegpu-2.0.0-alpha.1")
+set(DEFAULT_VISUALISATION_GIT_VERSION "d35ad8f265364ee05bca6c4bec62374d1dbbea94")
 set(DEFAULT_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # If overridden by the user, attempt to use that

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,203 +1,217 @@
 # Function to disable all (as many as possible) compiler warnings for a given target
-function(DisableCompilerWarnings)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        DCW
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT DCW_TARGET)
-        message(FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required.")
-    elseif(NOT TARGET ${DCW_TARGET})
-        message(FATAL_ERROR "DisableCompilerWarnings: TARGET '${DCW_TARGET}' is not a valid target")
-    endif()
-    # By default, suppress all warnings, so that warnings are applied per-target.
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
-    else()
-        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
-    endif()
-    # Always tell nvcc to disable warnings
-    target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
-endfunction()
+if(NOT COMMAND DisableCompilerWarnings)
+    function(DisableCompilerWarnings)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            DCW
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT DCW_TARGET)
+            message(FATAL_ERROR "DisableCompilerWarnings: 'TARGET' argument required.")
+        elseif(NOT TARGET ${DCW_TARGET})
+            message(FATAL_ERROR "DisableCompilerWarnings: TARGET '${DCW_TARGET}' is not a valid target")
+        endif()
+        # By default, suppress all warnings, so that warnings are applied per-target.
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W0>")
+        else()
+            target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-w>")
+        endif()
+        # Always tell nvcc to disable warnings
+        target_compile_options(${DCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-w>")
+    endfunction()
+endif()
 
 # Function to set a high level of compiler warnings for a target
 # Function to disable all (as many as possible) compiler warnings for a given target
-function(SetHighWarningLevel)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        SHWL
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT SHWL_TARGET)
-        message(FATAL_ERROR "SetHighWarningLevel: 'TARGET' argument required.")
-    elseif(NOT TARGET ${SHWL_TARGET})
-        message(FATAL_ERROR "SetHighWarningLevel: TARGET '${SHWL_TARGET}' is not a valid target")
-    endif()
-    
-    # Per host-compiler settings for high warning levels and opt-in warnings.
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
-    else()
-        # Assume using GCC/Clang which Wall is relatively sane for. 
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
-        # CUB 1.9.10 prevents Wreorder being usable on windows, so linux only. Cannot suppress via diag_suppress pragmas.
-        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
-        # Add warnings which suggest the use of override
-        # Disabled, as cpplint occasionally disagrees with gcc concerning override
-        # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wsuggest-override>")
-        # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsuggest-override>")
-    endif()
-    # Generic options regardless of platform/host compiler:
-    # Ensure NVCC outputs warning numbers
-    target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
-endfunction()
+if(NOT COMMAND SetHighWarningLevel)
+    function(SetHighWarningLevel)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            SHWL
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT SHWL_TARGET)
+            message(FATAL_ERROR "SetHighWarningLevel: 'TARGET' argument required.")
+        elseif(NOT TARGET ${SHWL_TARGET})
+            message(FATAL_ERROR "SetHighWarningLevel: TARGET '${SHWL_TARGET}' is not a valid target")
+        endif()
+        
+        # Per host-compiler settings for high warning levels and opt-in warnings.
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            # Only set W4 for MSVC, WAll is more like Wall, Wextra and Wpedantic
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /W4>")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
+        else()
+            # Assume using GCC/Clang which Wall is relatively sane for. 
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wall$<COMMA>-Wsign-compare>")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wall>")
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsign-compare>")
+            # CUB 1.9.10 prevents Wreorder being usable on windows, so linux only. Cannot suppress via diag_suppress pragmas.
+            target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
+            # Add warnings which suggest the use of override
+            # Disabled, as cpplint occasionally disagrees with gcc concerning override
+            # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wsuggest-override>")
+            # target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Wsuggest-override>")
+        endif()
+        # Generic options regardless of platform/host compiler:
+        # Ensure NVCC outputs warning numbers
+        target_compile_options(${SHWL_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+    endfunction()
+endif()
 
 # Function to apply warning suppressions to a given target, without changing the general warning level (This is so SWIG can have suppressions, with default warning levels)
-function(SuppressSomeCompilerWarnings)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        SSCW
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT SSCW_TARGET)
-        message(FATAL_ERROR "SuppressSomeCompilerWarnings: 'TARGET' argument required.")
-    elseif(NOT TARGET ${SSCW_TARGET})
-        message(FATAL_ERROR "SuppressSomeCompilerWarnings: TARGET '${SSCW_TARGET}' is not a valid target")
-    endif()
-
-    # Per host-compiler/OS settings for suppressions
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        # decorated name length exceeded, name was truncated
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
-        # 'function' : unreferenced local function has been removed
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
-        # unreferenced formal parameter warnings disabled - tests make use of it.
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
-        # C4127: conditional expression is constant. Longer term true static assertions would be better.
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
-        # Suppress some VS2015 specific warnings.
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
-            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
-            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
+if(NOT COMMAND SuppressSomeCompilerWarnings)
+    function(SuppressSomeCompilerWarnings)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            SSCW
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT SSCW_TARGET)
+            message(FATAL_ERROR "SuppressSomeCompilerWarnings: 'TARGET' argument required.")
+        elseif(NOT TARGET ${SSCW_TARGET})
+            message(FATAL_ERROR "SuppressSomeCompilerWarnings: TARGET '${SSCW_TARGET}' is not a valid target")
         endif()
-        # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
-        target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
-    else()
-        # Linux specific warning suppressions
-    endif()
-    # Generic OS/host compiler warning suppressions
-    # Ensure NVCC outputs warning numbers
-    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
-    # Suppress deprecated compute capability warnings.
-    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>")
-    target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:-Wno-deprecated-gpu-targets>")
-    # Supress CUDA 11.3 specific warnings, which are host compiler agnostic.
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
-        # Suppress 117-D, declared_but_not_referenced
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
-    endif()
-    # Suppress nodiscard warnings from the cuda frontend
-    target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
-    # Suppress Power9 + GCC >= 10 note re: ABI changes in GCC >= 5
-    # "Note: the layout of aggregates containing vectors with x-byte allignment has changed in GCC 5
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:>-Wno-psabi")
-    endif()
-endfunction()
+
+        # Per host-compiler/OS settings for suppressions
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            # decorated name length exceeded, name was truncated
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4503>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4503>")
+            # 'function' : unreferenced local function has been removed
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4505>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>")
+            # unreferenced formal parameter warnings disabled - tests make use of it.
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4100>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>")
+            # C4127: conditional expression is constant. Longer term true static assertions would be better.
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4127>")
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4127>")
+            # Suppress some VS2015 specific warnings.
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+                target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4091>")
+                target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/wd4091>")
+            endif()
+            # Suppress Fatbinc warnings on msvc at link time (CMake >= 3.18)
+            target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /wd4100>")
+            # CUDA 11.6 deprecates __device__ cudaDeviceSynchronize, but does not provide an alternative.
+            # This is used in cub/thrust, and windows still emits this warning from the third party library
+            if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.6.0)
+                target_compile_definitions(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX,CUDA>:__CDPRT_SUPPRESS_SYNC_DEPRECATION_WARNING>")
+            endif()
+        else()
+            # Linux specific warning suppressions
+        endif()
+        # Generic OS/host compiler warning suppressions
+        # Ensure NVCC outputs warning numbers
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --display_error_number>")
+        # Suppress deprecated compute capability warnings.
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>")
+        target_link_options(${SSCW_TARGET} PRIVATE "$<DEVICE_LINK:-Wno-deprecated-gpu-targets>")
+        # Supress CUDA 11.3 specific warnings, which are host compiler agnostic.
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3.0)
+            # Suppress 117-D, declared_but_not_referenced
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=declared_but_not_referenced>")
+        endif()
+        # Suppress nodiscard warnings from the cuda frontend
+        target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcudafe --diag_suppress=2809>")
+        # Suppress Power9 + GCC >= 10 note re: ABI changes in GCC >= 5
+        # "Note: the layout of aggregates containing vectors with x-byte allignment has changed in GCC 5
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+            target_compile_options(${SSCW_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:>-Wno-psabi")
+        endif()
+    endfunction()
+endif()
 
 # Function to promote warnings to errors, controlled by the WARNINGS_AS_ERRORS CMake option.
-function(EnableWarningsAsErrors)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        EWAS
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT EWAS_TARGET)
-        message(FATAL_ERROR "EnableWarningsAsErrors: 'TARGET' argument required.")
-    elseif(NOT TARGET ${EWAS_TARGET})
-        message(FATAL_ERROR "EnableWarningsAsErrors: TARGET '${EWAS_TARGET}' is not a valid target")
-    endif()
-    
-    # Check the WARNINGS_AS_ERRORS cmake option to optionally enable this.
-    if(WARNINGS_AS_ERRORS)
-        # OS Specific flags
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            # Windows specific options
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
-            # Device link warnings as errors, CMake 3.18+
-            target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /WX>")
-        else()
-            # Linux specific options
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
-            # Device link warnings as errors, CMake 3.18+
-            target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler -Werror>")
-            # Add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call>")
-            # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
+if(NOT COMMAND EnableWarningsAsErrors)
+    function(EnableWarningsAsErrors)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            EWAS
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT EWAS_TARGET)
+            message(FATAL_ERROR "EnableWarningsAsErrors: 'TARGET' argument required.")
+        elseif(NOT TARGET ${EWAS_TARGET})
+            message(FATAL_ERROR "EnableWarningsAsErrors: TARGET '${EWAS_TARGET}' is not a valid target")
         endif()
-        # Platform/host-compiler indifferent options:
-        # Generic WError settings for nvcc
-        target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
-        # If CUDA 10.2+, add all_warnings to the Werror option
-        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
-            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
+        
+        # Check the WARNINGS_AS_ERRORS cmake option to optionally enable this.
+        if(WARNINGS_AS_ERRORS)
+            # OS Specific flags
+            if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+                # Windows specific options
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /WX>")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/WX>")
+                # Device link warnings as errors, CMake 3.18+
+                target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler /WX>")
+            else()
+                # Linux specific options
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Werror>")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:-Werror>")
+                # Device link warnings as errors, CMake 3.18+
+                target_link_options(${EWAS_TARGET} PRIVATE "$<DEVICE_LINK:SHELL:-Xcompiler -Werror>")
+                # Add cross-execution-space-call. This is blocked under msvc by a jitify related bug (untested > CUDA 10.1): https://github.com/NVIDIA/jitify/issues/62
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror cross-execution-space-call>")
+                # Add reorder to Werror. This is blocked under msvc by cub/thrust and the lack of isystem on msvc. Appears unable to suppress the warning via diag_suppress pragmas.
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror reorder>")
+            endif()
+            # Platform/host-compiler indifferent options:
+            # Generic WError settings for nvcc
+            target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas=\"-Werror\" -Xnvlink=\"-Werror\">")
+            # If CUDA 10.2+, add all_warnings to the Werror option
+            if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
+                target_compile_options(${EWAS_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror all-warnings>")
+            endif()
         endif()
-    endif()
-endfunction()
-
+    endfunction()
+endif()
 
 # Define a function which sets our preffered warning options for a target:
 # + A high warning level
 # + With some warnings suppressed
 # + Optionally promotes warnings to errors.
 # Also enables the treating of warnings as errors if required.
-function(EnableFLAMEGPUCompilerWarnings)
-    # Parse the expected arguments, prefixing variables.
-    cmake_parse_arguments(
-        EFCW
-        ""
-        "TARGET"
-        ""
-        ${ARGN}
-    )
-    # Ensure that a target has been passed, and that it is a valid target.
-    if(NOT EFCW_TARGET)
-        message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: 'TARGET' argument required.")
-    elseif(NOT TARGET ${EFCW_TARGET})
-        message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: TARGET '${EFCW_TARGET}' is not a valid target")
-    endif()
+if(NOT COMMAND EnableFLAMEGPUCompilerWarnings)
+    function(EnableFLAMEGPUCompilerWarnings)
+        # Parse the expected arguments, prefixing variables.
+        cmake_parse_arguments(
+            EFCW
+            ""
+            "TARGET"
+            ""
+            ${ARGN}
+        )
+        # Ensure that a target has been passed, and that it is a valid target.
+        if(NOT EFCW_TARGET)
+            message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: 'TARGET' argument required.")
+        elseif(NOT TARGET ${EFCW_TARGET})
+            message(FATAL_ERROR "EnableFLAMEGPUCompilerWarnings: TARGET '${EFCW_TARGET}' is not a valid target")
+        endif()
 
-    # Enable a high level of warnings
-    SetHighWarningLevel(TARGET ${EFCW_TARGET})
-    # Suppress some warnings
-    SuppressSomeCompilerWarnings(TARGET ${EFCW_TARGET})
-    # Optionally promote warnings to errors.
-    EnableWarningsAsErrors(TARGET ${EFCW_TARGET})
-endfunction()
+        # Enable a high level of warnings
+        SetHighWarningLevel(TARGET ${EFCW_TARGET})
+        # Suppress some warnings
+        SuppressSomeCompilerWarnings(TARGET ${EFCW_TARGET})
+        # Optionally promote warnings to errors.
+        EnableWarningsAsErrors(TARGET ${EFCW_TARGET})
+    endfunction()
+endif()


### PR DESCRIPTION
CUDA 11.6 support

+ Suppress `__device__ cudaDeviceSychrozize()` for CUDA >= 11.6 with MSVC (--isystem suppresses this already on linux/gcc).
+ Updates the FLAMEGPU/FLAMEGPU2-visualiser repository pinned version to include the above change
+ Changes CMake functions related to compiler warnings, so they are not overwritten by the copy in the visualisation repository (in case there are differences)
+ Enabled CUDA 11.6 on CI where relevant.


This has been tested under linux, including an RTC build which may have been impacted by a compiler default change which may have potentially had a negative impact.

Closes #761