### PR TITLE
Update visualisation version.

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 # @todo - If the git version has changed in this file, fetch again? 
-set(DEFAULT_VISUALISATION_GIT_VERSION "d35ad8f265364ee05bca6c4bec62374d1dbbea94")
+set(DEFAULT_VISUALISATION_GIT_VERSION "2bf3078b303c83e084ba91db7882e7ea9e7c0dbb")
 set(DEFAULT_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # If overridden by the user, attempt to use that


### PR DESCRIPTION
This gets the visualisation to use the new official github mirror for freetype, which is hopefully more stable (Windows CI has been failing all day).

Wouldn't normally force a vis update for something so minor, but have repeated some CI runs 3+ times, with one of 3 windows runs failing each time.