### PR TITLE
Invalid XML input file test fixes

### DIFF
--- a/tests/swig/python/gpu/test_cuda_simulation.py
+++ b/tests/swig/python/gpu/test_cuda_simulation.py
@@ -55,6 +55,7 @@ class TestSimulation(TestCase):
         c.initialise(argv)
         assert c.SimulationConfig().input_file == ""
 
+    @pytest.mark.skip(reason="no way of intercepting exit called with c/c++ code from python")
     def test_argparse_inputfile_short(self):
         m = pyflamegpu.ModelDescription("test_argparse_inputfile_short")
         c = pyflamegpu.CUDASimulation(m)

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -104,7 +104,7 @@ TEST(TestSimulationDeathTest, ArgParse_inputfile_short) {
     CUDASimulation c(m);
     const char *argv[3] = { "prog.exe", "-i", "I_DO_NOT_EXIST.xml" };
     EXPECT_EQ(c.getSimulationConfig().input_file, "");
-    EXPECT_EXIT(c.initialise(sizeof(argv) / sizeof(char*), argv), testing::ExitedWithCode(EXIT_FAILURE), "[.]*");  // File doesn't exist
+    EXPECT_EXIT(c.initialise(sizeof(argv) / sizeof(char*), argv), testing::ExitedWithCode(EXIT_FAILURE), ".*Loading input file '.*' failed!.*");  // File doesn't exist
 }
 TEST(TestSimulation, ArgParse_steps_long) {
     ModelDescription m(MODEL_NAME);

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -99,16 +99,12 @@ TEST(TestSimulation, ArgParse_inputfile_long) {
     c.initialise(0, nullptr);
     EXPECT_EQ(c.getSimulationConfig().input_file, "");
 }
-TEST(TestSimulation, ArgParse_inputfile_short) {
+TEST(TestSimulationDeathTest, ArgParse_inputfile_short) {
     ModelDescription m(MODEL_NAME);
     CUDASimulation c(m);
     const char *argv[3] = { "prog.exe", "-i", "I_DO_NOT_EXIST.xml" };
     EXPECT_EQ(c.getSimulationConfig().input_file, "");
-    EXPECT_THROW(c.initialise(sizeof(argv) / sizeof(char*), argv), exception::InvalidInputFile);  // File doesn't exist
-    EXPECT_EQ(c.getSimulationConfig().input_file, argv[2]);
-    // Blank init resets value to default
-    c.initialise(0, nullptr);
-    EXPECT_EQ(c.getSimulationConfig().input_file, "");
+    EXPECT_EXIT(c.initialise(sizeof(argv) / sizeof(char*), argv), testing::ExitedWithCode(EXIT_FAILURE), "[.]*");  // File doesn't exist
 }
 TEST(TestSimulation, ArgParse_steps_long) {
     ModelDescription m(MODEL_NAME);


### PR DESCRIPTION
Closes #808

* Uses a `EXPECT_EXIT` in the google test, this emits a warning.
* SKips the python test, as cannot trap the C/C++ call to `exit`.