### PR TITLE
Extend uniform random range support to floating point types.

### DIFF
--- a/include/flamegpu/runtime/utility/AgentRandom.cuh
+++ b/include/flamegpu/runtime/utility/AgentRandom.cuh
@@ -43,8 +43,11 @@ class AgentRandom {
     template<typename T>
     __forceinline__ __device__ T logNormal(const T& mean, const T& stddev) const;
     /**
-     * Returns an integer uniformly distributed in the inclusive range [lowerBound, max]
-     * @note Available as signed and unsigned: char, short, int, long long
+     * Returns an integer uniformly distributed in the inclusive range [min, max]
+     * or
+     * Returns a floating point value uniformly distributed in the exclusive-inclusive range (min, max]
+     * @tparam T return type
+     * @note Available as signed and unsigned: char, short, int, long long, float, double
      */
     template<typename T>
     __forceinline__ __device__ T uniform(const T& min, const T& max) const;
@@ -96,7 +99,7 @@ __forceinline__ __device__ double AgentRandom::logNormal(const double& mean, con
     return curand_log_normal_double(d_random_state, mean, stddev);
 }
 /**
-* Uniform Int
+* Uniform Range
 */
 template<typename T>
 __forceinline__ __device__ T AgentRandom::uniform(const T& min, const T& max) const {
@@ -125,6 +128,24 @@ __forceinline__ __device__ uint64_t AgentRandom::uniform(const uint64_t& min, co
     }
 #endif
     return static_cast<uint64_t>(min + (max - min) * uniform<double>());
+}
+template<>
+__forceinline__ __device__ float AgentRandom::uniform(const float& min, const float& max) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    if (min > max) {
+        DTHROW("Invalid arguments passed to AgentRandom::uniform(), %f > %f\n", min, max);
+    }
+#endif
+    return min + (max - min) * uniform<float>();
+}
+template<>
+__forceinline__ __device__ double AgentRandom::uniform(const double& min, const double& max) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    if (min > max) {
+        DTHROW("Invalid arguments passed to AgentRandom::uniform(), %f > %f\n", min, max);
+    }
+#endif
+    return min + (max - min) * uniform<double>();
 }
 
 }  // namespace flamegpu

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -40,10 +40,12 @@ class HostRandom {
     template<typename T>
     inline T logNormal(const T& mean, const T& stddev) const;
     /**
-    * Returns an integer uniformly distributed in the inclusive range [lowerBound, max]
-    * @tparam T return type (must be integer)
-    * @note Available as signed and unsigned: char, short, int, long long
-    */
+     * Returns an integer uniformly distributed in the inclusive range [min, max]
+     * or
+     * Returns a floating point value uniformly distributed in the inclusive-exclusive range [min, max)
+     * @tparam T return type
+     * @note Available as signed and unsigned: char, short, int, long long
+     */
     template<typename T>
     inline T uniform(const T& min, const T& max) const;
     /**
@@ -110,6 +112,16 @@ template<>
 inline signed char HostRandom::uniform(const signed char& min, const signed char& max) const {
     std::uniform_int_distribution<int16_t> dist(min, max);
     return static_cast<signed char>(rng.getDistribution<int16_t>(dist));
+}
+template<>
+inline float HostRandom::uniform(const float& min, const float& max) const {
+    std::uniform_real_distribution<float> dist(min, max);
+    return rng.getDistribution<float>(dist);
+}
+template<>
+inline double HostRandom::uniform(const double& min, const double& max) const {
+    std::uniform_real_distribution<double> dist(min, max);
+    return rng.getDistribution<double>(dist);
 }
 
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/test_agent_random.cu
+++ b/tests/test_cases/runtime/test_agent_random.cu
@@ -158,6 +158,9 @@ FLAMEGPU_AGENT_FUNCTION(random2_func, MessageNone, MessageNone) {
     FLAMEGPU->setVariable<float>("uniform_float", FLAMEGPU->random.uniform<float>());
     FLAMEGPU->setVariable<double>("uniform_double", FLAMEGPU->random.uniform<double>());
 
+    FLAMEGPU->setVariable<float>("uniform_float_range", FLAMEGPU->random.uniform<float>(-FLT_MAX, FLT_MAX));
+    FLAMEGPU->setVariable<double>("uniform_double_range", FLAMEGPU->random.uniform<double>(-DBL_MAX, DBL_MAX));
+
     FLAMEGPU->setVariable<float>("normal_float", FLAMEGPU->random.normal<float>());
     FLAMEGPU->setVariable<double>("normal_double", FLAMEGPU->random.normal<double>());
 
@@ -191,6 +194,9 @@ TEST(AgentRandomTest, AgentRandomFunctionsNoExcept) {
 
     agent.newVariable<float>("uniform_float");
     agent.newVariable<double>("uniform_double");
+
+    agent.newVariable<float>("uniform_float_range");
+    agent.newVariable<double>("uniform_double_range");
 
     agent.newVariable<float>("normal_float");
     agent.newVariable<double>("normal_double");

--- a/tests/test_cases/runtime/test_host_random.cu
+++ b/tests/test_cases/runtime/test_host_random.cu
@@ -78,6 +78,14 @@ FLAMEGPU_STEP_FUNCTION(step_uniform_longlong) {
     for (int64_t &i : longlong_out)
         ASSERT_NO_THROW(i = FLAMEGPU->random.uniform<int64_t>(INT64_MIN, INT64_MAX));
 }
+FLAMEGPU_STEP_FUNCTION(step_uniform_float_range) {
+    for (float& i : float_out)
+        ASSERT_NO_THROW(i = FLAMEGPU->random.uniform<float>(1.0f, 12345.0f));
+}
+FLAMEGPU_STEP_FUNCTION(step_uniform_double_range) {
+    for (double& i : double_out)
+        ASSERT_NO_THROW(i = FLAMEGPU->random.uniform<double>(1.0, 12345.0));
+}
 FLAMEGPU_STEP_FUNCTION(step_uniform_uchar_range) {
     for (auto &i : unsigned_char_out)
         ASSERT_NO_THROW(i = FLAMEGPU->random.uniform<unsigned char>(
@@ -320,7 +328,6 @@ TEST_F(HostRandomTest, UniformDouble) {
     for (unsigned int i = 0; i < double_out.size(); ++i)
         EXPECT_EQ(double_out[i], _double_out[i]);
 }
-
 TEST_F(HostRandomTest, NormalFloat) {
     ms->model.addStepFunction(step_normal_float);
     // Initially 0
@@ -965,8 +972,24 @@ TEST_F(HostRandomTest, UniformDoubleRange) {
     ms->model.addStepFunction(step_uniform_double);
     ms->run();
     for (auto &i : double_out) {
-        EXPECT_GE(i, 0.0f);
-        EXPECT_LT(i, 1.0f);
+        EXPECT_GE(i, 0.0);
+        EXPECT_LT(i, 1.0);
+    }
+}
+TEST_F(HostRandomTest, UniformFloatRange2) {
+    ms->model.addStepFunction(step_uniform_float_range);
+    ms->run();
+    for (auto& i : float_out) {
+        EXPECT_GE(i, 1.0f);
+        EXPECT_LT(i, 12345.0f);
+    }
+}
+TEST_F(HostRandomTest, UniformDoubleRange2) {
+    ms->model.addStepFunction(step_uniform_double_range);
+    ms->run();
+    for (auto& i : double_out) {
+        EXPECT_GE(i, 1.0);
+        EXPECT_LT(i, 12345.0);
     }
 }
 


### PR DESCRIPTION
Amends rng tests to check they can be used (given rng tests are a bit limited).
Documentation?
Rename `AgentRandom`, `DeviceRandom` for continuity?


Closes #776