### PR TITLE
MessageSpatial2D::In::wrap()

### DIFF
--- a/include/flamegpu/runtime/messaging/MessageSpatial2D.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D.h
@@ -65,7 +65,7 @@ class MessageSpatial2D {
         /**
          * max-lowerBound
          */
-        float environmentWidth[3];
+        float environmentWidth[2];
     };
 };
 

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
@@ -269,6 +269,17 @@ class MessageSpatial2D::In {
 
                 return sqrt(dx * dx + dy * dy);
             }
+            /**
+             * Utility function for deciding next strip to access
+             */
+            __device__ void nextCell() {
+                if (relative_cell[1] >= 1) {
+                    relative_cell[1] = -1;
+                    relative_cell[0]++;
+                } else {
+                    relative_cell[1]++;
+                }
+            }
 
          public:
             /**
@@ -315,17 +326,6 @@ class MessageSpatial2D::In {
              */
             __device__ Message& operator++();
             /**
-             * Utility function for deciding next strip to access
-             */
-            __device__ void nextCell() {
-                if (relative_cell[1] >= 1) {
-                    relative_cell[1] = -1;
-                    relative_cell[0]++;
-                } else {
-                    relative_cell[1]++;
-                }
-            }
-            /**
              * Returns the value for the current message attached to the named variable
              * @param variable_name Name of the variable
              * @tparam T type of the variable
@@ -352,6 +352,26 @@ class MessageSpatial2D::In {
              */
             __device__ float getDistance() const {
                 return distance;
+            }
+            /**
+             * Returns the virtual x variable of the message
+             * This is the closest x coordinate the message would have, relative to the observers x coordinate in a wrapped environment
+             * @param x1 The x coordinate of the observer
+             */
+            __device__ float getVirtualX(float x1) const {
+                const float x2 = getVariable<float>("x");
+                const float x21 = x2 - x1;
+                return abs(x21) > _parent.metadata->environmentWidth[0] / 2.0f ? x2 - (x21 / abs(x21) * _parent.metadata->environmentWidth[0]) : x2;
+            }
+            /**
+             * Returns the virtual y variable of the message
+             * This is the closest y coordinate the message would have, relative to the observers x coordinate in a wrapped environment
+             * @param y1 The y coordinate of the observer
+             */
+            __device__ float getVirtualY(float y1) const {
+                const float y2 = getVariable<float>("y");
+                const float y21 = y2 - y1;
+                return abs(y21) > _parent.metadata->environmentWidth[1] / 2.0f ? y2 - (y21 / abs(y21) * _parent.metadata->environmentWidth[1]) : y2;
             }
         };
         /**

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
@@ -257,7 +257,19 @@ class MessageSpatial2D::In {
                 // Wrapping over boundaries
                 // https://blog.demofox.org/2017/10/01/calculating-the-distance-between-points-in-wrap-around-toroidal-space/
                 // Note, this falls over if either location is outside of [0, environmentWidth]
-                // That could be fixed moving out of bounds locations in bounds (+width until positive, then remainder op)
+#if !defined(SEATBELTS) || SEATBELTS
+                if (x > _parent.metadata->max[0] ||
+                    y > _parent.metadata->max[1] ||
+                    x < _parent.metadata->min[0] ||
+                    y < _parent.metadata->min[1]) {
+                    DTHROW("MessageSpatial2D message location (%f, %f) exceeds environment bounds (%g, %g):(%g, %g),"
+                        " this is unsupported for the wrapped iterator.\n", x, y,
+                        _parent.metadata->min[0], _parent.metadata->min[1],
+                        _parent.metadata->max[0], _parent.metadata->max[1]);
+                    // Return something which exceeds the radius
+                    return _parent.metadata->radius * 3;
+                }
+#endif
                 float dx = abs(_parent.loc[0] - x);
                 float dy = abs(_parent.loc[1] - y);
 
@@ -267,7 +279,7 @@ class MessageSpatial2D::In {
                 if (dy > _parent.metadata->environmentWidth[1] / 2.0f)
                     dy = _parent.metadata->environmentWidth[1] - dy;
 
-                return sqrt(dx * dx + dy * dy);
+                return sqrtf(dx * dx + dy * dy);
             }
             /**
              * Utility function for deciding next strip to access
@@ -501,6 +513,19 @@ class MessageSpatial2D::In {
       * @note Unlike the regular iterator, this iterator will not return messages outside of the search radius. The wrapped distance can be returned via WrapFilter::Message::distance()
       */
      inline __device__ WrapFilter wrap(const float x, const float y) const {
+#if !defined(SEATBELTS) || SEATBELTS
+         if (x > metadata->max[0] ||
+             y > metadata->max[1] ||
+             x < metadata->min[0] ||
+             y < metadata->min[1]) {
+             DTHROW("Location (%f, %f) exceeds environment bounds (%g, %g):(%g, %g),"
+                 " this is unsupported for the wrapped iterator, MessageSpatial2D::In::wrap().\n", x, y,
+                 metadata->min[0], metadata->min[1],
+                 metadata->max[0], metadata->max[1]);
+             // Return iterator at min corner of env, this should be safe
+             return WrapFilter(metadata, metadata->min[0], metadata->min[1]);
+         }
+#endif
          return WrapFilter(metadata, x, y);
      }
 

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
@@ -531,6 +531,7 @@ class MessageSpatial3D::In {
      *
      * @param x Search origin x coord
      * @param y Search origin y coord
+     * @param z Search origin z coord
      *
      * @note Unlike the regular iterator, this iterator will not return messages outside of the search radius. The wrapped distance can be returned via WrapFilter::Message::distance()
      */

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
@@ -46,13 +46,24 @@ class MessageSpatial3D::In {
              * This is the index of the currently accessed message, relative to the full message list
              */
             int cell_index = 0;
+            /**
+             * Utility function for deciding next strip to access
+             */
+            __device__ void nextStrip() {
+                if (relative_cell[1] >= 1) {
+                    relative_cell[1] = -1;
+                    relative_cell[0]++;
+                } else {
+                    relative_cell[1]++;
+                }
+            }
 
          public:
             /**
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter &parent, const int &relative_cell_y, const int &relative_cell_z, const int &_cell_index_max, const int &_cell_index)
+            __device__ Message(const Filter &parent, const int relative_cell_y, const int relative_cell_z, const int _cell_index_max, const int _cell_index)
                 : _parent(parent)
                 , cell_index_max(_cell_index_max)
                 , cell_index(_cell_index) {
@@ -93,17 +104,6 @@ class MessageSpatial3D::In {
              */
             __device__ Message& operator++();
             /**
-             * Utility function for deciding next strip to access
-             */
-            __device__ void nextStrip() {
-                if (relative_cell[1] >= 1) {
-                    relative_cell[1] = -1;
-                    relative_cell[0]++;
-                } else {
-                    relative_cell[1]++;
-                }
-            }
-            /**
              * Returns the value for the current message attached to the named variable
              * @param variable_name Name of the variable
              * @tparam T type of the variable
@@ -124,7 +124,7 @@ class MessageSpatial3D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M> __device__
-            T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
@@ -141,7 +141,7 @@ class MessageSpatial3D::In {
              * This iterator is constructed by MessageSpatial3D::In::Filter::begin()(float, float, float)
              * @see MessageSpatial3D::In::Operator()(float, float, float)
              */
-            __device__ iterator(const Filter &parent, const int &relative_cell_y, const int &relative_cell_z, const int &_cell_index_max, const int &_cell_index)
+            __device__ iterator(const Filter &parent, const int relative_cell_y, const int relative_cell_z, const int _cell_index_max, const int _cell_index)
                 : _message(parent, relative_cell_y, relative_cell_z, _cell_index_max, _cell_index) {
                 // Increment to find first message
                 ++_message;
@@ -192,7 +192,7 @@ class MessageSpatial3D::In {
          * @param y Search origin y coord
          * @param z search origin z coord
          */
-        __device__ Filter(const MetaData *_metadata, const float &x, const float &y, const float &z);
+        __device__ Filter(const MetaData *_metadata, float x, float y, float z);
         /**
          * Returns an iterator to the start of the message list subset about the search origin
          */
@@ -224,9 +224,290 @@ class MessageSpatial3D::In {
          */
         const MetaData *metadata;
     };
+    /**
+     * This class is created when a search origin is provided to MessageSpatial3D::In::wrap()(float, float, float)
+     * It provides iterator access to a subset of the full message list, according to the provided search origin
+     * 
+     * @see MessageSpatial3D::In::wrap()(float, float, float)
+     */
+    class WrapFilter {
+     public:
+        /**
+         * Provides access to a specific message
+         * Returned by the iterator
+         * @see In::WrapFilter::iterator
+         */
+        class Message {
+            /**
+             * Paired Filter class which created the iterator
+             */
+            const WrapFilter&_parent;
+            /**
+             * Relative strip within the Moore neighbourhood
+             * Strips run along the x axis
+             * relative_cell[0] corresponds to x offset
+             * relative_cell[1] corresponds to y offset
+             * relative_cell[2] corresponds to z offset
+             */
+            int relative_cell[3] = { -2, 1, -1 };
+            /**
+             * This is the index after the final message, relative to the full message list, in the current bin
+             */
+            int cell_index_max = 0;
+            /**
+             * This is the index of the currently accessed message, relative to the full message list
+             */
+            int cell_index = 0;
+            /**
+             * The pre-calculated boundary wrapping distance to the message
+             */
+            float distance;
+            __device__ float wrapped_distance(const float x, const float y, const float z) const {
+                // distance from x, y, z
+                // To _parent.loc
+                // Wrapping over boundaries
+                // https://blog.demofox.org/2017/10/01/calculating-the-distance-between-points-in-wrap-around-toroidal-space/
+                // Note, this falls over if either location is outside of [0, environmentWidth]
+                // That could be fixed moving out of bounds locations in bounds (+width until positive, then remainder op)
+                float dx = abs(_parent.loc[0] - x);
+                float dy = abs(_parent.loc[1] - y);
+                float dz = abs(_parent.loc[2] - z);
+
+                if (dx > _parent.metadata->environmentWidth[0] / 2.0f)
+                    dx = _parent.metadata->environmentWidth[0] - dx;
+
+                if (dy > _parent.metadata->environmentWidth[1] / 2.0f)
+                    dy = _parent.metadata->environmentWidth[1] - dy;
+
+                if (dz > _parent.metadata->environmentWidth[2] / 2.0f)
+                    dz = _parent.metadata->environmentWidth[2] - dz;
+
+                return sqrt(dx * dx + dy * dy + dz * dz);
+            }
+            /**
+             * Utility function for deciding next strip to access
+             */
+            __device__ void nextCell() {
+                if (relative_cell[2] >= 1) {
+                    relative_cell[2] = -1;
+                    if (relative_cell[1] >= 1) {
+                        relative_cell[1] = -1;
+                        ++relative_cell[0];
+                    } else {
+                        ++relative_cell[1];
+                    }
+                } else {
+                    ++relative_cell[2];
+                }
+            }
+
+         public:
+            /**
+             * Constructs a message and directly initialises all of it's member variables
+             * @note See member variable documentation for their purposes
+             */
+            __device__ Message(const WrapFilter& parent, const int relative_cell_x, const int relative_cell_y, const int relative_cell_z, const int _cell_index_max, const int _cell_index)
+                : _parent(parent)
+                , cell_index_max(_cell_index_max)
+                , cell_index(_cell_index) {
+                relative_cell[0] = relative_cell_x;
+                relative_cell[1] = relative_cell_y;
+                relative_cell[2] = relative_cell_z;
+            }
+            /**
+             * False minimal constructor used by iterator::end()
+             */
+            __device__ Message(const WrapFilter& parent)
+                : _parent(parent) { }
+            /**
+             * Equality operator
+             * Compares all internal member vars for equality
+             * @note Does not compare _parent
+             */
+            __device__ bool operator==(const Message &rhs) const {
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1]
+                    && this->relative_cell[2] == rhs.relative_cell[2]
+                    && this->cell_index_max == rhs.cell_index_max
+                    && this->cell_index == rhs.cell_index;
+            }
+            /**
+             * This should only be called to compare against end()
+             * It has been modified to check for end of iteration with minimal instructions
+             * Therefore it does not even perform the equality operation
+             * @note Use operator==() if proper equality is required
+             */
+            __device__ bool operator!=(const Message&) const {
+                // The incoming Message& is end(), so we don't care about that
+                // We only care that the host object has reached end
+                // When the strip number equals 2, it has exceeded the [1, 1, 1] range
+                return !(this->relative_cell[0] >= 2);
+            }
+            /**
+             * Updates the message to return variables from the next message in the message list
+             * @return Returns itself
+             */
+            __device__ Message& operator++();
+            /**
+             * Returns the value for the current message attached to the named variable
+             * @param variable_name Name of the variable
+             * @tparam T type of the variable
+             * @tparam N Length of variable name (this should be implicit if a string literal is passed to variable name)
+             * @return The specified variable, else 0x0 if an error occurs
+             */
+            template<typename T, unsigned int N>
+            __device__ T getVariable(const char(&variable_name)[N]) const;
+            /**
+             * Returns the specified variable array element from the current message attached to the named variable
+             * @param variable_name name used for accessing the variable, this value should be a string literal e.g. "foobar"
+             * @param index Index of the element within the variable array to return
+             * @tparam T Type of the message variable being accessed
+             * @tparam N The length of the array variable, as set within the model description hierarchy
+             * @tparam M Length of variable_name, this should always be implicit if passing a string literal
+             * @throws exception::DeviceError If name is not a valid variable within the agent (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
+             * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
+             */
+            template<typename T, MessageNone::size_type N, unsigned int M> __device__
+            T getVariable(const char(&variable_name)[M], unsigned int index) const;
+            /**
+             * Returns the wrapped distance from the search origin to the current message
+             */
+            __device__ float getDistance() const {
+                return distance;
+            }
+            /**
+             * Returns the virtual x variable of the message
+             * This is the closest x coordinate the message would have, relative to the observers x coordinate in a wrapped environment
+             * @param x1 The x coordinate of the observer
+             */
+            __device__ float getVirtualX(float x1) const {
+                const float x2 = getVariable<float>("x");
+                const float x21 = x2 - x1;
+                return abs(x21) > _parent.metadata->environmentWidth[0] / 2.0f ? x2 - (x21 / abs(x21) * _parent.metadata->environmentWidth[0]) : x2;
+            }
+            /**
+             * Returns the virtual y variable of the message
+             * This is the closest y coordinate the message would have, relative to the observers y coordinate in a wrapped environment
+             * @param y1 The y coordinate of the observer
+             */
+            __device__ float getVirtualY(float y1) const {
+                const float y2 = getVariable<float>("y");
+                const float y21 = y2 - y1;
+                return abs(y21) > _parent.metadata->environmentWidth[1] / 2.0f ? y2 - (y21 / abs(y21) * _parent.metadata->environmentWidth[1]) : y2;
+            }
+            /**
+             * Returns the virtual z variable of the message
+             * This is the closest z coordinate the message would have, relative to the observers z coordinate in a wrapped environment
+             * @param z1 The z coordinate of the observer
+             */
+            __device__ float getVirtualZ(float z1) const {
+                const float z2 = getVariable<float>("z");
+                const float z21 = z2 - z1;
+                return abs(z21) > _parent.metadata->environmentWidth[2] / 2.0f ? z2 - (z21 / abs(z21) * _parent.metadata->environmentWidth[2]) : z2;
+            }
+        };
+        /**
+         * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
+         */
+        class iterator {
+            /**
+             * The message returned to the user
+             */
+            Message _message;
+
+         public:
+            /**
+             * Constructor
+             * This iterator is constructed by MessageSpatial3D::In::WrapFilter::begin()(float, float, float)
+             * @see MessageSpatial3D::In::wrap()(float, float, float)
+             */
+            __device__ iterator(const WrapFilter& parent, const int relative_cell_x, const int relative_cell_y, const int relative_cell_z, const int _cell_index_max, const int _cell_index)
+                : _message(parent, relative_cell_x, relative_cell_y, relative_cell_z, _cell_index_max, _cell_index) {
+                // Increment to find first message
+                ++_message;
+            }
+            /**
+             * False constructor
+             * Only used by Filter::end(), creates a null objct
+             */
+            __device__ iterator(const WrapFilter& parent)
+                : _message(parent) { }
+            /**
+             * Moves to the next message
+             * (Prefix increment operator)
+             */
+            __device__ iterator& operator++() { ++_message;  return *this; }
+            /**
+             * Moves to the next message
+             * (Postfix increment operator, returns value prior to increment)
+             */
+            __device__ iterator operator++(int) {
+                iterator temp = *this;
+                ++*this;
+                return temp;
+            }
+            /**
+             * Equality operator
+             * Compares message
+             */
+            __device__ bool operator==(const iterator& rhs) const { return  _message == rhs._message; }
+            /**
+             * Inequality operator
+             * Compares message
+             */
+            __device__ bool operator!=(const iterator& rhs) const { return  _message != rhs._message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message& operator*() { return _message; }
+            /**
+             * Dereferences the iterator to return the message object, for accessing variables
+             */
+            __device__ Message* operator->() { return &_message; }
+        };
+        /**
+         * Constructor, takes the search parameters requried
+         * @param _metadata Pointer to message list metadata
+         * @param x Search origin x coord
+         * @param y Search origin y coord
+         * @param z search origin z coord
+         */
+        __device__ WrapFilter(const MetaData *_metadata, float x, float y, float z);
+        /**
+         * Returns an iterator to the start of the message list subset about the search origin
+         */
+        inline __device__ iterator begin(void) const {
+            // Bin before initial bin, as the constructor calls increment operator
+            return iterator(*this, -2, 1, 1, 1, 0);
+        }
+        /**
+         * Returns an iterator to the position beyond the end of the message list subset
+         * @note This iterator is the same for all message list subsets
+         */
+        inline __device__ iterator end(void) const {
+            // Empty init, because this object is never used
+            // iterator equality doesn't actually check the end object
+            return iterator(*this);
+        }
+
+     private:
+        /**
+         * Search origin
+         */
+        float loc[3];
+        /**
+         * Search origin's grid cell
+         */
+        GridPos3D cell;
+        /**
+         * Pointer to message list metadata, e.g. environment bounds, search radius, PBM location
+         */
+        const MetaData *metadata;
+    };
 
     /**
-     * Constructer
+     * Constructor
      * Initialises member variables
      * @param _metadata Reinterpreted as type MessageSpatial3D::MetaData
      */
@@ -241,8 +522,20 @@ class MessageSpatial3D::In {
      * @param y Search origin y coord
      * @param z Search origin z coord
      */
-    inline __device__ Filter operator() (const float &x, const float &y, const float &z) const {
+    inline __device__ Filter operator() (const float x, const float y, const float z) const {
         return Filter(metadata, x, y, z);
+    }
+    /**
+     * Returns a WrapFilter object which provides access to message iterator
+     * for iterating a subset of messages including those within the radius of the search origin
+     *
+     * @param x Search origin x coord
+     * @param y Search origin y coord
+     *
+     * @note Unlike the regular iterator, this iterator will not return messages outside of the search radius. The wrapped distance can be returned via WrapFilter::Message::distance()
+     */
+    inline __device__ WrapFilter wrap(const float x, const float y, const float z) const {
+        return WrapFilter(metadata, x, y, z);
     }
 
     /**
@@ -281,7 +574,7 @@ class MessageSpatial3D::Out : public MessageBruteForce::Out {
      * @param z Message z coord
      * @note Convenience wrapper for setVariable()
      */
-    __device__ void setLocation(const float &x, const float &y, const float &z) const;
+    __device__ void setLocation(float x, float y, float z) const;
 };
 
 template<typename T, unsigned int N>
@@ -298,7 +591,33 @@ __device__ T MessageSpatial3D::In::Filter::Message::getVariable(const char(&vari
     return value;
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageSpatial3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageSpatial3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (relative_cell[0] >= 2) {
+        DTHROW("MessageSpatial3D in invalid bin, unable to get variable '%s'.\n", variable_name);
+        return {};
+    }
+#endif
+    // get the value from curve using the message index.
+    T value = detail::curve::DeviceCurve::getMessageArrayVariable<T, N>(variable_name, cell_index, array_index);
+    return value;
+}
+template<typename T, unsigned int N>
+__device__ T MessageSpatial3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[N]) const {
+#if !defined(SEATBELTS) || SEATBELTS
+    // Ensure that the message is within bounds.
+    if (relative_cell[0] >= 2) {
+        DTHROW("MessageSpatial3D in invalid bin, unable to get variable '%s'.\n", variable_name);
+        return static_cast<T>(0);
+    }
+#endif
+    // get the value from curve using the message index.
+    T value = detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, cell_index);
+    return value;
+}
+template<typename T, MessageNone::size_type N, unsigned int M> __device__
+T MessageSpatial3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (relative_cell[0] >= 2) {
@@ -340,7 +659,7 @@ __device__ __forceinline__ unsigned int getHash3D(const MessageSpatial3D::MetaDa
         gridPos[0]);                                      // x
 }
 
-__device__ inline void MessageSpatial3D::Out::setLocation(const float &x, const float &y, const float &z) const {
+__device__ inline void MessageSpatial3D::Out::setLocation(const float x, const float y, const float z) const {
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;  // + d_message_count;
 
     // set the variables using curve
@@ -352,7 +671,7 @@ __device__ inline void MessageSpatial3D::Out::setLocation(const float &x, const 
     this->scan_flag[index] = 1;
 }
 
-__device__ inline MessageSpatial3D::In::Filter::Filter(const MetaData* _metadata, const float& x, const float& y, const float& z)
+__device__ inline MessageSpatial3D::In::Filter::Filter(const MetaData* _metadata, const float x, const float y, const float z)
     : metadata(_metadata) {
     loc[0] = x;
     loc[1] = y;
@@ -384,6 +703,48 @@ __device__ inline MessageSpatial3D::In::Filter::Message& MessageSpatial3D::In::F
         }
         move_strip = cell_index >= cell_index_max;
     }
+    return *this;
+}
+__device__ inline MessageSpatial3D::In::WrapFilter::WrapFilter(const MetaData* _metadata, const float x, const float y, const float z)
+    : metadata(_metadata) {
+    loc[0] = x;
+    loc[1] = y;
+    loc[2] = z;
+    cell = getGridPosition3D(_metadata, x, y, z);
+}
+__device__ inline MessageSpatial3D::In::WrapFilter::Message& MessageSpatial3D::In::WrapFilter::Message::operator++() {
+    do {
+        cell_index++;
+        bool move_strip = cell_index >= cell_index_max;
+        while (move_strip) {
+            nextCell();
+            cell_index = 0;
+            cell_index_max = 1;
+            if (relative_cell[0] < 2) {
+                // Calculate the strips start and end hash
+                int absolute_cell_x = (_parent.cell.x + relative_cell[0] + static_cast<int>(_parent.metadata->gridDim[0])) % _parent.metadata->gridDim[0];
+                int absolute_cell_y = (_parent.cell.y + relative_cell[1] + static_cast<int>(_parent.metadata->gridDim[1])) % _parent.metadata->gridDim[1];
+                int absolute_cell_z = (_parent.cell.z + relative_cell[2] + static_cast<int>(_parent.metadata->gridDim[2])) % _parent.metadata->gridDim[2];
+                // Skip the strip if it is completely out of bounds
+                unsigned int start_hash = getHash3D(_parent.metadata, { absolute_cell_x, absolute_cell_y, absolute_cell_z });
+                unsigned int end_hash = getHash3D(_parent.metadata, { absolute_cell_x, absolute_cell_y, absolute_cell_z });
+                // Lookup start and end indicies from PBM
+                cell_index = _parent.metadata->PBM[start_hash];
+                cell_index_max = _parent.metadata->PBM[end_hash + 1];
+            }
+            move_strip = cell_index >= cell_index_max;
+        }
+        // If message is out of bounds, break
+        if (relative_cell[0] >= 2) {
+            distance = 0;
+            break;
+        }
+        // Else, fetch it's location and update distance
+        const float msg_x = getVariable<float>("x");
+        const float msg_y = getVariable<float>("y");
+        const float msg_z = getVariable<float>("z");
+        distance = wrapped_distance(msg_x, msg_y, msg_z);
+    } while (distance > _parent.metadata->radius);
     return *this;
 }
 

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -785,7 +785,6 @@ TEST(Spatial2DMessageTest, DISABLED_ArrayVariable_glm) { }
 TEST(RTCSpatial2DMessageTest, DISABLED_ArrayVariable_glm) { }
 #endif
 
-
 FLAMEGPU_AGENT_FUNCTION(inWrapped2D, MessageSpatial2D, MessageNone) {
     const float x1 = FLAMEGPU->getVariable<float>("x");
     const float y1 = FLAMEGPU->getVariable<float>("y");

--- a/tests/test_cases/runtime/messaging/test_spatial_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_3d.cu
@@ -14,7 +14,7 @@ namespace flamegpu {
 namespace test_message_spatial3d {
 
 FLAMEGPU_AGENT_FUNCTION(out_mandatory3D, MessageNone, MessageSpatial3D) {
-    FLAMEGPU->message_out.setVariable<int>("id", FLAMEGPU->getVariable<int>("id"));
+    FLAMEGPU->message_out.setVariable<flamegpu::id_t>("id", FLAMEGPU->getID());
     FLAMEGPU->message_out.setLocation(
         FLAMEGPU->getVariable<float>("x"),
         FLAMEGPU->getVariable<float>("y"),
@@ -23,7 +23,7 @@ FLAMEGPU_AGENT_FUNCTION(out_mandatory3D, MessageNone, MessageSpatial3D) {
 }
 FLAMEGPU_AGENT_FUNCTION(out_optional3D, MessageNone, MessageSpatial3D) {
     if (FLAMEGPU->getVariable<int>("do_output")) {
-        FLAMEGPU->message_out.setVariable<int>("id", FLAMEGPU->getVariable<int>("id"));
+        FLAMEGPU->message_out.setVariable<flamegpu::id_t>("id", FLAMEGPU->getID());
         FLAMEGPU->message_out.setLocation(
             FLAMEGPU->getVariable<float>("x"),
             FLAMEGPU->getVariable<float>("y"),
@@ -79,11 +79,10 @@ TEST(Spatial3DMessageTest, Mandatory) {
         message.setMax(5, 5, 5);
         message.setRadius(1);
         // 5x5x5 bins, total 125
-        message.newVariable<int>("id");  // unused by current test
+        message.newVariable<flamegpu::id_t>("id");  // unused by current test
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");
-        agent.newVariable<int>("id");
         agent.newVariable<float>("x");
         agent.newVariable<float>("y");
         agent.newVariable<float>("z");
@@ -112,7 +111,6 @@ TEST(Spatial3DMessageTest, Mandatory) {
         std::uniform_real_distribution<float> dist(0.0f, 5.0f);
         for (unsigned int i = 0; i < AGENT_COUNT; i++) {
             AgentVector::Agent instance = population[i];
-            instance.setVariable<int>("id", i);
             float pos[3] = { dist(rng), dist(rng), dist(rng) };
             instance.setVariable<float>("x", pos[0]);
             instance.setVariable<float>("y", pos[1]);
@@ -221,11 +219,10 @@ TEST(Spatial3DMessageTest, Optional) {
         message.setMax(5, 5, 5);
         message.setRadius(1);
         // 5x5x5 bins, total 125
-        message.newVariable<int>("id");  // unused by current test
+        message.newVariable<flamegpu::id_t>("id");  // unused by current test
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");
-        agent.newVariable<int>("id");
         agent.newVariable<float>("x");
         agent.newVariable<float>("y");
         agent.newVariable<float>("z");
@@ -257,7 +254,6 @@ TEST(Spatial3DMessageTest, Optional) {
         std::uniform_real_distribution<float> dist(0.0f, 5.0f);
         for (unsigned int i = 0; i < AGENT_COUNT; i++) {
             AgentVector::Agent instance = population[i];
-            instance.setVariable<int>("id", i);
             float pos[3] = { dist(rng), dist(rng), dist(rng) };
             int do_output = dist(rng) < 4 ? 1 : 0;  // 80% chance of output  // NEW!
             instance.setVariable<float>("x", pos[0]);
@@ -372,11 +368,10 @@ TEST(Spatial3DMessageTest, OptionalNone) {
         message.setMax(5, 5, 5);
         message.setRadius(1);
         // 5x5x5 bins, total 125
-        message.newVariable<int>("id");  // unused by current test
+        message.newVariable<flamegpu::id_t>("id");  // unused by current test
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");
-        agent.newVariable<int>("id");
         agent.newVariable<float>("x");
         agent.newVariable<float>("y");
         agent.newVariable<float>("z");
@@ -408,7 +403,6 @@ TEST(Spatial3DMessageTest, OptionalNone) {
         std::uniform_real_distribution<float> dist(0.0f, 5.0f);
         for (unsigned int i = 0; i < AGENT_COUNT; i++) {
             AgentVector::Agent instance = population[i];
-            instance.setVariable<int>("id", i);
             float pos[3] = { dist(rng), dist(rng), dist(rng) };
             int do_output = dist(rng) < 4 ? 1 : 0;  // 80% chance of output  // NEW!
             instance.setVariable<float>("x", pos[0]);
@@ -518,7 +512,7 @@ TEST(Spatial3DMessageTest, ReadEmpty) {
         message.setMin(-3, -3, -3);
         message.setMax(3, 3, 3);
         message.setRadius(2);
-        message.newVariable<int>("id");  // unused by current test
+        message.newVariable<flamegpu::id_t>("id");  // unused by current test
     }
     {   // Circle agent
         AgentDescription &agent = model.newAgent("agent");
@@ -858,5 +852,106 @@ TEST(Spatial3DMessageTest, DISABLED_ArrayVariable_glm) { }
 TEST(RTCSpatial3DMessageTest, DISABLED_ArrayVariable_glm) { }
 #endif
 
+FLAMEGPU_AGENT_FUNCTION(inWrapped3D, MessageSpatial3D, MessageNone) {
+    const float x1 = FLAMEGPU->getVariable<float>("x");
+    const float y1 = FLAMEGPU->getVariable<float>("y");
+    const float z1 = FLAMEGPU->getVariable<float>("z");
+    const flamegpu::id_t ID = FLAMEGPU->getID();
+    unsigned int count = 0;
+    unsigned int badCount = 0;
+    float xSum = 0;
+    float ySum = 0;
+    float zSum = 0;
+    // Count how many messages we recieved (including our own)
+    // This is all those which fall within the 3x3x3 Moore neighbourhood
+    // Not our search radius
+    for (const auto& message : FLAMEGPU->message_in.wrap(x1, y1, z1)) {
+        count++;
+        if (message.getVariable<flamegpu::id_t>("id") != ID) {
+            xSum += (message.getVirtualX(x1) - x1);
+            ySum += (message.getVirtualY(y1) - y1);
+            zSum += (message.getVirtualZ(z1) - z1);
+        }
+        if (message.getDistance() > FLAMEGPU->message_in.radius() ||
+            (abs((message.getVirtualX(x1) - x1)) != 2.0f && message.getVirtualX(x1) != x1) ||
+            (abs((message.getVirtualY(y1) - y1)) != 2.0f && message.getVirtualY(y1) != y1) ||
+            (abs((message.getVirtualZ(z1) - z1)) != 2.0f && message.getVirtualZ(z1) != z1)
+        ) {
+            badCount++;
+        }
+    }
+    FLAMEGPU->setVariable<unsigned int>("count", count);
+    FLAMEGPU->setVariable<unsigned int>("badCount", badCount);
+    FLAMEGPU->setVariable<float>("result_x", xSum);
+    FLAMEGPU->setVariable<float>("result_y", ySum);
+    FLAMEGPU->setVariable<float>("result_z", zSum);
+    return ALIVE;
+}
+TEST(Spatial3DMessageTest, Wrapped) {
+    std::unordered_map<int, unsigned int> bin_counts;
+    // Construct model
+    ModelDescription model("Spatial2DMessageTestModel");
+    {   // Location message
+        MessageSpatial3D::Description& message = model.newMessage<MessageSpatial3D>("location");
+        message.setMin(0, 0, 0);
+        message.setMax(70, 70, 70);
+        message.setRadius(3.5);  // With a grid of agents spaced 2 units apart, this configuration should give each agent 8 neighbours (assuming my basic maths guessing works out)
+        message.newVariable<flamegpu::id_t>("id");  // unused by current test
+    }
+    {   // Circle agent
+        AgentDescription& agent = model.newAgent("agent");
+        agent.newVariable<float>("x");
+        agent.newVariable<float>("y");
+        agent.newVariable<float>("z");
+        agent.newVariable<float>("result_x");  // Sum all virtual X values, and this should equal 0 (or very close)
+        agent.newVariable<float>("result_y");  // Sum all virtual X values, and this should equal 0 (or very close)
+        agent.newVariable<float>("result_z");  // Sum all virtual X values, and this should equal 0 (or very close)
+        agent.newVariable<unsigned int>("count");  // Count how many messages we receive
+        agent.newVariable<unsigned int>("badCount");  // Count how many messages we receive that have bad data
+        agent.newFunction("out", out_mandatory3D).setMessageOutput("location");
+        agent.newFunction("in", inWrapped3D).setMessageInput("location");
+    }
+    {   // Layer #1
+        LayerDescription& layer = model.newLayer();
+        layer.addAgentFunction(out_mandatory3D);
+    }
+    {   // Layer #2
+        LayerDescription& layer = model.newLayer();
+        layer.addAgentFunction(inWrapped3D);
+    }
+    CUDASimulation cudaSimulation(model);
+
+    AgentVector population(model.Agent("agent"), 35u * 35u * 35U);  // This must fit the env dims/radius set out above
+    // Initialise agents (TODO)
+    {
+        // Currently population has not been init, so generate an agent population on the fly
+        for (unsigned int i = 0; i < 35u; i++) {
+            for (unsigned int j = 0; j < 35u; j++) {
+                for (unsigned int k = 0; k < 35u; k++) {
+                    unsigned int w =  (i * 35u+ j) * 35u + k;
+                    AgentVector::Agent instance = population[w];
+                    instance.setVariable<float>("x", i * 2.0f);
+                    instance.setVariable<float>("y", j * 2.0f);
+                    instance.setVariable<float>("z", k * 2.0f);
+                }
+            }
+        }
+        cudaSimulation.setPopulationData(population);
+    }
+
+    // Execute a single step of the model
+    cudaSimulation.step();
+
+    // Recover the results and check they match what was expected
+    cudaSimulation.getPopulationData(population);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : population) {
+        EXPECT_EQ(0.0f, ai.getVariable<float>("result_x"));
+        EXPECT_EQ(0.0f, ai.getVariable<float>("result_y"));
+        EXPECT_EQ(0.0f, ai.getVariable<float>("result_z"));
+        EXPECT_EQ(0u, ai.getVariable<unsigned int>("badCount"));
+        EXPECT_EQ(27u, ai.getVariable<unsigned int>("count"));
+    }
+}
 }  // namespace test_message_spatial3d
 }  // namespace flamegpu


### PR DESCRIPTION
Python Circles 2D wrapped example [here](https://gist.github.com/Robadob/afabd42efc736366b390e74d9b80d6d1).

Currently `operator++()` only returns messages within the search radius, **this is different to regular spatial messages**.
I'm kind of torn on whether to keep this behaviour which adds a redundant extra load of each location variable and caches the distance, or to revert back to non-wrapped behaviour and provide a distance function which users must pass 2-4 floats to for the result.

Not to sure what else can be tested, just feels like it probably needs more.

Docs might need some minor redrafting, didn't feel too clean.

Haven't added an example to the main repo (there's already too much bloat with multiple versions of circles).

Docs PR: https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/90


Closes #185