### PR TITLE
Update linked Jitify version

### DIFF
--- a/cmake/dependencies/Jitify.cmake
+++ b/cmake/dependencies/Jitify.cmake
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0079 NEW)
 FetchContent_Declare(
     jitify
     GIT_REPOSITORY https://github.com/NVIDIA/jitify.git
-    GIT_TAG        00232c873704f53dbdec92ad8656f2cc3b1a4067
+    GIT_TAG        7b724609f7134d3e216678bb20b74edb187fbcaa
     SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/jitify-src/jitify
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON


### PR DESCRIPTION
This fixes a memory leak during RTC compilation.

Closes #756