### PR TITLE
Extend logging to allow inclusion of timing data.

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -427,8 +427,9 @@ class CUDASimulation : public Simulation {
     /**
      * Check if step_count is a divisible by step_log_config.frequency
      * If true, add the current simulation state to the step log
+     * @param step_time_seconds Duration of the step to be logged in seconds
      */
-    void processStepLog();
+    void processStepLog(const double &step_time_seconds);
     /**
      * Replace the current exit log with the current simulation state
      */

--- a/include/flamegpu/io/JSONLogger.h
+++ b/include/flamegpu/io/JSONLogger.h
@@ -9,6 +9,8 @@
 
 namespace flamegpu {
 struct RunLog;
+struct StepLogFrame;
+struct ExitLogFrame;
 struct LogFrame;
 class RunPlan;
 
@@ -24,24 +26,24 @@ class JSONLogger : public Logger{
      * Log a runlog to file, using a RunPlan in place of config
      * @throws May throw exceptions if logging to file failed for any reason
      */
-    void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true) const override;
+    void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true, bool logStepTime = false, bool logExitTime = false) const override;
     /**
      * Log a runlog to file, uses config data (random seed) from the RunLog
      * @throws May throw exceptions if logging to file failed for any reason
      */
-    void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true) const override;
+    void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true, bool logStepTime = false, bool logExitTime = false) const override;
 
  private:
     /**
      * Internal logging method, allows Plan to be passed as null
      */
-    void logCommon(const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit) const;
+    void logCommon(const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit, bool logStepTime, bool logExitTime) const;
     /**
      * rapidjson::Writer doesn't have virtual methods, so can't pass rapidjson::PrettyWriter around as ptr to rapidjson::writer
      * Instead we call a templated version of all the methods
      */
     template<typename T>
-    void logCommon(T &writer, const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit) const;
+    void logCommon(T &writer, const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit, bool logStepTime, bool logExitTime) const;
     /**
      * Writes out the run config via a JSON object
      * @param writer Rapidjson writer instance
@@ -63,21 +65,52 @@ class JSONLogger : public Logger{
     /**
      * Writes out step logs as a JSON array via the provided writer
      * @param writer Rapidjson writer instance
-     * @param log RunLog containing the step logs to be written
+     * @param log RunLog containing the config items to be written
      * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
      * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
      */
     template<typename T>
-    void logSteps(T &writer, const RunLog &log) const;
+    void logPerformanceSpecs(T& writer, const RunLog& log) const;
+    /**
+     * Writes out step logs as a JSON array via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param log RunLog containing the step logs to be written
+     * @param logTime Include time in the log to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void logSteps(T &writer, const RunLog &log, bool logTime) const;
     /**
      * Writes out an exit log as a JSON object via the provided writer
      * @param writer Rapidjson writer instance
      * @param log RunLog containing the exit log to be written
+     * @param logTime Include time in the log to be written
      * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
      * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
      */
     template<typename T>
-    void logExit(T &writer, const RunLog &log) const;
+    void logExit(T &writer, const RunLog &log, bool logTime) const;
+    /**
+     * Writes out an StepLogFrame instance as a JSON object via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param log LogFrame to be written
+     * @param logTime Include time in the log to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void writeLogFrame(T &writer, const StepLogFrame&log, bool logTime) const;
+    /**
+     * Writes out an ExitLogFrame instance as a JSON object via the provided writer
+     * @param writer Rapidjson writer instance
+     * @param log LogFrame to be written
+     * @param logTime Include time in the log to be written
+     * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
+     * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
+     */
+    template<typename T>
+    void writeLogFrame(T& writer, const ExitLogFrame& log, bool logTime) const;
     /**
      * Writes out a LogFrame instance as a JSON object via the provided writer
      * @param writer Rapidjson writer instance
@@ -86,7 +119,7 @@ class JSONLogger : public Logger{
      * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
      */
     template<typename T>
-    void writeLogFrame(T &writer, const LogFrame &log) const;
+    void writeCommonLogFrame(T& writer, const LogFrame& log) const;
     /**
      * Writes out the value of an Any via the provided writer
      * @param writer Rapidjson writer instance

--- a/include/flamegpu/io/Logger.h
+++ b/include/flamegpu/io/Logger.h
@@ -20,12 +20,12 @@ class Logger {
      * Log a runlog to file, using a RunPlan in place of config
      * @throws May throw exceptions if logging to file failed for any reason
      */
-    virtual void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true) const = 0;
+    virtual void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true, bool logStepTime = false, bool logExitTime = false) const = 0;
     /**
      * Log a runlog to file, uses config data (random seed) from the RunLog
      * @throws May throw exceptions if logging to file failed for any reason
      */
-    virtual void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true) const = 0;
+    virtual void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true, bool logStepTime = false, bool logExitTime = false) const = 0;
 };
 }  // namespace io
 }  // namespace flamegpu

--- a/include/flamegpu/io/XMLLogger.h
+++ b/include/flamegpu/io/XMLLogger.h
@@ -16,6 +16,8 @@ class XMLElement;
 namespace flamegpu {
 
 struct RunLog;
+struct StepLogFrame;
+struct ExitLogFrame;
 struct LogFrame;
 class RunPlan;
 
@@ -30,18 +32,18 @@ class XMLLogger : public Logger{
      * Log a runlog to file, using a RunPlan in place of config
      * @throws May throw exceptions if logging to file failed for any reason
      */
-    void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true) const override;
+    void log(const RunLog &log, const RunPlan &plan, bool logSteps = true, bool logExit = true, bool logStepTime = false, bool logExitTime = false) const override;
     /**
      * Log a runlog to file, uses config data (random seed) from the RunLog
      * @throws May throw exceptions if logging to file failed for any reason
      */
-    void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true) const override;
+    void log(const RunLog &log, bool logConfig = true, bool logSteps = true, bool logExit = true, bool logStepTime = false, bool logExitTime = false) const override;
 
  private:
     /**
      * Internal logging method, allows Plan to be passed as null
      */
-    void logCommon(const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit) const;
+    void logCommon(const RunLog &log, const RunPlan *plan, bool logConfig, bool logSteps, bool logExit, bool logStepTime, bool logExitTime) const;
     /**
      * Writes out the run config via a JSON object to the provided node
      * @param doc tinyxml2 document used for allocating the new element
@@ -50,33 +52,59 @@ class XMLLogger : public Logger{
      */
     tinyxml2::XMLNode *logConfig(tinyxml2::XMLDocument &doc, const RunLog &log) const;
     /**
-     * Writes out step logs as a JSON array to the provided node
+     * Writes out RunPlan configuration (and environment overrides) as a JSON array to the provided node
      * @param doc tinyxml2 document used for allocating the new element
      * @param plan RunPlan containing the config items to be written
      * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
      */
     tinyxml2::XMLNode *logConfig(tinyxml2::XMLDocument &doc, const RunPlan &plan) const;
     /**
+     * Writes out performance specifications as a JSON array to the provided node
+     * @param doc tinyxml2 document used for allocating the new element
+     * @param log RunLog containing the performance spec items to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode* logPerformanceSpecs(tinyxml2::XMLDocument& doc, const RunLog& log) const;
+    /**
      * Writes out step logs as a JSON array to the provided node
      * @param doc tinyxml2 document used for allocating the new element
      * @param log RunLog containing the step logs to be written
+     * @param logTime True if the time is to be included in the log
      * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
      */
-    tinyxml2::XMLNode *logSteps(tinyxml2::XMLDocument &doc, const RunLog &log) const;
+    tinyxml2::XMLNode *logSteps(tinyxml2::XMLDocument &doc, const RunLog &log, bool logTime) const;
     /**
      * Writes out an exit log as a JSON object to the provided node
      * @param doc tinyxml2 document used for allocating the new element
      * @param log RunLog containing the exit log to be written
+     * @param logTime True if the time is to be included in the log
      * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
      */
-    tinyxml2::XMLNode *logExit(tinyxml2::XMLDocument &doc, const RunLog &log) const;
+    tinyxml2::XMLNode *logExit(tinyxml2::XMLDocument &doc, const RunLog &log, bool logTime) const;
     /**
-     * Writes out a LogFrame instance as a JSON object to the provided node
+     * Writes out a StepLogFrame instance as XML and returns the created node
      * @param doc tinyxml document to append the log frame to
      * @param log LogFrame to be written
+     * @param logTime True if the time is to be included in the log
      * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
      */
-    tinyxml2::XMLNode *writeLogFrame(tinyxml2::XMLDocument &doc, const LogFrame &log) const;
+    tinyxml2::XMLNode *writeLogFrame(tinyxml2::XMLDocument &doc, const StepLogFrame &log, bool logTime) const;
+    /**
+     * Writes out a ExitLogFrame instance as XML and returns the created node
+     * @param doc tinyxml document to append the log frame to
+     * @param log LogFrame to be written
+     * @param logTime True if the time is to be included in the log
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    tinyxml2::XMLNode* writeLogFrame(tinyxml2::XMLDocument& doc, const ExitLogFrame& log, bool logTime) const;
+    /**
+     * Writes out a LogFrame data to the provided node
+     * @param doc tinyxml document to append the log frame to
+     * @param pFrameElement tinyxml document to append the log frame to
+     * @param frame LogFrame to be written
+     * @return The created XMLNode, the calling method will then add it to the main XML hierarchy
+     */
+    void writeCommonLogFrame(tinyxml2::XMLDocument& doc, tinyxml2::XMLElement* pFrameElement, const LogFrame& frame) const;
     /**
      * Writes out the value of an Any to the provided node
      * @param element The element to set the value of

--- a/include/flamegpu/sim/LoggingConfig.h
+++ b/include/flamegpu/sim/LoggingConfig.h
@@ -35,6 +35,10 @@ class LoggingConfig {
      * CUDASimulation::processStepLog() Requires access for reading the config
      */
     friend class CUDASimulation;
+    /**
+     * Requires access to log_timing
+     */
+    friend void CUDAEnsemble::simulate(const RunPlanVector& plans);
 
  public:
     /**
@@ -114,6 +118,14 @@ class LoggingConfig {
      * @throws InvalidEnvironment
      */
     void logEnvironment(const std::string &property_name);
+    /**
+     * Log timing information for the complete simulation to file
+     * In the case of step log, this will cause the step time to be logged
+     * @param doLogTiming True if timing data should be logged
+     * @note By default, timing information is not logged to file
+     * @note Timing information will always be available in the programmatic logs accessed via code
+     */
+    void logTiming(bool doLogTiming);
 
  private:
     /**
@@ -129,6 +141,10 @@ class LoggingConfig {
      * map<<agent_name:agent_state, variable_reductions:log_count>
      */
     std::map<util::StringPair, std::pair<std::shared_ptr<std::set<NameReductionFn>>, bool>> agents;
+    /**
+     * Flag denoting whether timing information for the simulation/steps should be logged
+     */
+    bool log_timing;
 };
 
 /**

--- a/include/flamegpu/sim/SimLogger.h
+++ b/include/flamegpu/sim/SimLogger.h
@@ -30,6 +30,8 @@ class SimLogger {
      * @param log_export_queue_cdn The condition is notified every time a log has been added to the queue
      * @param _export_step If true step logs will be exported
      * @param _export_exit If true exit logs will be exported
+     * @param _export_step_time If true step log time will be exported
+     * @param _export_exit_time If true exit log time will be exported
      */
     SimLogger(const std::vector<RunLog> &run_logs,
         const RunPlanVector &run_plans,
@@ -39,7 +41,9 @@ class SimLogger {
         std::mutex &log_export_queue_mutex,
         std::condition_variable &log_export_queue_cdn,
         bool _export_step,
-        bool _export_exit);
+        bool _export_exit,
+        bool _export_step_time,
+        bool _export_exit_time);
     /**
      * The thread which the logger is executing on, created by the constructor
      */
@@ -85,6 +89,14 @@ class SimLogger {
      * If true exit log files will be exported
      */
     bool export_exit;
+    /**
+     * If true step time will be included in the step log file
+     */
+    bool export_step_time;
+    /**
+     * If true exit time will be included in the exit log file
+     */
+    bool export_exit_time;
 };
 
 }  // namespace flamegpu

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -106,10 +106,12 @@ class Simulation {
      * @param path The file to output (must end '.json' or '.xml')
      * @param steps Whether the step log should be included in the log file
      * @param exit Whether the exit log should be included in the log file
+     * @param stepTime Whether the step time should be included in the log file (always treated as false if steps=false)
+     * @param exitTime Whether the simulation time should be included in the log file (always treated as false if exit=false)
      * @param prettyPrint Whether the log file should be minified or not
      * @note The config (possibly just random seed) is always output
      */
-    void exportLog(const std::string &path, bool steps, bool exit, bool prettyPrint = true);
+    void exportLog(const std::string &path, bool steps, bool exit, bool stepTime, bool exitTime, bool prettyPrint = true);
 
     virtual void setPopulationData(AgentVector& population, const std::string& state_name = ModelData::DEFAULT_STATE) = 0;
     virtual void getPopulationData(AgentVector& population, const std::string& state_name = ModelData::DEFAULT_STATE) = 0;

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -129,7 +129,7 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
     // Init log worker
     SimLogger *log_worker = nullptr;
     if (!config.out_directory.empty() && !config.out_format.empty()) {
-        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, step_log_config.get(), exit_log_config.get());
+        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, step_log_config.get(), exit_log_config.get(), step_log_config && step_log_config->log_timing, exit_log_config->log_timing);
     } else if (!config.out_directory.empty() ^ !config.out_format.empty())  {
         fprintf(stderr, "Warning: Only 1 of out_directory and out_format is set, both must be set for logging to commence to file.\n");
     }

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -129,7 +129,8 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
     // Init log worker
     SimLogger *log_worker = nullptr;
     if (!config.out_directory.empty() && !config.out_format.empty()) {
-        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, step_log_config.get(), exit_log_config.get(), step_log_config && step_log_config->log_timing, exit_log_config->log_timing);
+        log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn,
+        step_log_config.get(), exit_log_config.get(), step_log_config && step_log_config->log_timing, exit_log_config && exit_log_config->log_timing);
     } else if (!config.out_directory.empty() ^ !config.out_format.empty())  {
         fprintf(stderr, "Warning: Only 1 of out_directory and out_format is set, both must be set for logging to commence to file.\n");
     }

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1182,7 +1182,6 @@ void CUDASimulation::simulate() {
         // Run the step
         bool continueSimulation = step();
         if (!continueSimulation) {
-            processStepLog(this->elapsedSecondsPerStep.back());
             break;
         }
         #ifdef VISUALISATION

--- a/src/flamegpu/io/JSONLogger.cu
+++ b/src/flamegpu/io/JSONLogger.cu
@@ -18,11 +18,11 @@ JSONLogger::JSONLogger(const std::string &outPath, bool _prettyPrint, bool _trun
     , prettyPrint(_prettyPrint)
     , truncateFile(_truncateFile) { }
 
-void JSONLogger::log(const RunLog &log, const RunPlan &plan, bool logSteps, bool logExit) const {
-  logCommon(log, &plan, false, logSteps, logExit);
+void JSONLogger::log(const RunLog &log, const RunPlan &plan, bool logSteps, bool logExit, bool logStepTime, bool logExitTime) const {
+  logCommon(log, &plan, false, logSteps, logExit, logStepTime, logExitTime);
 }
-void JSONLogger::log(const RunLog &log, bool logConfig, bool logSteps, bool logExit) const {
-  logCommon(log, nullptr, logConfig, logSteps, logExit);
+void JSONLogger::log(const RunLog &log, bool logConfig, bool logSteps, bool logExit, bool logStepTime, bool logExitTime) const {
+  logCommon(log, nullptr, logConfig, logSteps, logExit, logStepTime, logExitTime);
 }
 
 template<typename T>
@@ -65,85 +65,111 @@ void JSONLogger::writeAny(T &writer, const util::Any &value, const unsigned int 
     }
 }
 template<typename T>
-void JSONLogger::writeLogFrame(T &writer, const LogFrame &frame) const {
+void JSONLogger::writeLogFrame(T& writer, const StepLogFrame& frame, bool logTime) const {
     writer.StartObject();
     {
-        // Add static items
-        writer.Key("step_index");
-        writer.Uint(frame.getStepCount());
-        if (frame.getEnvironment().size()) {
-            // Add dynamic environment values
-            writer.Key("environment");
-            writer.StartObject();
-            {
-                for (const auto &prop : frame.getEnvironment()) {
-                    writer.Key(prop.first.c_str());
-                    // Log value
-                    writeAny(writer, prop.second, prop.second.elements);
-                }
-            }
-            writer.EndObject();
+        if (logTime) {
+            writer.Key("step_time");
+            writer.Double(frame.getStepTime());
         }
-
-        if (frame.getAgents().size()) {
-            // Add dynamic agent values
-            writer.Key("agents");
-            writer.StartObject();
-            {
-                // This assumes that sort order places all agents of same name, different state consecutively
-                std::string current_agent;
-                for (const auto &agent : frame.getAgents()) {
-                    // Start/end new agent
-                    if (current_agent != agent.first.first) {
-                        if (!current_agent.empty())
-                            writer.EndObject();
-                        current_agent = agent.first.first;
-                        writer.Key(current_agent.c_str());
-                        writer.StartObject();
-                    }
-                    // Start new state
-                    writer.Key(agent.first.second.c_str());
-                    writer.StartObject();
-                    {
-                        // Log agent count if provided
-                        if (agent.second.second != UINT_MAX) {
-                            writer.Key("count");
-                            writer.Uint(agent.second.second);
-                        }
-                        if (agent.second.first.size()) {
-                            writer.Key("variables");
-                            writer.StartObject();
-                            // This assumes that sort order places all variables of same name, different reduction consecutively
-                            std::string current_variable;
-                            // Log each reduction
-                            for (auto &var : agent.second.first) {
-                                // Start/end new variable
-                                if (current_variable != var.first.name) {
-                                    if (!current_variable.empty())
-                                        writer.EndObject();
-                                    current_variable = var.first.name;
-                                    writer.Key(current_variable.c_str());
-                                    writer.StartObject();
-                                }
-                                // Build name key for the variable
-                                writer.Key(LoggingConfig::toString(var.first.reduction));
-                                // Log value
-                                writeAny(writer, var.second, 1);
-                            }
-                            if (!current_variable.empty())
-                                writer.EndObject();
-                            writer.EndObject();
-                        }
-                    }
-                    writer.EndObject();
-                }
-                if (!current_agent.empty())
-                    writer.EndObject();
-            }
-            writer.EndObject();
-        }
+        writeCommonLogFrame(writer, frame);
     }
     writer.EndObject();
+}
+template<typename T>
+void JSONLogger::writeLogFrame(T& writer, const ExitLogFrame& frame, bool logTime) const {
+    writer.StartObject();
+    {
+        if (logTime) {
+            writer.Key("rtc_time");
+            writer.Double(frame.getRTCTime());
+            writer.Key("init_time");
+            writer.Double(frame.getInitTime());
+            writer.Key("exit_time");
+            writer.Double(frame.getExitTime());
+            writer.Key("total_time");
+            writer.Double(frame.getTotalTime());
+        }
+        writeCommonLogFrame(writer, frame);
+    }
+    writer.EndObject();
+}
+template<typename T>
+void JSONLogger::writeCommonLogFrame(T &writer, const LogFrame &frame) const {
+    // Add static items
+    writer.Key("step_index");
+    writer.Uint(frame.getStepCount());
+    if (frame.getEnvironment().size()) {
+        // Add dynamic environment values
+        writer.Key("environment");
+        writer.StartObject();
+        {
+            for (const auto &prop : frame.getEnvironment()) {
+                writer.Key(prop.first.c_str());
+                // Log value
+                writeAny(writer, prop.second, prop.second.elements);
+            }
+        }
+        writer.EndObject();
+    }
+
+    if (frame.getAgents().size()) {
+        // Add dynamic agent values
+        writer.Key("agents");
+        writer.StartObject();
+        {
+            // This assumes that sort order places all agents of same name, different state consecutively
+            std::string current_agent;
+            for (const auto &agent : frame.getAgents()) {
+                // Start/end new agent
+                if (current_agent != agent.first.first) {
+                    if (!current_agent.empty())
+                        writer.EndObject();
+                    current_agent = agent.first.first;
+                    writer.Key(current_agent.c_str());
+                    writer.StartObject();
+                }
+                // Start new state
+                writer.Key(agent.first.second.c_str());
+                writer.StartObject();
+                {
+                    // Log agent count if provided
+                    if (agent.second.second != UINT_MAX) {
+                        writer.Key("count");
+                        writer.Uint(agent.second.second);
+                    }
+                    if (agent.second.first.size()) {
+                        writer.Key("variables");
+                        writer.StartObject();
+                        // This assumes that sort order places all variables of same name, different reduction consecutively
+                        std::string current_variable;
+                        // Log each reduction
+                        for (auto &var : agent.second.first) {
+                            // Start/end new variable
+                            if (current_variable != var.first.name) {
+                                if (!current_variable.empty())
+                                    writer.EndObject();
+                                current_variable = var.first.name;
+                                writer.Key(current_variable.c_str());
+                                writer.StartObject();
+                            }
+                            // Build name key for the variable
+                            writer.Key(LoggingConfig::toString(var.first.reduction));
+                            // Log value
+                            writeAny(writer, var.second, 1);
+                        }
+                        if (!current_variable.empty())
+                            writer.EndObject();
+                        writer.EndObject();
+                    }
+                }
+                writer.EndObject();
+            }
+            if (!current_agent.empty())
+                writer.EndObject();
+        }
+        writer.EndObject();
+    }
 }
 
 template<typename T>
@@ -181,24 +207,45 @@ void JSONLogger::logConfig(T &writer, const RunPlan &plan) const {
     writer.EndObject();
 }
 template<typename T>
-void JSONLogger::logSteps(T &writer, const RunLog &log) const {
+void JSONLogger::logPerformanceSpecs(T& writer, const RunLog& log) const {
+    writer.Key("performance_specs");
+    writer.StartObject();
+    {
+        // Add static items
+        writer.Key("device_name");
+        writer.String(log.getPerformanceSpecs().device_name.c_str());
+        writer.Key("device_cc_major");
+        writer.Int(log.getPerformanceSpecs().device_cc_major);
+        writer.Key("device_cc_minor");
+        writer.Int(log.getPerformanceSpecs().device_cc_minor);
+        writer.Key("cuda_version");
+        writer.Int(log.getPerformanceSpecs().cuda_version);
+        writer.Key("seatbelts");
+        writer.Bool(log.getPerformanceSpecs().seatbelts);
+        writer.Key("flamegpu_version");
+        writer.String(log.getPerformanceSpecs().flamegpu_version.c_str());
+    }
+    writer.EndObject();
+}
+template<typename T>
+void JSONLogger::logSteps(T &writer, const RunLog &log, bool logTime) const {
     writer.Key("steps");
     writer.StartArray();
     {
         for (const auto &step : log.getStepLog()) {
-            writeLogFrame(writer, step);
+            writeLogFrame(writer, step, logTime);
         }
     }
     writer.EndArray();
 }
 template<typename T>
-void JSONLogger::logExit(T &writer, const RunLog &log) const {
+void JSONLogger::logExit(T &writer, const RunLog &log, bool logTime) const {
     writer.Key("exit");
-    writeLogFrame(writer, log.getExitLog());
+    writeLogFrame(writer, log.getExitLog(), logTime);
 }
 
 template<typename T>
-void JSONLogger::logCommon(T &writer, const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit) const {
+void JSONLogger::logCommon(T &writer, const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit, bool doLogStepTime, bool doLogExitTime) const {
     // Begin json output object
     writer->StartObject();
     {
@@ -208,32 +255,35 @@ void JSONLogger::logCommon(T &writer, const RunLog &log, const RunPlan *plan, bo
         } else if (doLogConfig) {
             logConfig(*writer, log);
         }
+        if (doLogStepTime || doLogExitTime) {
+            logPerformanceSpecs(*writer, log);
+        }
 
         // Log step log
         if (doLogSteps) {
-            logSteps(*writer, log);
+            logSteps(*writer, log, doLogStepTime);
         }
 
         // Log exit log
         if (doLogExit) {
-            logExit(*writer, log);
+            logExit(*writer, log, doLogExitTime);
         }
     }
     // End Json file
     writer->EndObject();
 }
-void JSONLogger::logCommon(const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit) const {
+void JSONLogger::logCommon(const RunLog &log, const RunPlan *plan, bool doLogConfig, bool doLogSteps, bool doLogExit, bool doLogStepTime, bool doLogExitTime) const {
     // Init writer
     rapidjson::StringBuffer s;
     if (prettyPrint) {
         // rapidjson::Writer doesn't have virtual methods, so can't pass rapidjson::PrettyWriter around as ptr to rapidjson::writer
         rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer = new rapidjson::PrettyWriter<rapidjson::StringBuffer>(s);
         writer->SetIndent('\t', 1);
-        logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit);
+        logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit, doLogStepTime, doLogExitTime);
         delete writer;
     } else {
         rapidjson::Writer<rapidjson::StringBuffer> *writer = new rapidjson::Writer<rapidjson::StringBuffer>(s);
-        logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit);
+        logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit, doLogStepTime, doLogExitTime);
         delete writer;
     }
     // Perform output

--- a/src/flamegpu/io/XMLLogger.cu
+++ b/src/flamegpu/io/XMLLogger.cu
@@ -169,9 +169,7 @@ tinyxml2::XMLNode *XMLLogger::logSteps(tinyxml2::XMLDocument &doc, const RunLog 
     return pStepsElement;
 }
 tinyxml2::XMLNode *XMLLogger::logExit(tinyxml2::XMLDocument &doc, const RunLog &log, bool logTime) const {
-    tinyxml2::XMLElement *pExitElement = doc.NewElement("exit");
-    pExitElement->InsertEndChild(writeLogFrame(doc, log.getExitLog(), logTime));
-    return pExitElement;
+    return writeLogFrame(doc, log.getExitLog(), logTime);
 }
 tinyxml2::XMLNode* XMLLogger::writeLogFrame(tinyxml2::XMLDocument& doc, const StepLogFrame& frame, bool logTime) const {
     tinyxml2::XMLElement* pFrameElement = doc.NewElement("step");

--- a/src/flamegpu/sim/LogFrame.cu
+++ b/src/flamegpu/sim/LogFrame.cu
@@ -6,8 +6,8 @@ LogFrame::LogFrame()
     : step_count(0) { }
 
 
-LogFrame::LogFrame(const std::map<std::string, util::Any> &&_environment,
-const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>> &&_agents,
+LogFrame::LogFrame(const std::map<std::string, util::Any> &_environment,
+const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>> &_agents,
 const unsigned int &_step_count)
     : environment(_environment)
     , agents(_agents)
@@ -58,5 +58,33 @@ double AgentLogFrame::getStandardDev(const std::string &variable_name) const {
     }
     return *static_cast<double *>(it->second.ptr);
 }
+
+StepLogFrame::StepLogFrame()
+    : LogFrame()
+    , step_time(0.0) { }
+
+
+StepLogFrame::StepLogFrame(const std::map<std::string, util::Any>&& _environment,
+    const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>>&& _agents,
+    const unsigned int& _step_count)
+    : LogFrame(_environment, _agents, _step_count)
+    , step_time(0.0) { }
+
+ExitLogFrame::ExitLogFrame()
+    : LogFrame()
+    , rtc_time(0.0)
+    , init_time(0.0)
+    , exit_time(0.0)
+    , total_time(0.0) { }
+
+
+ExitLogFrame::ExitLogFrame(const std::map<std::string, util::Any>&& _environment,
+    const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>>&& _agents,
+    const unsigned int& _step_count)
+    : LogFrame(_environment, _agents, _step_count)
+    , rtc_time(0.0)
+    , init_time(0.0)
+    , exit_time(0.0)
+    , total_time(0.0) { }
 
 }  // namespace flamegpu

--- a/src/flamegpu/sim/LoggingConfig.cu
+++ b/src/flamegpu/sim/LoggingConfig.cu
@@ -8,13 +8,16 @@
 namespace flamegpu {
 
 LoggingConfig::LoggingConfig(const ModelDescription &_model)
-    :model(_model.model->clone()) { }
+    :model(_model.model->clone())
+    , log_timing(false) { }
 LoggingConfig::LoggingConfig(const ModelData &_model)
-    :model(_model.clone()) { }
+    :model(_model.clone())
+    , log_timing(false) { }
 LoggingConfig::LoggingConfig(const LoggingConfig &other)
     : model(other.model->clone())
     , environment(other.environment)
-    , agents(other.agents) { }
+    , agents(other.agents)
+    , log_timing(other.log_timing) { }
 AgentLoggingConfig LoggingConfig::agent(const std::string &agent_name, const std::string &agent_state) {
     // Validate the agent state combination exists
     auto model_agent_it = model->agents.find(agent_name);
@@ -49,6 +52,9 @@ void LoggingConfig::logEnvironment(const std::string &property_name) {
             "in LoggingConfig::logEnvironment()\n",
             property_name.c_str());
     }
+}
+void LoggingConfig::logTiming(bool doLogTiming) {
+    log_timing = doLogTiming;
 }
 StepLoggingConfig::StepLoggingConfig(const ModelDescription &model)
     : LoggingConfig(model)

--- a/src/flamegpu/sim/SimLogger.cu
+++ b/src/flamegpu/sim/SimLogger.cu
@@ -34,7 +34,9 @@ SimLogger::SimLogger(const std::vector<RunLog> &_run_logs,
         std::mutex &_log_export_queue_mutex,
         std::condition_variable &_log_export_queue_cdn,
         bool _export_step,
-        bool _export_exit)
+        bool _export_exit,
+        bool _export_step_time,
+        bool _export_exit_time)
     : run_logs(_run_logs)
     , run_plans(_run_plans)
     , out_directory(_out_directory)
@@ -43,7 +45,9 @@ SimLogger::SimLogger(const std::vector<RunLog> &_run_logs,
     , log_export_queue_mutex(_log_export_queue_mutex)
     , log_export_queue_cdn(_log_export_queue_cdn)
     , export_step(_export_step)
-    , export_exit(_export_exit) {
+    , export_exit(_export_exit)
+    , export_step_time(_export_step_time)
+    , export_exit_time(_export_exit_time) {
     this->thread = std::thread(&SimLogger::start, this);
     // Attempt to name the thread
 #ifdef _MSC_VER
@@ -85,12 +89,12 @@ void SimLogger::start() {
             if (export_exit) {
                 const path exit_path = p_out_directory / path(run_plans[target_log].getOutputSubdirectory()) / path("exit." + out_format);
                 const auto exit_logger = io::LoggerFactory::createLogger(exit_path.generic_string(), false, false);
-                exit_logger->log(run_logs[target_log], true, false, true);
+                exit_logger->log(run_logs[target_log], true, false, true, false, export_exit_time);
             }
             if (export_step) {
                 const path step_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path(std::to_string(target_log)+"."+out_format);
                 const auto step_logger = io::LoggerFactory::createLogger(step_path.generic_string(), false, false);
-                step_logger->log(run_logs[target_log], true, true, false);
+                step_logger->log(run_logs[target_log], true, true, false, export_step_time, false);
             }
             // Continue
             ++logs_processed;

--- a/src/flamegpu/sim/SimLogger.cu
+++ b/src/flamegpu/sim/SimLogger.cu
@@ -89,12 +89,12 @@ void SimLogger::start() {
             if (export_exit) {
                 const path exit_path = p_out_directory / path(run_plans[target_log].getOutputSubdirectory()) / path("exit." + out_format);
                 const auto exit_logger = io::LoggerFactory::createLogger(exit_path.generic_string(), false, false);
-                exit_logger->log(run_logs[target_log], true, false, true, false, export_exit_time);
+                exit_logger->log(run_logs[target_log], run_plans[target_log], false, true, false, export_exit_time);
             }
             if (export_step) {
                 const path step_path = p_out_directory/path(run_plans[target_log].getOutputSubdirectory())/path(std::to_string(target_log)+"."+out_format);
                 const auto step_logger = io::LoggerFactory::createLogger(step_path.generic_string(), false, false);
-                step_logger->log(run_logs[target_log], true, true, false, export_step_time, false);
+                step_logger->log(run_logs[target_log], run_plans[target_log], true, false, export_step_time, false);
             }
             // Continue
             ++logs_processed;

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -133,11 +133,11 @@ void Simulation::exportData(const std::string &path, bool prettyPrint) {
     io::StateWriter *write__ = io::StateWriterFactory::createWriter(model->name, getInstanceID(), pops, getStepCounter(), path, this);
     write__->writeStates(prettyPrint);
 }
-void Simulation::exportLog(const std::string &path, bool steps, bool exit, bool prettyPrint) {
+void Simulation::exportLog(const std::string &path, bool steps, bool exit, bool stepTime, bool exitTime, bool prettyPrint) {
     // Create the correct type of logger
     auto logger = io::LoggerFactory::createLogger(path, prettyPrint, config.truncate_log_files);
     // Perform logging
-    logger->log(getRunLog(), true, steps, exit);
+    logger->log(getRunLog(), true, steps, exit, stepTime, exitTime);
 }
 
 int Simulation::checkArgs(int argc, const char** argv) {

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -1,3 +1,5 @@
+#include <chrono>
+#include <thread>
 // If earlier than VS 2019
 #if defined(_MSC_VER) && _MSC_VER < 1920
 #include <filesystem>
@@ -46,6 +48,9 @@ FLAMEGPU_STEP_FUNCTION(step_fn1) {
     FLAMEGPU->environment.setProperty<int, 3>("int_prop_array", {b[0] + 1, b[1] + 1, b[2] + 1});
     FLAMEGPU->environment.setProperty<unsigned int, 4>("uint_prop_array", {c[0] + 1, c[1] + 1, c[2] + 1, c[3] + 1});
 }
+FLAMEGPU_HOST_FUNCTION(Sleep_100_Milliseconds) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}
 template<typename T>
 void logAllAgent(AgentLoggingConfig &alcfg, const std::string &var_name) {
     alcfg.logMin<T>(var_name);
@@ -88,6 +93,7 @@ TEST(LoggingTest, CUDASimulationStep) {
     lcfg.logEnvironment("float_prop_array");
     lcfg.logEnvironment("int_prop_array");
     lcfg.logEnvironment("uint_prop_array");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -202,6 +208,7 @@ TEST(LoggingTest, CUDASimulationSimulate) {
     lcfg.logEnvironment("float_prop_array");
     lcfg.logEnvironment("int_prop_array");
     lcfg.logEnvironment("uint_prop_array");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -412,6 +419,7 @@ TEST(LoggingTest, CUDAEnsembleSimulate) {
     lcfg.logEnvironment("float_prop_array");
     lcfg.logEnvironment("int_prop_array");
     lcfg.logEnvironment("uint_prop_array");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -571,6 +579,7 @@ TEST(TestLogging, Simulation_ToFile_Step) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -631,6 +640,7 @@ TEST(TestLogging, Simulation_ToFile_Exit) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -691,6 +701,7 @@ TEST(TestLogging, Simulation_ToFile_Common) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -742,6 +753,7 @@ TEST(TestLogging, Simulation_ToFile_All) {
     a.newVariable<unsigned int>("uint_var");
     AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
     m.newLayer().addAgentFunction(f1);
+    m.addStepFunction(Sleep_100_Milliseconds);
 
     // Define logging configs
     LoggingConfig lcfg(m);
@@ -750,6 +762,7 @@ TEST(TestLogging, Simulation_ToFile_All) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -812,6 +825,7 @@ TEST(TestLogging, Ensemble_ToFile_Step) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -872,6 +886,7 @@ TEST(TestLogging, Ensemble_ToFile_Exit) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);
@@ -927,6 +942,7 @@ TEST(TestLogging, Ensemble_ToFile_All) {
     a.newVariable<unsigned int>("uint_var");
     AgentFunctionDescription& f1 = a.newFunction(FUNCTION_NAME1, agent_fn1);
     m.newLayer().addAgentFunction(f1);
+    m.addStepFunction(Sleep_100_Milliseconds);
     m.addInitFunction(logging_ensemble_init);
     m.Environment().newProperty<int>("instance_id", 0);  // This will act as the modifier for ensemble instances, only impacting the init fn
 
@@ -937,6 +953,7 @@ TEST(TestLogging, Ensemble_ToFile_All) {
     logAllAgent<float>(alcfg, "float_var");
     logAllAgent<int>(alcfg, "int_var");
     logAllAgent<unsigned int>(alcfg, "uint_var");
+    lcfg.logTiming(true);
 
     StepLoggingConfig slcfg(lcfg);
     slcfg.setFrequency(2);

--- a/tests/test_cases/io/test_logging_exceptions.cu
+++ b/tests/test_cases/io/test_logging_exceptions.cu
@@ -19,9 +19,9 @@ TEST(LoggingExceptionTest, LoggerSupportedFileType) {
     ModelDescription m(MODEL_NAME);
     m.newAgent(AGENT_NAME1);
     CUDASimulation sim(m);
-    EXPECT_THROW(sim.exportLog("test.csv", true, true), exception::UnsupportedFileType);
-    EXPECT_THROW(sim.exportLog("test.html", true, true), exception::UnsupportedFileType);
-    EXPECT_NO_THROW(sim.exportLog("test.json", true, true));
+    EXPECT_THROW(sim.exportLog("test.csv", true, true, false, false), exception::UnsupportedFileType);
+    EXPECT_THROW(sim.exportLog("test.html", true, true, false, false), exception::UnsupportedFileType);
+    EXPECT_NO_THROW(sim.exportLog("test.json", true, true, false, false));
     // Cleanup
     ASSERT_EQ(::remove("test.json"), 0);
 }


### PR DESCRIPTION
Users are able to request time is included in the step or exit log, if either is selected a performance specs struct will be included in the log side besides config. Should work with ensemble logs too (these use a slightly different method to include `RunPlan` data).

The step log for step 0 includes the init function time.
The exit log only contains the full simulation time.

Exit function time, RTC layer time are never logged.

Also several bug fixes, see the individual commits.