### PR TITLE
CUDASimulation::setEnvironmentProperty()

### DIFF
--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -871,6 +871,12 @@ T EnvironmentManager::setProperty(const NamePair &name, const T &value) {
             "in EnvironmentManager::setProperty().",
             name.first, name.second.c_str());
     }
+    const size_type array_len = length(name);
+    if (array_len != 1) {
+        THROW exception::InvalidEnvPropertyType("Named environmental property is an array of length %u, the array function must be used! "
+            "in EnvironmentManager::setProperty().",
+            array_len);
+    }
     // Copy old data to return
     T rtn = getProperty<T>(name);
     std::unique_lock<std::shared_timed_mutex> lock(mutex);
@@ -911,7 +917,7 @@ std::array<T, N> EnvironmentManager::setProperty(const NamePair &name, const std
     const size_type array_len = length(name);
     if (array_len != N) {
         THROW exception::OutOfBoundsException("Length of named environmental property array (%u) does not match template argument N (%u)! "
-            "in EnvironmentManager::set().",
+            "in EnvironmentManager::setProperty().",
             array_len, N);
     }
     // Copy old data to return
@@ -1043,6 +1049,12 @@ T EnvironmentManager::getProperty(const NamePair &name) {
         THROW exception::InvalidEnvPropertyType("Environmental property ('%u:%s') type (%s) does not match template argument T (%s), "
             "in EnvironmentManager::getProperty().",
             name.first, name.second.c_str(), typ_id.name(), typeid(T).name());
+    }
+    const size_type array_len = length(name);
+    if (array_len != 1) {
+        THROW exception::InvalidEnvPropertyType("Named environmental property is an array of length %u, the array function must be used! "
+            "in EnvironmentManager::getProperty().",
+            array_len);
     }
     std::shared_lock<std::shared_timed_mutex> lock(mutex);
     // Copy old data to return

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -669,6 +669,12 @@ TEMPLATE_VARIABLE_INSTANTIATE_ID(setProperty, flamegpu::HostEnvironment::setProp
 TEMPLATE_VARIABLE_INSTANTIATE_ID(setPropertyArray, flamegpu::HostEnvironment::setPropertyArray)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(getMacroProperty, flamegpu::HostEnvironment::getMacroProperty_swig)
 
+// Instantiate template versions of CUDASimulation environment functions
+TEMPLATE_VARIABLE_INSTANTIATE_ID(setEnvironmentProperty, flamegpu::CUDASimulation::setEnvironmentProperty)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(setEnvironmentPropertyArray, flamegpu::CUDASimulation::setEnvironmentPropertyArray)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(getEnvironmentProperty, flamegpu::CUDASimulation::getEnvironmentProperty)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(getEnvironmentPropertyArray, flamegpu::CUDASimulation::getEnvironmentPropertyArray)
+
 // Instance template versions of the HostMacroProperty class
 // Extend HostMacroProperty so that it is python iterable
 %extend flamegpu::HostMacroProperty_swig {

--- a/tests/test_cases/runtime/test_host_environment.cu
+++ b/tests/test_cases/runtime/test_host_environment.cu
@@ -861,9 +861,10 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyReadOnly) {
     // array version
     std::array<int, TEST_ARRAY_LEN> b;
     auto setArray = &HostEnvironment::setProperty<int, TEST_ARRAY_LEN>;
-    // EXPECT_THROW(FLAMEGPU->environment.set<int>("read_only_a", b), exception::ReadOnlyEnvProperty);  // Doesn't build on Travis
+    auto getArray = &HostEnvironment::getProperty<int, TEST_ARRAY_LEN>;
+    EXPECT_THROW(FLAMEGPU->environment.setProperty<int>("read_only_a", 0, 0), exception::ReadOnlyEnvProperty);
     EXPECT_THROW((FLAMEGPU->environment.*setArray)("read_only_a", b), exception::ReadOnlyEnvProperty);
-    EXPECT_NO_THROW(FLAMEGPU->environment.getProperty<int>("read_only_a"));
+    EXPECT_NO_THROW((FLAMEGPU->environment.*getArray)("read_only_a"));
     EXPECT_NO_THROW(FLAMEGPU->environment.getProperty<int>("read_only_a", 1));
 }
 


### PR DESCRIPTION
Adds `CUDASimulation::setEnvironmentProperty()`, `CUDASimulation::getEnvironmentProperty()`, similar to the existing `setPopulationData()`, `getPopulationData()`. Added one thorough test to C and SWIG suites respectively. 

Other Changes:
*  `EnvironmentManager.setProperty()`/`getProperty()` did not check that length=1
* The test HostEnvironment::ExceptionPropertyReadOnly was calling non-array method with array types.

Todo:
- [x] SWIG template expansion
- [x] Tests