### PR TITLE
Add support for automatically sorting agents with xy and xyz location vars

### DIFF
--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -436,6 +436,12 @@ void CUDASimulation::determineAgentsToSort() {
 void CUDASimulation::spatialSortAgent(const std::string& funcName, const std::string& agentName, const std::string& state, const int mode) {
     // Fetch the appropriate message name
     CUDAAgent& cuda_agent = getCUDAAgent(agentName);
+
+    const unsigned int state_list_size = cuda_agent.getStateSize(state);
+    // Can't sort no agents
+    if (!state_list_size)
+        return;
+
     auto& cudaAgentData = cuda_agent.getAgentDescription();
     auto& funcData = cudaAgentData.functions.at(funcName);
     std::string messageName;
@@ -492,7 +498,6 @@ void CUDASimulation::spatialSortAgent(const std::string& funcName, const std::st
     int blockSize = 0;  // The launch configurator returned block size
     int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
     int gridSize = 0;  // The actual grid size needed, based on input size
-    const unsigned int state_list_size = cuda_agent.getStateSize(state);
     cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, calculateSpatialHash, 0, state_list_size);
 
     //! Round up according to CUDAAgent state list size

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -175,6 +175,9 @@ CUDASimulation::CUDASimulation(const std::shared_ptr<SubModelData> &submodel_des
     // Submodels all run quiet/not verbose by default
     SimulationConfig().verbose = false;
     SimulationConfig().steps = submodel_desc->max_steps;
+
+    // Determine which agents will be spatially sorted
+    this->determineAgentsToSort();
 }
 
 CUDASimulation::~CUDASimulation() {

--- a/tests/test_cases/runtime/test_spatial_agent_sort.cu
+++ b/tests/test_cases/runtime/test_spatial_agent_sort.cu
@@ -10,7 +10,10 @@ namespace test_spatial_agent_sort {
 const unsigned int AGENT_COUNT = 4;
 
 // Function doesn't need to do anything, just needs to use spatial messaging
-FLAMEGPU_AGENT_FUNCTION(dummySpatialFunc, MessageSpatial3D, MessageNone) {
+FLAMEGPU_AGENT_FUNCTION(dummySpatialFunc_3D, MessageSpatial3D, MessageNone) {
+    return ALIVE;
+}
+FLAMEGPU_AGENT_FUNCTION(dummySpatialFunc_2D, MessageSpatial2D, MessageNone) {
     return ALIVE;
 }
 
@@ -28,7 +31,7 @@ TEST(AutomaticSpatialAgentSort, SortingDisabled) {
     locationMessage.setMin(-5, -5, -5);
     locationMessage.setMax(5, 5, 5);
     locationMessage.setRadius(0.2f);
-    AgentFunctionDescription& dummyFunc = agent.newFunction("dummySpatialFunc", dummySpatialFunc);
+    AgentFunctionDescription& dummyFunc = agent.newFunction("dummySpatialFunc", dummySpatialFunc_3D);
     dummyFunc.setMessageInput("location");
     LayerDescription& layer = model.newLayer();
     layer.addAgentFunction(dummyFunc);
@@ -73,7 +76,7 @@ TEST(AutomaticSpatialAgentSort, SortEveryStep) {
     locationMessage.setMin(-5, -5, -5);
     locationMessage.setMax(5, 5, 5);
     locationMessage.setRadius(0.2f);
-    AgentFunctionDescription& dummyFunc = agent.newFunction("dummySpatialFunc", dummySpatialFunc);
+    AgentFunctionDescription& dummyFunc = agent.newFunction("dummySpatialFunc", dummySpatialFunc_3D);
     dummyFunc.setMessageInput("location");
     LayerDescription& layer = model.newLayer();
     layer.addAgentFunction(dummyFunc);
@@ -102,6 +105,86 @@ TEST(AutomaticSpatialAgentSort, SortEveryStep) {
         finalOrder.push_back(instance.getVariable<int>("initial_order"));
     }
     std::vector<int> expectedResult {3, 2, 1, 0};
+    EXPECT_EQ(expectedResult, finalOrder);
+}
+
+// Initialises a reverse-sorted population and checks that it is correctly sorted after one step
+TEST(AutomaticSpatialAgentSort, SortEveryStep_vec2) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent");
+    agent.newVariable<int>("initial_order");
+    agent.newVariable<float, 2>("xy");
+    MessageSpatial2D::Description& locationMessage = model.newMessage<MessageSpatial2D>("location");
+    locationMessage.setMin(-5, -5);
+    locationMessage.setMax(5, 5);
+    locationMessage.setRadius(0.2f);
+    AgentFunctionDescription& dummyFunc = agent.newFunction("dummySpatialFunc", dummySpatialFunc_2D);
+    dummyFunc.setMessageInput("location");
+    LayerDescription& layer = model.newLayer();
+    layer.addAgentFunction(dummyFunc);
+
+    // Init pop
+    AgentVector pop(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentVector::Agent instance = pop[i];
+        instance.setVariable<int>("initial_order", i);
+        instance.setVariable<float, 2>("xy", { static_cast<float>(-i), static_cast<float>(-i)});
+    }
+
+    // Setup Model
+    CUDASimulation cudaSimulation(model);
+    cudaSimulation.setPopulationData(pop);
+
+    // Execute step fn
+    cudaSimulation.step();
+
+    // Check results
+    cudaSimulation.getPopulationData(pop);
+    std::vector<int> finalOrder;
+    for (AgentVector::Agent instance : pop) {
+        finalOrder.push_back(instance.getVariable<int>("initial_order"));
+    }
+    std::vector<int> expectedResult{ 3, 2, 1, 0 };
+    EXPECT_EQ(expectedResult, finalOrder);
+}
+TEST(AutomaticSpatialAgentSort, SortEveryStep_vec3) {
+    // Define model
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent");
+    agent.newVariable<int>("initial_order");
+    agent.newVariable<float, 3>("xyz");
+    MessageSpatial3D::Description& locationMessage = model.newMessage<MessageSpatial3D>("location");
+    locationMessage.setMin(-5, -5, -5);
+    locationMessage.setMax(5, 5, 5);
+    locationMessage.setRadius(0.2f);
+    AgentFunctionDescription& dummyFunc = agent.newFunction("dummySpatialFunc", dummySpatialFunc_3D);
+    dummyFunc.setMessageInput("location");
+    LayerDescription& layer = model.newLayer();
+    layer.addAgentFunction(dummyFunc);
+
+    // Init pop
+    AgentVector pop(agent, AGENT_COUNT);
+    for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
+        AgentVector::Agent instance = pop[i];
+        instance.setVariable<int>("initial_order", i);
+        instance.setVariable<float, 3>("xyz", {static_cast<float>(-i), static_cast<float>(-i), static_cast<float>(-i) });
+    }
+
+    // Setup Model
+    CUDASimulation cudaSimulation(model);
+    cudaSimulation.setPopulationData(pop);
+
+    // Execute step fn
+    cudaSimulation.step();
+
+    // Check results
+    cudaSimulation.getPopulationData(pop);
+    std::vector<int> finalOrder;
+    for (AgentVector::Agent instance : pop) {
+        finalOrder.push_back(instance.getVariable<int>("initial_order"));
+    }
+    std::vector<int> expectedResult{ 3, 2, 1, 0 };
     EXPECT_EQ(expectedResult, finalOrder);
 }
 }  // namespace test_spatial_agent_sort


### PR DESCRIPTION
Also added a bit of extra type checking and cuda error checking, this caught a bug when trying to sort an empty agent pop.

I've additionally extended agent sort detection to submodels. For the time being, this should suffice for Primage, where I'm hoping to sort once per submodel (I just set the sort period unreasonably high). But we may want to consider if a model like primage only wanted to sort every N parent model steps.

*Note, this merges into `logging_timings` branch, because I'm going to test it with Primage, which currently requires that for the timing stuff. Although after all this faff, I've manually applied the subsequent changes in both places.*