### PR TITLE
HostAgentAPI standard deviation (and mean) reduction.

### DIFF
--- a/include/flamegpu/sim/AgentLoggingConfig.h
+++ b/include/flamegpu/sim/AgentLoggingConfig.h
@@ -102,63 +102,6 @@ class AgentLoggingConfig {
     bool &log_count;
 };
 
-
-/**
- * Template for converting a type to the most suitable type of the same format with greatest range
- * Useful when summing unknown values
- * e.g. sum_input_t<float>::result_t == double
- * e.g. sum_input_t<uint8_t>::result_t == uint64_t
- */
-template <typename T> struct sum_input_t;
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<float> { typedef double result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<double> { typedef double result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<char> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint8_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint16_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint32_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint64_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int8_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int16_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int32_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int64_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <typename T> struct sum_input_t { typedef T result_t; };
-
 /**
  * @brief FLAMEGPU log reduction function pointer definition
  *  this runs on the host as an init/step/exit or host layer function

--- a/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
+++ b/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
@@ -54,6 +54,63 @@ __device__ __forceinline__ OutT standard_deviation_subtract_mean_impl::unary_fun
 }
 
 }  // namespace detail
+
+/**
+ * Template for converting a type to the most suitable type of the same format with greatest range
+ * Useful when summing unknown values
+ * e.g. sum_input_t<float>::result_t == double
+ * e.g. sum_input_t<uint8_t>::result_t == uint64_t
+ */
+template <typename T> struct sum_input_t;
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<float> { typedef double result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<double> { typedef double result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<char> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint8_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint16_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint32_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint64_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int8_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int16_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int32_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int64_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <typename T> struct sum_input_t { typedef T result_t; };
+
 }  // namespace flamegpu
 
 #endif  // INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_REDUCTIONS_CUH_

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -55,6 +55,7 @@ using namespace flamegpu; // @todo - is this required? Ideally it shouldn't be, 
 %include <std_array.i>
 %include <std_list.i>
 %include <std_set.i>
+%include <std_pair.i>
 %include <stdint.i>
 
 // argc/argv support
@@ -85,6 +86,9 @@ using namespace flamegpu; // @todo - is this required? Ideally it shouldn't be, 
 
 // Instantiate the set type used by CUDAEnsembleConfig.devices
 %template(IntSet) std::set<int>;
+
+// Instance the pair type, as returned by HostAgentAPI::meanStandardDeviation
+%template(DoublePair) std::pair<double, double>;
 
 /**
  * TEMPLATE_VARIABLE_INSTANTIATE_FLOATS macro
@@ -661,6 +665,7 @@ TEMPLATE_VARIABLE_INSTANTIATE(count, flamegpu::HostAgentAPI::count)
 TEMPLATE_VARIABLE_INSTANTIATE(min, flamegpu::HostAgentAPI::min)
 TEMPLATE_VARIABLE_INSTANTIATE(max, flamegpu::HostAgentAPI::max)
 TEMPLATE_SUM_INSTANTIATE(flamegpu::HostAgentAPI)
+TEMPLATE_VARIABLE_INSTANTIATE(meanStandardDeviation, flamegpu::HostAgentAPI::meanStandardDeviation)
 
 // Instantiate template versions of host environment functions from the API
 TEMPLATE_VARIABLE_INSTANTIATE_ID(getProperty, flamegpu::HostEnvironment::getProperty)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/host_reduction/test_count.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/host_reduction/test_transform_reduce.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/host_reduction/test_histogram_even.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/host_reduction/test_mean_standarddeviation.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/host_reduction/test_misc.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/test_subenvironment_manager.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/runtime/messaging/test_messaging.cu

--- a/tests/helpers/host_reductions_common.cu
+++ b/tests/helpers/host_reductions_common.cu
@@ -12,6 +12,7 @@ uint32_t uint32_t_out = 0;
 int32_t int32_t_out = 0;
 uint64_t uint64_t_out = 0;
 int64_t int64_t_out = 0;
+std::pair<double, double> mean_sd_out;
 std::vector<unsigned int> uint_vec;
 std::vector<int> int_vec;
 

--- a/tests/helpers/host_reductions_common.h
+++ b/tests/helpers/host_reductions_common.h
@@ -16,6 +16,7 @@
 #include <array>
 #include <random>
 #include <vector>
+#include <utility>
 
 #include "flamegpu/flamegpu.h"
 
@@ -34,6 +35,7 @@ extern uint32_t uint32_t_out;
 extern int32_t int32_t_out;
 extern uint64_t uint64_t_out;
 extern int64_t int64_t_out;
+extern std::pair<double, double> mean_sd_out;
 extern std::vector<unsigned int> uint_vec;
 extern std::vector<int> int_vec;
 

--- a/tests/swig/python/runtime/host_reduction/test_mean_standarddev.py
+++ b/tests/swig/python/runtime/host_reduction/test_mean_standarddev.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+import random as rand
+
+TEST_LEN = 101
+
+class step_func_mean_sd(pyflamegpu.HostFunctionCallback):
+    def __init__(self, Type, variable):
+        super().__init__()
+        self.Type = Type
+        self.variable = variable
+        self.mean = 0
+        self.sd = 0
+
+    def run(self, FLAMEGPU):
+        agent = FLAMEGPU.agent("agent")
+        sum_func = getattr(agent, f"meanStandardDeviation{self.Type}")
+        self.mean, self.sd = sum_func(self.variable)
+
+    def assert_mean_sd(self, expected_mean, expected_sd):
+        assert abs(expected_mean - self.mean) < 0.0001
+        assert abs(expected_sd - self.sd) < 0.0001
+
+class MiniSim():
+
+    def __init__(self, Type, variable):
+        self.model = pyflamegpu.ModelDescription("model")
+        self.agent = self.model.newAgent("agent")
+        
+        # add agent variable
+        new_var_func = getattr(self.agent, f"newVariable{Type}")
+        new_var_func(variable)
+        
+        # create a mean sd step function
+        self.step = step_func_mean_sd(Type, variable)
+        self.model.addStepFunctionCallback(self.step)
+        
+        # create a population and set random values to be sumed
+        self.population = pyflamegpu.AgentVector(self.agent, TEST_LEN)
+        rand.seed() # Seed does not matter 
+        self.expected_sum = 0
+        i = 0
+        for instance in self.population:
+            self.expected_sum += i
+            # set instance value (will be cast to correct type)
+            set_var_func = getattr(instance, f"setVariable{Type}")
+            set_var_func(variable, i)
+            i += 1
+
+    
+    def run(self): 
+        self.cudaSimulation = pyflamegpu.CUDASimulation(self.model)
+        self.cudaSimulation.SimulationConfig().steps = 1
+        self.cudaSimulation.setPopulationData(self.population)      
+        self.cudaSimulation.simulate()
+        # check assertions
+        self.step.assert_mean_sd(self.expected_sum/101, 29.15476)
+        
+
+class HostReductionTest(TestCase):
+
+    def test_SumFloat(self):
+        ms = MiniSim("Float", "float")         
+        ms.run()
+        
+    def test_SumDouble(self):
+        ms = MiniSim("Double", "double")         
+        ms.run()
+            
+    def test_SumInt8(self):
+        ms = MiniSim("Int8", "int8")         
+        ms.run()
+        
+    def test_SumUInt8(self):
+        ms = MiniSim("UInt8", "uint8")         
+        ms.run()
+        
+    def test_SumInt16(self):
+        ms = MiniSim("Int16", "int16")         
+        ms.run()
+        
+    def test_SumUInt16(self):
+        ms = MiniSim("UInt16", "uint16")         
+        ms.run()
+     
+    def test_SumInt32(self):
+        ms = MiniSim("Int32", "int32")         
+        ms.run()
+        
+    def test_SumUInt32(self):
+        ms = MiniSim("UInt32", "uint32")         
+        ms.run()     
+
+    def test_SumInt64(self):
+        ms = MiniSim("Int64", "int64")         
+        ms.run()
+        
+    def test_SumUInt64(self):
+        ms = MiniSim("UInt64", "uint64")         
+        ms.run() 
+

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -719,7 +719,7 @@ TEST(TestCUDASimulation, setEnvironmentProperty) {
     auto float_s_1 = &CUDASimulation::setEnvironmentProperty<float>;
     auto int_g_1 = &CUDASimulation::getEnvironmentProperty<int>;
     auto float_g_1 = &CUDASimulation::getEnvironmentProperty<float>;
-    EXPECT_THROW((s.*int_s_1)("float", 2.0f), exception::InvalidEnvProperty);  // Bad name
+    EXPECT_THROW((s.*int_s_1)("float", 2), exception::InvalidEnvProperty);  // Bad name
     EXPECT_THROW((s.*int_s_1)("int3", 3), exception::InvalidEnvPropertyType);  // Bad length
     EXPECT_THROW((s.*float_s_1)("int", 3), exception::InvalidEnvPropertyType);  // Bad type
     EXPECT_THROW((s.*int_g_1)("float"), exception::InvalidEnvProperty);  // Bad name

--- a/tests/test_cases/runtime/host_reduction/test_mean_standarddeviation.cu
+++ b/tests/test_cases/runtime/host_reduction/test_mean_standarddeviation.cu
@@ -1,0 +1,56 @@
+#include "helpers/host_reductions_common.h"
+namespace flamegpu {
+
+namespace test_host_reductions {
+FLAMEGPU_STEP_FUNCTION(step_sum_float) {
+    mean_sd_out = FLAMEGPU->agent("agent").meanStandardDeviation<float>("float");
+}
+FLAMEGPU_STEP_FUNCTION(step_sum_int32_t) {
+    mean_sd_out = FLAMEGPU->agent("agent").meanStandardDeviation<int32_t>("int32_t");
+}
+FLAMEGPU_STEP_FUNCTION(step_sum_uint32_t) {
+    mean_sd_out = FLAMEGPU->agent("agent").meanStandardDeviation<uint32_t>("uint32_t");
+}
+
+TEST_F(HostReductionTest, MeanStandardDeviation_float) {
+    ms->model.addStepFunction(step_sum_float);
+    ms->population->resize(101);
+    uint64_t sum = 0;
+    for (unsigned int i = 0; i < 101; i++) {
+        AgentVector::Agent instance = ms->population->at(i);
+        instance.setVariable<float>("float", static_cast<float>(i));
+        sum += i;
+    }
+    ms->run();
+    EXPECT_DOUBLE_EQ(sum / 101.0, mean_sd_out.first);
+    EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(mean_sd_out.second));  // Test value calculated with excel
+}
+TEST_F(HostReductionTest, MeanStandardDeviation_int32_t) {
+    ms->model.addStepFunction(step_sum_int32_t);
+    ms->population->resize(101);
+    uint64_t sum = 0;
+    for (unsigned int i = 0; i < 101; i++) {
+        AgentVector::Agent instance = ms->population->at(i);
+        instance.setVariable<int>("int32_t", static_cast<int>(i + 1));
+        sum += (i + 1);
+    }
+    ms->run();
+    EXPECT_DOUBLE_EQ(sum / 101.0, mean_sd_out.first);
+    EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(mean_sd_out.second));  // Test value calculated with excel
+}
+TEST_F(HostReductionTest, MeanStandardDeviation_uint32_t) {
+    ms->model.addStepFunction(step_sum_uint32_t);
+    ms->population->resize(101);
+    uint64_t sum = 0;
+    for (unsigned int i = 0; i < 101; i++) {
+        AgentVector::Agent instance = ms->population->at(i);
+        instance.setVariable<unsigned int>("uint32_t", static_cast<uint32_t>(i + 2));
+        sum += (i+2);
+    }
+    ms->run();
+    EXPECT_DOUBLE_EQ(sum / 101.0, mean_sd_out.first);
+    EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(mean_sd_out.second));  // Test value calculated with excel
+}
+
+}  // namespace test_host_reductions
+}  // namespace flamegpu


### PR DESCRIPTION
This leans heavily on the logging implementation. Returns both mean and standard deviation at once, to save users computing mean twice.

Todo
- [x] C tests
- [x] Python tests
- [x] does std::pair need swigifying?