### PR TITLE
type_decode: GLM types can now mostly be treated like native types

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -173,6 +173,17 @@ class CUDASimulation : public Simulation {
      */
     template<typename T, unsigned int N>
     void setEnvironmentProperty(const std::string &property_name, const std::array<T, N> &value);
+    /**
+     * Update the value of the specified element of the named environment property array
+     * @param property_name Name of the environment property to be updated
+     * @param index Index of the element within the property array to be updated
+     * @param value New value for the named environment property
+     * @tparam T Type of the elements of the environment property array
+     * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
+     * @throws exception::ReadOnlyEnvProperty If the named environment property is marked as read-only
+     */
+    template<typename T>
+    void setEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type &index, const T& value);
 #ifdef SWIG
     /**
      * Update the current value of the named environment property array
@@ -188,7 +199,7 @@ class CUDASimulation : public Simulation {
 #endif
     /**
      * Return the current value of the named environment property
-     * @param property_name Name of the environment property to be updated
+     * @param property_name Name of the environment property to be returned
      * @tparam T Type of the environment property
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      */
@@ -196,12 +207,21 @@ class CUDASimulation : public Simulation {
     T getEnvironmentProperty(const std::string &property_name);
     /**
      * Return the current value of the named environment property array
-     * @param property_name Name of the environment property to be updated
+     * @param property_name Name of the environment property to be returned
      * @tparam T Type of the elements of the environment property array
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      */
     template<typename T, unsigned int N>
     std::array<T, N> getEnvironmentProperty(const std::string &property_name);
+    /**
+     * Return the current value of the specified element of the named environment property array
+     * @param property_name Name of the environment property to be returned
+     * @param index Index of the element within the property array to be returned
+     * @tparam T Type of the elements of the environment property array
+     * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
+     */
+    template<typename T>
+    T getEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type& index);
 #ifdef SWIG
     /**
      * Return the current value of the named environment property array
@@ -659,6 +679,12 @@ void CUDASimulation::setEnvironmentProperty(const std::string& property_name, co
     singletons->environment.setProperty<T, N>({ instance_id, property_name }, value);
 }
 template<typename T>
+void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type& index, const T& value) {
+    if (!singletonsInitialised)
+        initialiseSingletons();
+    singletons->environment.setProperty<T>({ instance_id, property_name }, index, value);
+}
+template<typename T>
 T CUDASimulation::getEnvironmentProperty(const std::string& property_name) {
     if (!singletonsInitialised)
         initialiseSingletons();
@@ -669,6 +695,12 @@ std::array<T, N> CUDASimulation::getEnvironmentProperty(const std::string& prope
     if (!singletonsInitialised)
         initialiseSingletons();
     return singletons->environment.getProperty<T, N>({ instance_id, property_name });
+}
+template<typename T>
+T CUDASimulation::getEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type& index) {
+    if (!singletonsInitialised)
+        initialiseSingletons();
+    return singletons->environment.getProperty<T>({ instance_id, property_name }, index);
 }
 #ifdef SWIG
 template<typename T>

--- a/include/flamegpu/runtime/HostAgentAPI.cuh
+++ b/include/flamegpu/runtime/HostAgentAPI.cuh
@@ -28,6 +28,7 @@
 #include "flamegpu/pop/DeviceAgentVector.h"
 #include "flamegpu/pop/DeviceAgentVector_impl.h"
 #include "flamegpu/sim/AgentLoggingConfig_Reductions.cuh"
+#include "flamegpu/sim/AgentLoggingConfig_SumReturn.h"
 
 namespace flamegpu {
 

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -7,6 +7,7 @@
 
 #include "flamegpu/model/Variable.h"
 #include "flamegpu/defines.h"
+#include "flamegpu/util/type_decode.h"
 
 namespace flamegpu {
 
@@ -137,16 +138,13 @@ struct NewAgentStorage {
                 "in NewAgentStorage::setVariable().",
                 var_name.c_str());
         }
-#ifndef USE_GLM
-        const auto t_type = std::type_index(typeid(T));
-        // GLM is awkward, so we skip type comparisons and only care about size
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
         if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s', incorrect  type '%s' was requested, "
                 "in NewAgentStorage::setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-#endif
-        if (var->second.len != sizeof(T)) {
+        if (var->second.len != sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t) {
             THROW exception::InvalidAgentVar("This method is not suitable for agent array variables, "
                 " variable '%s' was passed, "
                 "in NewAgentStorage::setVariable().",
@@ -167,16 +165,16 @@ struct NewAgentStorage {
         //         "in NewAgentStorage::setVariable().",
         //         var_name.c_str());
         // }
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-        if (var->second.len != sizeof(T) * N) {
+        if (var->second.len != sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t * N) {
             THROW exception::InvalidVarArrayLen("Variable '%s' is an array with %u elements, incorrect array of length %u was provided, "
                 "in NewAgentStorage::setVariable().",
-                var_name.c_str(), var->second.len / sizeof(T), N);
+                var_name.c_str(), var->second.len / (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t), N);
         }
         memcpy(data + var->second.offset, val.data(), var->second.len);
     }
@@ -193,18 +191,18 @@ struct NewAgentStorage {
         //         "in NewAgentStorage::setVariable().",
         //         var_name.c_str());
         // }
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::setVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-        if (var->second.len < sizeof(T) * (index + 1)) {
+        if (var->second.len < (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t) * (index + 1)) {
             THROW exception::OutOfRangeVarArray("Variable '%s' is an array with %u elements, index %u is out of range, "
                 "in NewAgentStorage::setVariable().",
-                var_name.c_str(), var->second.len / sizeof(T), index);
+                var_name.c_str(), var->second.len / (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t), index);
         }
-        memcpy(data + var->second.offset + (index * sizeof(T)), &val, sizeof(T));
+        memcpy(data + var->second.offset + (index * sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t), &val, sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t);
     }
 #ifdef SWIG
     template<typename T>
@@ -220,16 +218,16 @@ struct NewAgentStorage {
         //         "in NewAgentStorage::setVariableArray().",
         //         var_name.c_str());
         // }
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::setVariableArray().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-        if (var->second.len != sizeof(T) * val.size()) {
+        if (var->second.len != sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t * val.size()) {
             THROW exception::InvalidVarArrayLen("Variable '%s' is an array with %u elements, incorrect array of length %u was provided, "
                 "in NewAgentStorage::setVariableArray().",
-                var_name.c_str(), var->second.len / sizeof(T), val.size());
+                var_name.c_str(), var->second.len / (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t), val.size());
         }
         memcpy(data + var->second.offset, val.data(), var->second.len);
     }
@@ -242,16 +240,13 @@ struct NewAgentStorage {
                 "in NewAgentStorage::getVariable()",
                 var_name.c_str());
         }
-#ifndef USE_GLM
-        // GLM is awkward, so we skip type comparisons and only care about size
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::getVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-#endif
-        if (var->second.len != sizeof(T)) {
+        if (var->second.len != sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t) {
             THROW exception::InvalidAgentVar("This method is not suitable for agent array variables, "
                 " variable '%s' was passed, "
                 "in NewAgentStorage::getVariable().",
@@ -272,16 +267,16 @@ struct NewAgentStorage {
         //         "in NewAgentStorage::getVariable().",
         //         var_name.c_str());
         // }
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::getVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-        if (var->second.len != sizeof(T) * N) {
+        if (var->second.len != sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t * N) {
             THROW exception::InvalidVarArrayLen("Variable '%s' is an array with %u elements, incorrect array of length %u was specified, "
                 "in NewAgentStorage::getVariable().",
-                var_name.c_str(), var->second.len / sizeof(T), N);
+                var_name.c_str(), var->second.len / (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t), N);
         }
         std::array<T, N> rtn;
         memcpy(rtn.data(), data + var->second.offset, var->second.len);
@@ -300,18 +295,18 @@ struct NewAgentStorage {
         //         "in NewAgentStorage::getVariable().",
         //         var_name.c_str());
         // }
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::getVariable().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-        if (var->second.len < sizeof(T) * (index + 1)) {
+        if (var->second.len < sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t * (index + 1)) {
             THROW exception::OutOfRangeVarArray("Variable '%s' is an array with %u elements, index %u is out of range, "
                 "in NewAgentStorage::getVariable().",
-                var_name.c_str(), var->second.len / sizeof(T), index);
+                var_name.c_str(), var->second.len / (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t), index);
         }
-        return *reinterpret_cast<T*>(data + var->second.offset + (index * sizeof(T)));
+        return *reinterpret_cast<T*>(data + var->second.offset + (index * sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t));
     }
 #ifdef SWIG
     template<typename T>
@@ -322,13 +317,18 @@ struct NewAgentStorage {
                 "in NewAgentStorage::getVariableArray().",
                 var_name.c_str());
         }
-        const auto t_type = std::type_index(typeid(T));
-        if (var->second.type != std::type_index(typeid(T))) {
+        const auto t_type = std::type_index(typeid(typename type_decode<T>::type_t));
+        if (var->second.type != t_type) {
             THROW exception::InvalidVarType("Variable '%s' has type '%s, incorrect  type '%s' was requested, "
                 "in NewAgentStorage::getVariableArray().",
                 var_name.c_str(), var->second.type.name(), t_type.name());
         }
-        const size_t elements = var->second.len / sizeof(T);
+        if (var->second.len % (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t) != 0) {
+            THROW exception::InvalidVarType("Variable '%s' has length (%llu) is not divisible by vector length (%u), "
+                "in NewAgentStorage::getVariableArray().",
+                var_name.c_str(), var->second.len / sizeof(typename type_decode<T>::type_t), type_decode<T>::len_t);
+        }
+        const size_t elements = var->second.len / (sizeof(typename type_decode<T>::type_t) * type_decode<T>::len_t);
         std::vector<T> rtn(elements);
         memcpy(rtn.data(), data + var->second.offset, var->second.len);
         return rtn;

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh
@@ -242,7 +242,11 @@ __device__ T MessageBruteForce::In::Message::getVariable(const char(&variable_na
     }
 #endif
     // get the value from curve using the stored hashes and message index.
+#ifdef USE_GLM
+    T value = detail::curve::Curve::getMessageVariable<T>(variable_name, this->_parent.combined_hash, index);
+#else
     T value = detail::curve::Curve::getMessageVariable_ldg<T>(variable_name, this->_parent.combined_hash, index);
+#endif
     return value;
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
@@ -257,7 +261,11 @@ T MessageBruteForce::In::Message::getVariable(const char(&variable_name)[M], con
     }
 #endif
     // get the value from curve using the stored hashes and message index.
+#ifdef USE_GLM
+    T value = detail::curve::Curve::getMessageArrayVariable<T, N>(variable_name, this->_parent.combined_hash, index, array_index);
+#else
     T value = detail::curve::Curve::getMessageArrayVariable_ldg<T, N>(variable_name, this->_parent.combined_hash, index, array_index);
+#endif
     return value;
 }
 

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
@@ -14,6 +14,7 @@
 #include "flamegpu/runtime/messaging/MessageNone/MessageNoneHost.h"
 #include "flamegpu/runtime/messaging/MessageBruteForce.h"
 #include "flamegpu/runtime/messaging/MessageSortingType.h"
+#include "flamegpu/util/type_decode.h"
 
 namespace flamegpu {
 
@@ -289,9 +290,9 @@ void MessageBruteForce::Description::newVariable(const std::string& variable_nam
             "in MessageDescription::newVariable().");
     }
     // Array length 0 makes no sense
-    static_assert(N > 0, "A variable cannot have 0 elements.");
+    static_assert(type_decode<T>::len_t * N > 0, "A variable cannot have 0 elements.");
     if (message->variables.find(variable_name) == message->variables.end()) {
-        message->variables.emplace(variable_name, Variable(std::array<T, N>{}));
+        message->variables.emplace(variable_name, Variable(std::array<typename type_decode<T>::type_t, type_decode<T>::len_t * N>{}));
         return;
     }
     THROW exception::InvalidMessageVar("Message ('%s') already contains variable '%s', "
@@ -310,8 +311,8 @@ void MessageBruteForce::Description::newVariableArray(const std::string& variabl
             "in MessageDescription::newVariable().");
     }
     if (message->variables.find(variable_name) == message->variables.end()) {
-        std::vector<T> temp(static_cast<size_t>(length));
-        message->variables.emplace(variable_name, Variable(length, temp));
+        std::vector<typename type_decode<T>::type_t> temp(static_cast<size_t>(type_decode<T>::len_t * length));
+        message->variables.emplace(variable_name, Variable(type_decode<T>::len_t * length, temp));
         return;
     }
     THROW exception::InvalidMessageVar("Message ('%s') already contains variable '%s', "

--- a/include/flamegpu/sim/AgentLoggingConfig.h
+++ b/include/flamegpu/sim/AgentLoggingConfig.h
@@ -9,6 +9,7 @@
 
 #include "flamegpu/sim/LoggingConfig.h"
 #include "flamegpu/sim/AgentLoggingConfig_Reductions.cuh"
+#include "flamegpu/sim/AgentLoggingConfig_SumReturn.h"
 #include "flamegpu/runtime/HostAgentAPI.cuh"
 
 namespace flamegpu {

--- a/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
+++ b/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
@@ -1,8 +1,6 @@
 #ifndef INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_REDUCTIONS_CUH_
 #define INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_REDUCTIONS_CUH_
 
-#include <functional>
-
 namespace flamegpu {
 namespace detail {
 
@@ -54,62 +52,6 @@ __device__ __forceinline__ OutT standard_deviation_subtract_mean_impl::unary_fun
 }
 
 }  // namespace detail
-
-/**
- * Template for converting a type to the most suitable type of the same format with greatest range
- * Useful when summing unknown values
- * e.g. sum_input_t<float>::result_t == double
- * e.g. sum_input_t<uint8_t>::result_t == uint64_t
- */
-template <typename T> struct sum_input_t;
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<float> { typedef double result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<double> { typedef double result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<char> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint8_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint16_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint32_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<uint64_t> { typedef uint64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int8_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int16_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int32_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <> struct sum_input_t<int64_t> { typedef int64_t result_t; };
-/**
- * @see sum_input_t
- */
-template <typename T> struct sum_input_t { typedef T result_t; };
 
 }  // namespace flamegpu
 

--- a/include/flamegpu/sim/AgentLoggingConfig_SumReturn.h
+++ b/include/flamegpu/sim/AgentLoggingConfig_SumReturn.h
@@ -1,0 +1,66 @@
+#ifndef INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_SUMRETURN_H_
+#define INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_SUMRETURN_H_
+
+#include <cstdint>
+
+namespace flamegpu {
+
+/**
+ * Template for converting a type to the most suitable type of the same format with greatest range
+ * Useful when summing unknown values
+ * e.g. sum_input_t<float>::result_t == double
+ * e.g. sum_input_t<uint8_t>::result_t == uint64_t
+ */
+template <typename T> struct sum_input_t;
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<float> { typedef double result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<double> { typedef double result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<char> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint8_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint16_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint32_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<uint64_t> { typedef uint64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int8_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int16_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int32_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <> struct sum_input_t<int64_t> { typedef int64_t result_t; };
+/**
+ * @see sum_input_t
+ */
+template <typename T> struct sum_input_t { typedef T result_t; };
+
+}  // namespace flamegpu
+
+#endif  // INCLUDE_FLAMEGPU_SIM_AGENTLOGGINGCONFIG_SUMRETURN_H_

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -10,6 +10,7 @@
 
 #include "flamegpu/sim/RunPlan.h"
 #include "flamegpu/util/detail/StaticAssert.h"
+#include "flamegpu/util/type_decode.h"
 
 
 namespace flamegpu {
@@ -81,7 +82,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
-     * @throws std::out_of_range If index is not in range of the length of the property array
+     * @throws exception::OutOfBoundsException If index is not in range of the length of the property array
      * @see setProperty(const std::string &name, const T &value)
      */
     template<typename T>
@@ -111,7 +112,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
     void setPropertyUniformDistribution(const std::string &name, const T &min, const T &max);
@@ -127,8 +128,8 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
-     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      * @see setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
      */
     template<typename T>
@@ -155,7 +156,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
     void setPropertyUniformRandom(const std::string &name, const T &min, const T &max);
@@ -171,8 +172,8 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
-     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      * @see setPropertyUniformRandom(const std::string &name, const T &min, const T &max)
      */
     template<typename T>
@@ -186,7 +187,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
     void setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev);
@@ -201,8 +202,8 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
-     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      * @see setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
      */
     template<typename T>
@@ -216,7 +217,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
     void setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev);
@@ -231,8 +232,8 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam T The type of the environment property, this must match the ModelDescription
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
-     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      * @see setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
      */
     template<typename T>
@@ -245,7 +246,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam rand_dist An object satisfying the requirements of RandomNumberDistribution e.g. std::uniform_real_distribution
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T, typename rand_dist>
     void setPropertyRandom(const std::string &name, rand_dist &distribution);
@@ -259,8 +260,8 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @tparam rand_dist An object satisfying the requirements of RandomNumberDistribution e.g. std::uniform_real_distribution
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
-     * @throws std::out_of_range If index is greater than or equal to the length of the environment property array
-     * @throws std::out_of_range If this vector has a length less than 2
+     * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
+     * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T, typename rand_dist>
     void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution);
@@ -314,12 +315,12 @@ void RunPlanVector::setProperty(const std::string &name, const T &value) {
             "in RunPlanVector::setProperty()\n",
             name.c_str());
     }
-    if (it->second.data.type != std::type_index(typeid(T))) {
+    if (it->second.data.type != std::type_index(typeid(typename type_decode<T>::type_t))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
             "in RunPlanVector::setProperty()\n",
-            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(typename type_decode<T>::type_t)).name());
     }
-    if (it->second.data.elements != 1) {
+    if (it->second.data.elements != type_decode<T>::len_t) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' is an array with %u elements, array method should be used, "
             "in RunPlanVector::setProperty()\n",
             name.c_str(), it->second.data.elements);
@@ -337,15 +338,15 @@ void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> 
             "in RunPlanVector::setProperty()\n",
             name.c_str());
     }
-    if (it->second.data.type != std::type_index(typeid(T))) {
+    if (it->second.data.type != std::type_index(typeid(typename type_decode<T>::type_t))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
             "in RunPlanVector::setProperty()\n",
-            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(typename type_decode<T>::type_t)).name());
     }
-    if (it->second.data.elements != N) {
+    if (it->second.data.elements != N * type_decode<T>::len_t) {
         THROW exception::InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
             "in RunPlanVector::setProperty()\n",
-            name.c_str(), it->second.data.elements, N);
+            name.c_str(), it->second.data.elements, N * type_decode<T>::len_t);
     }
     for (auto &i : *this) {
         i.setProperty<T, N>(name, value);
@@ -360,13 +361,14 @@ void RunPlanVector::setProperty(const std::string &name, const EnvironmentManage
             "in RunPlanVector::setProperty()\n",
             name.c_str());
     }
-    if (it->second.data.type != std::type_index(typeid(T))) {
+    if (it->second.data.type != std::type_index(typeid(typename type_decode<T>::type_t))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
             "in RunPlanVector::setProperty()\n",
-            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(typename type_decode<T>::type_t)).name());
     }
-    if (index > it->second.data.elements) {
-        throw std::out_of_range("Environment property array index out of bounds "
+    const unsigned int t_index = type_decode<T>::len_t * index + type_decode<T>::len_t;
+    if (t_index > it->second.data.elements || t_index < index) {
+        throw exception::OutOfBoundsException("Environment property array index out of bounds "
             "in RunPlanVector::setProperty()\n");
     }
     for (auto &i : *this) {
@@ -383,15 +385,15 @@ void RunPlanVector::setPropertyArray(const std::string &name, const EnvironmentM
             "in RunPlanVector::setPropertyArray()\n",
             name.c_str());
     }
-    if (it->second.data.type != std::type_index(typeid(T))) {
+    if (it->second.data.type != std::type_index(typeid(typename type_decode<T>::type_t))) {
         THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
             "in RunPlanVector::setPropertyArray()\n",
-            name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
+            name.c_str(), it->second.data.type.name(), std::type_index(typeid(typename type_decode<T>::type_t)).name());
     }
-    if (it->second.data.elements != N) {
+    if (it->second.data.elements != N * type_decode<T>::len_t) {
         THROW exception::InvalidEnvPropertyType("Environment property array '%s' length mismatch %u != %u "
             "in RunPlanVector::setPropertyArray()\n",
-            name.c_str(), it->second.data.elements, N);
+            name.c_str(), it->second.data.elements, N * type_decode<T>::len_t);
     }
     if (value.size() != N) {
         THROW exception::InvalidEnvProperty("Environment property array length does not match the value provided, %u != %llu,"
@@ -408,7 +410,7 @@ template<typename T>
 void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max) {
     // Validation
     if (this->size() < 2) {
-        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+        THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
             "in RunPlanVector::setPropertyUniformDistribution()\n");
     }
     const auto it = environment->find(name);
@@ -441,7 +443,7 @@ template<typename T>
 void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max) {
     // Validation
     if (this->size() < 2) {
-        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+        THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
             "in RunPlanVector::setPropertyUniformDistribution()\n");
     }
     const auto it = environment->find(name);
@@ -455,8 +457,9 @@ void RunPlanVector::setPropertyUniformDistribution(const std::string &name, cons
             "in RunPlanVector::setPropertyUniformDistribution()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (index > it->second.data.elements) {
-        throw std::out_of_range("Environment property array index out of bounds "
+    const unsigned int t_index = type_decode<T>::len_t * index + type_decode<T>::len_t;
+    if (t_index > it->second.data.elements || t_index < index) {
+        throw exception::OutOfBoundsException("Environment property array index out of bounds "
             "in RunPlanVector::setPropertyUniformDistribution()\n");
     }
     unsigned int ct = 0;
@@ -474,7 +477,7 @@ template<typename T, typename rand_dist>
 void RunPlanVector::setPropertyRandom(const std::string &name, rand_dist &distribution) {
     // Validation
     if (this->size() < 2) {
-        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+        THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
             "in RunPlanVector::setPropertyRandom()\n");
     }
     const auto it = environment->find(name);
@@ -501,7 +504,7 @@ template<typename T, typename rand_dist>
 void RunPlanVector::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution) {
     // Validation
     if (this->size() < 2) {
-        THROW std::out_of_range("Unable to apply a property distribution a vector with less than 2 elements, "
+        THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
             "in RunPlanVector::setPropertyRandom()\n");
     }
     const auto it = environment->find(name);
@@ -515,8 +518,9 @@ void RunPlanVector::setPropertyRandom(const std::string &name, const Environment
             "in RunPlanVector::setPropertyRandom()\n",
             name.c_str(), it->second.data.type.name(), std::type_index(typeid(T)).name());
     }
-    if (index > it->second.data.elements) {
-        throw std::out_of_range("Environment property array index out of bounds "
+    const unsigned int t_index = type_decode<T>::len_t * index + type_decode<T>::len_t;
+    if (t_index > it->second.data.elements || t_index < index) {
+        throw exception::OutOfBoundsException("Environment property array index out of bounds "
             "in RunPlanVector::setPropertyRandom()\n");
     }
     for (auto &i : *this) {

--- a/include/flamegpu/util/type_decode.h
+++ b/include/flamegpu/util/type_decode.h
@@ -1,0 +1,36 @@
+#ifndef INCLUDE_FLAMEGPU_UTIL_TYPE_DECODE_H_
+#define INCLUDE_FLAMEGPU_UTIL_TYPE_DECODE_H_
+
+/**
+ * This struct allows us to natively decode GLM types to their type + length
+ */
+template <typename T>
+struct type_decode {
+    // Length of the decoded type
+    static constexpr unsigned int len_t = 1;
+    // Type of the decoded type
+    typedef T type_t;
+};
+
+#if defined(USE_GLM) || defined(GLM_VERSION)
+#ifndef GLM_VERSION
+#ifdef __CUDACC__
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress = esa_on_defaulted_function_ignored
+#else
+#pragma diag_suppress = esa_on_defaulted_function_ignored
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#endif  // __CUDACC__
+#include <glm/glm.hpp>
+#endif
+/**
+ * GLM specialisation, only enabled if GLM is present
+ */
+template <int N, typename T, glm::qualifier Q>
+struct type_decode<glm::vec<N, T, Q>> {
+    static constexpr unsigned int len_t = N;
+    typedef T type_t;
+};
+#endif
+
+#endif  // INCLUDE_FLAMEGPU_UTIL_TYPE_DECODE_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,7 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/gpu/CUDAMacroEnvironment.h
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentInterface.h
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentLoggingConfig.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentLoggingConfig_SumReturn.h
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/AgentLoggingConfig_Reductions.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/LoggingConfig.h
     ${FLAMEGPU_ROOT}/include/flamegpu/sim/LogFrame.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,7 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/util/nvtx.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/StringPair.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/StringUint32Pair.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/util/type_decode.h
     ${FLAMEGPU_ROOT}/include/flamegpu/util/detail/compute_capability.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/util/detail/wddm.cuh
     ${FLAMEGPU_ROOT}/include/flamegpu/util/detail/CUDAEventTimer.cuh

--- a/src/flamegpu/model/EnvironmentDescription.cu
+++ b/src/flamegpu/model/EnvironmentDescription.cu
@@ -38,7 +38,7 @@ bool EnvironmentDescription::operator!=(const EnvironmentDescription& rhs) const
     return !(*this == rhs);
 }
 
-void EnvironmentDescription::newProperty(const std::string &name, const char *ptr, const size_t &length, const bool &isConst, const EnvironmentManager::size_type &elements, const std::type_index &type) {
+void EnvironmentDescription::newProperty(const std::string &name, const char *ptr, size_t length, bool isConst, EnvironmentManager::size_type elements, const std::type_index &type) {
     properties.emplace(name, PropData(isConst, util::Any(ptr, length, type, elements)));
 }
 

--- a/src/flamegpu/sim/RunPlan.cpp
+++ b/src/flamegpu/sim/RunPlan.cpp
@@ -30,7 +30,7 @@ void RunPlan::setRandomSimulationSeed(const uint64_t &_random_seed) {
 }
 void RunPlan::setSteps(const unsigned int &_steps) {
     if (_steps == 0 && !allow_0_steps) {
-        throw std::out_of_range("Model description requires atleast 1 exit condition to have unlimited steps, "
+        throw exception::OutOfBoundsException("Model description requires atleast 1 exit condition to have unlimited steps, "
             "in RunPlan::setSteps()");
     }
     steps = _steps;

--- a/src/flamegpu/sim/RunPlanVector.cpp
+++ b/src/flamegpu/sim/RunPlanVector.cpp
@@ -27,7 +27,7 @@ void RunPlanVector::setRandomSimulationSeed(const uint64_t &initial_seed, const 
 }
 void RunPlanVector::setSteps(const unsigned int &steps) {
     if (steps == 0 && !allow_0_steps) {
-        throw std::out_of_range("Model description requires atleast 1 exit condition to have unlimited steps, "
+        throw exception::OutOfBoundsException("Model description requires atleast 1 exit condition to have unlimited steps, "
             "in RunPlanVector::setSteps()");
     }
     for (auto &i : *this) {

--- a/src/flamegpu/util/detail/JitifyCache.cu
+++ b/src/flamegpu/util/detail/JitifyCache.cu
@@ -439,6 +439,7 @@ void JitifyCache::getKnownHeaders(std::vector<std::string>& headers) {
     headers.push_back("flamegpu/runtime/utility/DeviceEnvironment.cuh");
     headers.push_back("flamegpu/runtime/utility/DeviceMacroProperty.cuh");
     headers.push_back("flamegpu/util/detail/StaticAssert.h");
+    headers.push_back("flamegpu/util/type_decode.h");
     // headers.push_back("jitify_preinclude.h");  // I think Jitify adds this itself
     headers.push_back("limits");
     headers.push_back("limits.h");

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -547,6 +547,7 @@ class ModelVis;
 // Include logging implementations
 %include "flamegpu/sim/LoggingConfig.h"
 %include "flamegpu/sim/AgentLoggingConfig.h"
+%include "flamegpu/sim/AgentLoggingConfig_SumReturn.h"
 %include "flamegpu/sim/LogFrame.h"  // Includes RunLog. 
 
 // Include ensemble implementations
@@ -640,7 +641,7 @@ class ModelVis;
 // DependencyNode template instantiations
 %template(dependsOn) flamegpu::DependencyNode::dependsOn<flamegpu::DependencyNode>;
 
-%template(LogFrameList) std::list<flamegpu::LogFrame>;
+%template(StepLogFrameList) std::list<flamegpu::StepLogFrame>;
 %template(RunLogVec) std::vector<flamegpu::RunLog>;
  
 // Instantiate template versions of agent functions from the API

--- a/tests/helpers/host_reductions_common.cu
+++ b/tests/helpers/host_reductions_common.cu
@@ -12,6 +12,9 @@ uint32_t uint32_t_out = 0;
 int32_t int32_t_out = 0;
 uint64_t uint64_t_out = 0;
 int64_t int64_t_out = 0;
+#ifdef USE_GLM
+glm::vec3 vec3_t_out = glm::vec3(0);
+#endif
 std::pair<double, double> mean_sd_out;
 std::vector<unsigned int> uint_vec;
 std::vector<int> int_vec;

--- a/tests/helpers/host_reductions_common.h
+++ b/tests/helpers/host_reductions_common.h
@@ -35,6 +35,9 @@ extern uint32_t uint32_t_out;
 extern int32_t int32_t_out;
 extern uint64_t uint64_t_out;
 extern int64_t int64_t_out;
+#ifdef USE_GLM
+extern glm::vec3 vec3_t_out;
+#endif
 extern std::pair<double, double> mean_sd_out;
 extern std::vector<unsigned int> uint_vec;
 extern std::vector<int> int_vec;
@@ -55,6 +58,9 @@ class MiniSim {
         agent.newVariable<int32_t>("int32_t");
         agent.newVariable<uint64_t>("uint64_t");
         agent.newVariable<int64_t>("int64_t");
+#ifdef USE_GLM
+        agent.newVariable<glm::vec3>("vec3");
+#endif
         population = new AgentVector(agent, TEST_LEN);
     }
     ~MiniSim() { delete population; }

--- a/tests/swig/python/io/test_logging_exceptions.py
+++ b/tests/swig/python/io/test_logging_exceptions.py
@@ -16,13 +16,13 @@ class LoggingExceptionTest(TestCase):
         sim = pyflamegpu.CUDASimulation(m);
         # Unsupported file types
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:  # exception::UnsupportedFileType exception
-            sim.exportLog("test.csv", True, True);
+            sim.exportLog("test.csv", True, True, True, True);
         assert e.value.type() == "UnsupportedFileType"
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:  # exception::UnsupportedFileType exception
-            sim.exportLog("test.html", True, True);
+            sim.exportLog("test.html", True, True, True, True);
         assert e.value.type() == "UnsupportedFileType"
         # Does not throw
-        sim.exportLog("test.json", True, True);
+        sim.exportLog("test.json", True, True, True, True);
         # Cleanup
         os.remove("test.json")
         

--- a/tests/swig/python/runtime/messaging/test_brute_force.py
+++ b/tests/swig/python/runtime/messaging/test_brute_force.py
@@ -24,7 +24,7 @@ FLAMEGPU_AGENT_FUNCTION(OutFunction, flamegpu::MessageNone, flamegpu::MessageBru
 OutFunction_Optional = """
 FLAMEGPU_AGENT_FUNCTION(OutFunction_Optional, flamegpu::MessageNone, flamegpu::MessageBruteForce) {
     const int x = FLAMEGPU->getVariable<int>("x");
-    if (x) FLAMEGPU->message_out.setVariable("x", x);
+    if (x) FLAMEGPU->message_out.setVariable<int>("x", x);
     return flamegpu::ALIVE;
 }
 """
@@ -38,6 +38,7 @@ FLAMEGPU_AGENT_FUNCTION(InFunction, flamegpu::MessageBruteForce, flamegpu::Messa
         sum += x;
         product *= x;
         product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
     }
     FLAMEGPU->setVariable<int>("sum", sum);
     FLAMEGPU->setVariable<int>("product", product);
@@ -54,6 +55,7 @@ FLAMEGPU_AGENT_FUNCTION(InFunction2, flamegpu::MessageBruteForce, flamegpu::Mess
         sum += x;
         product *= x;
         product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
     }
     FLAMEGPU->setVariable<int>("sum", sum);
     FLAMEGPU->setVariable<int>("product", product);
@@ -142,17 +144,24 @@ class TestMessage_BruteForce(TestCase):
         product = 1
         for ai in pop:
             x = rand.randint(-3, 3)
+            ai.setVariableInt("x", x)
+            ai.setVariableInt("sum", 0)
+            ai.setVariableInt("product", 1)
             sum += x
             product *= x
             if product > 1000000:
                 product = 1
+            if product < -1000000:
+                product = -1
+        for ai in pop:
+            x = ai.getVariableInt("x")
+            # Calc second iteration sum/product
             sum += (x + 1)
             product *= (x + 1)
             if product > 1000000:
                 product = 1
-            ai.setVariableInt("x", x)
-            ai.setVariableInt("sum", 0)
-            ai.setVariableInt("product", 1)
+                if product < -1000000:
+                    product = -1
         
         lo = m.newLayer(OUT_LAYER_NAME)
         lo.addAgentFunction(fo)
@@ -196,6 +205,8 @@ class TestMessage_BruteForce(TestCase):
                 product *= x
                 if product > 1000000:
                     product = 1
+                if product < -1000000:
+                    product = -1
             
             ai.setVariableInt("x", x)
             ai.setVariableInt("sum", 0)
@@ -234,24 +245,29 @@ class TestMessage_BruteForce(TestCase):
         sum = 0
         product = 1
         for ai in pop:
-            x = rand.randint(-3,3)
+            x = rand.randint(-3,3)            
+            ai.setVariableInt("x", x)
+            ai.setVariableInt("sum", 0)
+            ai.setVariableInt("product", 1)
+            # Calc first iteration sum/product
             if (x): 
                 sum += x
                 product *= x
                 if product > 1000000:
                     product = 1
-            
-            ai.setVariableInt("x", x)
-            ai.setVariableInt("sum", 0)
-            ai.setVariableInt("product", 1)
+                if product < -1000000:
+                    product = -1
         
         for ai in pop:
             x = ai.getVariableInt("x")
+            # Calc second iteration sum/product
             if (x + 1): # dont proceed if x == -1
                 sum += (x + 1)
                 product *= (x + 1)
                 if product > 1000000:
                     product = 1
+                if product < -1000000:
+                    product = -1
             
         lo = m.newLayer(OUT_LAYER_NAME)
         lo.addAgentFunction(fo)

--- a/tests/swig/python/runtime/test_host_environment.py
+++ b/tests/swig/python/runtime/test_host_environment.py
@@ -1250,7 +1250,7 @@ class exception_property_read_only(pyflamegpu.HostFunctionCallback):
         except pyflamegpu.FLAMEGPURuntimeException as e:
             self.e2 = e.type()
         # no throw
-        FLAMEGPU.environment.getPropertyInt("read_only_a")
+        FLAMEGPU.environment.getPropertyFloat("read_only")
         FLAMEGPU.environment.getPropertyInt("read_only_a", 1)     
         
     def apply_assertions(self):

--- a/tests/swig/python/sim/test_RunPlan.py
+++ b/tests/swig/python/sim/test_RunPlan.py
@@ -51,8 +51,9 @@ class TestRunPlan(TestCase):
         assert updatedSteps == newSteps
 
         # Expected exception tests
-        with pytest.raises(RuntimeError) as e: # std::out_of_range == Runtimeerror
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plan.setSteps(0)
+        assert e.value.type() == "OutOfBoundsException"
 
     def test_setOutputSubdirectory(self):
         # Create a model
@@ -137,11 +138,13 @@ class TestRunPlan(TestCase):
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plan.getPropertyFloat("u_a", 0)
         assert e.value.type() == "InvalidEnvPropertyType"
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             minus_one_uint32_t = -1 & 0xffffffff
             plan.getPropertyInt("i_a", minus_one_uint32_t)
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        assert e.value.type() == "OutOfBoundsException"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plan.getPropertyInt("i_a", 4)
+        assert e.value.type() == "OutOfBoundsException"
 
     def test_getRandomSimulationSeed(self):
         # Create a model
@@ -226,11 +229,13 @@ class TestRunPlan(TestCase):
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plan.setPropertyFloat("u_a", 0, 3.)
         assert e.value.type() == "InvalidEnvPropertyType"
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             minus_one_uint32_t = -1 & 0xffffffff
             plan.setPropertyInt("i_a", minus_one_uint32_t, 3)
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        assert e.value.type() == "OutOfBoundsException"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plan.setPropertyInt("i_a", 4, 3)
+        assert e.value.type() == "OutOfBoundsException"
 
     def test_operatorAssignment(self):
         # Create a model

--- a/tests/swig/python/sim/test_RunPlanVector.py
+++ b/tests/swig/python/sim/test_RunPlanVector.py
@@ -65,8 +65,9 @@ class TestRunPlanVector(TestCase):
             assert plan.getSteps() != originalValues[idx]
         
         # Expect an exception if setting the value to 0?
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setSteps(0)
+        assert e.value.type() == "OutOfBoundsException"
 
         # If the model has an exit condition, then it will not throw.
         modelWithExit = pyflamegpu.ModelDescription("modelWithExit")
@@ -167,11 +168,13 @@ class TestRunPlanVector(TestCase):
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setPropertyFloat("u3", 0, 3)
         assert e.value.type() == "InvalidEnvPropertyType"
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             minus_one_uint32_t = -1 & 0xffffffff
             plans.setPropertyDouble("d3", minus_one_uint32_t, 3)
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        assert e.value.type() == "OutOfBoundsException"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setPropertyDouble("d3", 4, 3)
+        assert e.value.type() == "OutOfBoundsException"
     
     # Check that all values set lie within the min and max inclusive
     # @todo - should fp be [min, max) like when using RNG?
@@ -226,8 +229,9 @@ class TestRunPlanVector(TestCase):
         singlePlanVector = pyflamegpu.RunPlanVector(model, 1)
         # Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
         # void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             singlePlanVector.setPropertyUniformDistributionFloat("f", 1., 100.)
+        assert e.value.type() == "OutOfBoundsException"
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setPropertyUniformDistributionFloat("does_not_exist", 1., 100.)
         assert e.value.type() == "InvalidEnvProperty"
@@ -239,19 +243,22 @@ class TestRunPlanVector(TestCase):
         assert e.value.type() == "InvalidEnvPropertyType"
         # void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type
         # Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             singlePlanVector.setPropertyUniformDistributionUInt("u3", 0, 1, 100)
+        assert e.value.type() == "OutOfBoundsException"
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setPropertyUniformDistributionFloat("does_not_exist", 0, 1., 100.)
         assert e.value.type() == "InvalidEnvProperty"
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setPropertyUniformDistributionFloat("u3", 0, 1., 100.)
         assert e.value.type() == "InvalidEnvPropertyType"
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             minus_one_uint32_t = -1 & 0xffffffff
             plans.setPropertyUniformDistributionUInt("u3", minus_one_uint32_t, 1, 100)
-        with pytest.raises(RuntimeError) as e: # std::out_of_range
+        assert e.value.type() == "OutOfBoundsException"
+        with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             plans.setPropertyUniformDistributionUInt("u3", 4, 1, 100)
+        assert e.value.type() == "OutOfBoundsException"
     
     # Checking for uniformity of distribution would require a very large samples size.
     # As std:: is used, we trust the distribution is legit, and instead just check for min/max.

--- a/tests/test_cases/model/test_agent.cu
+++ b/tests/test_cases/model/test_agent.cu
@@ -86,6 +86,18 @@ TEST(AgentDescriptionTest, variables) {
     EXPECT_EQ(sizeof(int16_t), a.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(float)), a.getVariableType(VARIABLE_NAME1));
     EXPECT_EQ(std::type_index(typeid(int16_t)), a.getVariableType(VARIABLE_NAME2));
+#ifdef USE_GLM
+    // Can create variable with GLM types
+    a.newVariable<glm::vec3>("vec3");
+    a.newVariable<glm::uvec4>("uvec4");
+    EXPECT_EQ(a.getVariablesCount(), 5u);
+    EXPECT_EQ(3u, a.getVariableLength("vec3"));
+    EXPECT_EQ(4u, a.getVariableLength("uvec4"));
+    EXPECT_EQ(sizeof(float), a.getVariableSize("vec3"));
+    EXPECT_EQ(sizeof(unsigned int), a.getVariableSize("uvec4"));
+    EXPECT_EQ(std::type_index(typeid(float)), a.getVariableType("vec3"));
+    EXPECT_EQ(std::type_index(typeid(unsigned int)), a.getVariableType("uvec4"));
+#endif
 }
 TEST(AgentDescriptionTest, variables_array) {
     ModelDescription m(MODEL_NAME);
@@ -118,6 +130,18 @@ TEST(AgentDescriptionTest, variables_array) {
     EXPECT_EQ(sizeof(int16_t), a.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(float)), a.getVariableType(VARIABLE_NAME1));
     EXPECT_EQ(std::type_index(typeid(int16_t)), a.getVariableType(VARIABLE_NAME2));
+#ifdef USE_GLM
+    // Can create variable array with GLM types
+    a.newVariable<glm::vec3, 5>("vec3_5");
+    a.newVariable<glm::uvec4, 2>("uvec4_2");
+    EXPECT_EQ(a.getVariablesCount(), 6u);
+    EXPECT_EQ(5 * 3u, a.getVariableLength("vec3_5"));
+    EXPECT_EQ(2 * 4u, a.getVariableLength("uvec4_2"));
+    EXPECT_EQ(sizeof(float), a.getVariableSize("vec3_5"));
+    EXPECT_EQ(sizeof(unsigned int), a.getVariableSize("uvec4_2"));
+    EXPECT_EQ(std::type_index(typeid(float)), a.getVariableType("vec3_5"));
+    EXPECT_EQ(std::type_index(typeid(unsigned int)), a.getVariableType("uvec4_2"));
+#endif
 }
 TEST(AgentDescriptionTest, states) {
     ModelDescription m(MODEL_NAME);

--- a/tests/test_cases/model/test_environment_description.cu
+++ b/tests/test_cases/model/test_environment_description.cu
@@ -35,6 +35,18 @@ void AddGet_SetGet_test() {
     EXPECT_EQ(ed.setProperty<T>("a", c), b);
     EXPECT_EQ(ed.getProperty<T>("a"), c);
 }
+#ifdef USE_GLM
+template<typename T>
+void AddGet_SetGet_vec_test() {
+    EnvironmentDescription ed;
+    T b = T(1);
+    T c = T(2);
+    ed.newProperty<T>("a", b);
+    EXPECT_EQ(ed.getProperty<T>("a"), b);
+    EXPECT_EQ(ed.setProperty<T>("a", c), b);
+    EXPECT_EQ(ed.getProperty<T>("a"), c);
+}
+#endif
 /**
  * Tests void EnvDesc::newProperty<T, N>(const std::string &, const std::array<T, N>&)
  * Tests std::array<T, N> EnvDesc::get<T, N>(const std::string &)
@@ -65,6 +77,32 @@ void AddGet_SetGet_array_test() {
         EXPECT_EQ(a[i], c[i]);
     }
 }
+#ifdef USE_GLM
+template<typename T>
+void AddGet_SetGet_array_vec_test() {
+    EnvironmentDescription ed;
+    std::array<T, ARRAY_TEST_LEN> b;
+    std::array<T, ARRAY_TEST_LEN> c;
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        b[i] = T(static_cast<typename type_decode<T>::type_t>(i));
+        c[i] = T(static_cast<typename type_decode<T>::type_t>(ARRAY_TEST_LEN - i));
+    }
+    ed.newProperty<T, ARRAY_TEST_LEN>("a", b);
+    std::array<T, ARRAY_TEST_LEN> a;
+    a = ed.getProperty<T, ARRAY_TEST_LEN>("a");
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        EXPECT_EQ(a[i], b[i]);
+    }
+    a = ed.setProperty<T, ARRAY_TEST_LEN>("a", c);
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        EXPECT_EQ(a[i], b[i]);
+    }
+    a = ed.getProperty<T, ARRAY_TEST_LEN>("a");
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        EXPECT_EQ(a[i], c[i]);
+    }
+}
+#endif
 /**
  * Tests void EnvDesc::newProperty<T, N>(const std::string &, const std::array<T, N>&)
  * Tests T EnvDesc::get<T, N>(const std::string &, const size_type &)
@@ -89,6 +127,26 @@ void AddGet_SetGet_array_element_test() {
         EXPECT_EQ(ed.getProperty<T>("a", i), c[i]);
     }
 }
+#ifdef USE_GLM
+template<typename T>
+void AddGet_SetGet_array_element_vec_test() {
+    EnvironmentDescription ed;
+    std::array<T, ARRAY_TEST_LEN> b;
+    std::array<T, ARRAY_TEST_LEN> c;
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        b[i] = T(static_cast<typename type_decode<T>::type_t>(i));
+        c[i] = T(static_cast<typename type_decode<T>::type_t>(ARRAY_TEST_LEN - i));
+    }
+    ed.newProperty<T, ARRAY_TEST_LEN>("a", b);
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        EXPECT_EQ(ed.getProperty<T>("a", i), b[i]);
+        EXPECT_EQ(ed.setProperty<T>("a", i, c[i]), b[i]);
+    }
+    for (int i = 0; i < ARRAY_TEST_LEN; ++i) {
+        EXPECT_EQ(ed.getProperty<T>("a", i), c[i]);
+    }
+}
+#endif
 
 template<typename T, typename _T>
 void ExceptionPropertyType_test() {
@@ -126,9 +184,9 @@ void ExceptionPropertyLength_test() {
     auto fn1 = &EnvironmentDescription::setProperty<T, 1>;
     auto fn2 = &EnvironmentDescription::setProperty<T, ARRAY_TEST_LEN + 1>;
     auto fn3 = &EnvironmentDescription::setProperty<T, ARRAY_TEST_LEN * 2>;
-    EXPECT_THROW((ed.*fn1)("a", _b1), exception::OutOfBoundsException);
-    EXPECT_THROW((ed.*fn2)("a", _b2), exception::OutOfBoundsException);
-    EXPECT_THROW((ed.*fn3)("a", _b3), exception::OutOfBoundsException);
+    EXPECT_THROW((ed.*fn1)("a", _b1), exception::InvalidEnvPropertyType);
+    EXPECT_THROW((ed.*fn2)("a", _b2), exception::InvalidEnvPropertyType);
+    EXPECT_THROW((ed.*fn3)("a", _b3), exception::InvalidEnvPropertyType);
 }
 
 template<typename T>
@@ -177,6 +235,14 @@ TEST(EnvironmentDescriptionTest, AddGet_SetGetint64_t) {
 TEST(EnvironmentDescriptionTest, AddGet_SetGetuint64_t) {
     AddGet_SetGet_test<uint64_t>();
 }
+#ifdef USE_GLM
+TEST(EnvironmentDescriptionTest, AddGet_SetGetvec3) {
+    AddGet_SetGet_vec_test<glm::vec3>();
+}
+TEST(EnvironmentDescriptionTest, AddGet_SetGetuvec4) {
+    AddGet_SetGet_vec_test<glm::uvec4>();
+}
+#endif
 
 TEST(EnvironmentDescriptionTest, AddGet_SetGetarray_float) {
     AddGet_SetGet_array_test<float>();
@@ -208,6 +274,14 @@ TEST(EnvironmentDescriptionTest, AddGet_SetGetarray_int64_t) {
 TEST(EnvironmentDescriptionTest, AddGet_SetGetarray_uint64_t) {
     AddGet_SetGet_array_test<uint64_t>();
 }
+#ifdef USE_GLM
+TEST(EnvironmentDescriptionTest, AddGet_SetGetrray_vec3) {
+    AddGet_SetGet_array_vec_test<glm::vec3>();
+}
+TEST(EnvironmentDescriptionTest, AddGet_SetGetrray_uvec4) {
+    AddGet_SetGet_array_vec_test<glm::uvec4>();
+}
+#endif
 
 TEST(EnvironmentDescriptionTest, AddGet_SetGetarray_element_float) {
     AddGet_SetGet_array_element_test<float>();
@@ -239,15 +313,25 @@ TEST(EnvironmentDescriptionTest, AddGet_SetGetarray_element_int64_t) {
 TEST(EnvironmentDescriptionTest, AddGet_SetGetarray_element_uint64_t) {
     AddGet_SetGet_array_element_test<uint64_t>();
 }
+#ifdef USE_GLM
+TEST(EnvironmentDescriptionTest, AddGet_SetGetrray_element_vec3) {
+    AddGet_SetGet_array_element_vec_test<glm::vec3>();
+}
+TEST(EnvironmentDescriptionTest, AddGet_SetGetrray_element_uvec4) {
+    AddGet_SetGet_array_element_vec_test<glm::uvec4>();
+}
+#endif
 
 TEST(EnvironmentDescriptionTest, ExceptionPropertyType_float) {
     ExceptionPropertyType_test<float, uint64_t>();
+    ExceptionPropertyType_test<float, int32_t>();
 }
 TEST(EnvironmentDescriptionTest, ExceptionPropertyType_double) {
     ExceptionPropertyType_test<double, uint64_t>();
 }
 TEST(EnvironmentDescriptionTest, ExceptionPropertyType_int8_t) {
     ExceptionPropertyType_test<int8_t, uint64_t>();
+    ExceptionPropertyType_test<int8_t, uint8_t>();
 }
 TEST(EnvironmentDescriptionTest, ExceptionPropertyType_uint8_t) {
     ExceptionPropertyType_test<uint8_t, uint64_t>();
@@ -266,9 +350,13 @@ TEST(EnvironmentDescriptionTest, ExceptionPropertyType_uint32_t) {
 }
 TEST(EnvironmentDescriptionTest, ExceptionPropertyType_int64_t) {
     ExceptionPropertyType_test<int64_t, float>();
+    ExceptionPropertyType_test<int64_t, double>();
+    ExceptionPropertyType_test<int64_t, uint64_t>();
 }
 TEST(EnvironmentDescriptionTest, ExceptionPropertyType_uint64_t) {
     ExceptionPropertyType_test<uint64_t, float>();
+    ExceptionPropertyType_test<uint64_t, double>();
+    ExceptionPropertyType_test<uint64_t, int64_t>();
 }
 
 TEST(EnvironmentDescriptionTest, ExceptionPropertyLength_float) {
@@ -332,6 +420,45 @@ TEST(EnvironmentDescriptionTest, ExceptionPropertyRange_int64_t) {
 TEST(EnvironmentDescriptionTest, ExceptionPropertyRange_uint64_t) {
     ExceptionPropertyRange_test<uint64_t>();
 }
+#ifdef USE_GLM
+TEST(EnvironmentDescriptionTest, Exception_array_glm) {
+    EnvironmentDescription ed;
+    std::array<float, 15> b;
+    ed.newProperty<float, 15>("a", b);
+    {
+        auto fn1 = &EnvironmentDescription::getProperty<glm::vec3, 5>;
+        auto fn2 = &EnvironmentDescription::getProperty<glm::vec4, 3>;
+        auto fn3 = &EnvironmentDescription::getProperty<glm::vec4, 4>;
+        EXPECT_NO_THROW((ed.*fn1)("a"));
+        EXPECT_THROW((ed.*fn2)("a"), exception::InvalidEnvPropertyType);
+        EXPECT_THROW((ed.*fn3)("a"), exception::InvalidEnvPropertyType);
+    }
+    {
+        auto fn1 = &EnvironmentDescription::setProperty<glm::vec3, 5>;
+        auto fn2 = &EnvironmentDescription::setProperty<glm::vec4, 3>;
+        auto fn3 = &EnvironmentDescription::setProperty<glm::vec4, 4>;
+        std::array<glm::vec3, 5> c;  // Works
+        std::array<glm::vec4, 3> d;  // Too short
+        std::array<glm::vec4, 4> e;  // Too long
+        EXPECT_NO_THROW((ed.*fn1)("a", c));
+        EXPECT_THROW((ed.*fn2)("a", d), exception::InvalidEnvPropertyType);
+        EXPECT_THROW((ed.*fn3)("a", e), exception::InvalidEnvPropertyType);
+    }
+    {
+        // Can't use auto for overloaded fn
+        EXPECT_NO_THROW((ed.getProperty<glm::vec3>)("a", 4));  // In bounds
+        EXPECT_THROW((ed.getProperty<glm::vec3>)("a", 5), exception::OutOfBoundsException);  // Out of bounds
+        EXPECT_THROW((ed.getProperty<glm::vec4>)("a", 0), exception::InvalidEnvPropertyType);  // Type not divisible
+        EXPECT_THROW((ed.getProperty<glm::uvec2>)("a", 0), exception::InvalidEnvPropertyType);  // Wrong type
+    }
+    {
+        EXPECT_NO_THROW((ed.setProperty<glm::vec3>)("a", 4, glm::vec3(0)));  // In bounds
+        EXPECT_THROW((ed.setProperty<glm::vec3>)("a", 5, glm::vec3(0)), exception::OutOfBoundsException);  // Out of bounds
+        EXPECT_THROW((ed.setProperty<glm::vec4>)("a", 0, glm::vec4(0)), exception::InvalidEnvPropertyType);  // Type not divisible
+        EXPECT_THROW((ed.setProperty<glm::uvec2>)("a", 0, glm::uvec2(0)), exception::InvalidEnvPropertyType);  // Wrong type
+    }
+}
+#endif
 
 TEST(EnvironmentDescriptionTest, ExceptionPropertyDoesntExist) {
     EnvironmentDescription ed;
@@ -341,12 +468,15 @@ TEST(EnvironmentDescriptionTest, ExceptionPropertyDoesntExist) {
     EXPECT_EQ(ed.getProperty<float>("a"), a);
     // array version
     auto f = &EnvironmentDescription::getProperty<int, 2>;
+    auto g = &EnvironmentDescription::getProperty<int, ARRAY_TEST_LEN>;
     EXPECT_THROW((ed.*f)("b"), exception::InvalidEnvProperty);
+    EXPECT_THROW((ed.*g)("b"), exception::InvalidEnvProperty);
+    EXPECT_THROW(ed.getProperty<int>("b", 1), exception::InvalidEnvProperty);
     auto addArray = &EnvironmentDescription::newProperty<int, ARRAY_TEST_LEN>;
     std::array<int, ARRAY_TEST_LEN> b;
     // EXPECT_NO_THROW(ed.newProperty<int>("b", b));  // Doesn't build on Travis
     EXPECT_NO_THROW((ed.*addArray)("b", b, false));
-    EXPECT_NO_THROW(ed.getProperty<int>("b"));
+    EXPECT_NO_THROW((ed.*g)("b"));
     EXPECT_NO_THROW(ed.getProperty<int>("b", 1));
 }
 

--- a/tests/test_cases/model/test_message.cu
+++ b/tests/test_cases/model/test_message.cu
@@ -34,6 +34,18 @@ TEST(MessageDescriptionTest, variables) {
     EXPECT_EQ(sizeof(int16_t), m.getVariableSize(VARIABLE_NAME2));
     EXPECT_EQ(std::type_index(typeid(int16_t)), m.getVariableType(VARIABLE_NAME2));
     EXPECT_EQ(1u, m.getVariableLength(VARIABLE_NAME2));
+#ifdef USE_GLM
+    // Can create variable with GLM types
+    m.newVariable<glm::vec3>("vec3");
+    m.newVariable<glm::uvec4>("uvec4");
+    EXPECT_EQ(m.getVariablesCount(), 4u);
+    EXPECT_EQ(3u, m.getVariableLength("vec3"));
+    EXPECT_EQ(4u, m.getVariableLength("uvec4"));
+    EXPECT_EQ(sizeof(float), m.getVariableSize("vec3"));
+    EXPECT_EQ(sizeof(unsigned int), m.getVariableSize("uvec4"));
+    EXPECT_EQ(std::type_index(typeid(float)), m.getVariableType("vec3"));
+    EXPECT_EQ(std::type_index(typeid(unsigned int)), m.getVariableType("uvec4"));
+#endif
 }
 TEST(MessageDescriptionTest, variables_array) {
     ModelDescription _m(MODEL_NAME);
@@ -62,6 +74,18 @@ TEST(MessageDescriptionTest, variables_array) {
     EXPECT_EQ(std::type_index(typeid(int16_t)), m.getVariableType(VARIABLE_NAME2));
     EXPECT_EQ(2u, m.getVariableLength(VARIABLE_NAME1));
     EXPECT_EQ(2u, m.getVariableLength(VARIABLE_NAME2));
+#ifdef USE_GLM
+    // Can create variable array with GLM types
+    m.newVariable<glm::vec3, 5>("vec3_5");
+    m.newVariable<glm::uvec4, 2>("uvec4_2");
+    EXPECT_EQ(m.getVariablesCount(), 5u);
+    EXPECT_EQ(5 * 3u, m.getVariableLength("vec3_5"));
+    EXPECT_EQ(2 * 4u, m.getVariableLength("uvec4_2"));
+    EXPECT_EQ(sizeof(float), m.getVariableSize("vec3_5"));
+    EXPECT_EQ(sizeof(unsigned int), m.getVariableSize("uvec4_2"));
+    EXPECT_EQ(std::type_index(typeid(float)), m.getVariableType("vec3_5"));
+    EXPECT_EQ(std::type_index(typeid(unsigned int)), m.getVariableType("uvec4_2"));
+#endif
 }
 
 FLAMEGPU_AGENT_FUNCTION(NoInput, MessageNone, MessageSpatial3D) {

--- a/tests/test_cases/pop/test_agent_instance.cu
+++ b/tests/test_cases/pop/test_agent_instance.cu
@@ -10,10 +10,16 @@ TEST(AgentInstanceTest, constructor) {
     AgentDescription& agent = model.newAgent("agent");
     agent.newVariable<int>("int", 1);
     agent.newVariable<unsigned int>("uint", 2u);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
     AgentInstance ai(agent);
     // New AgentInstance is default init
     ASSERT_EQ(ai.getVariable<int>("int"), 1);
     ASSERT_EQ(ai.getVariable<unsigned int>("uint"), 2u);
+#ifdef USE_GLM
+    ASSERT_EQ(ai.getVariable<glm::vec3>("vec3"), glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
 }
 TEST(AgentInstanceTest, copy_constructor) {
   ModelDescription model("model");
@@ -21,6 +27,9 @@ TEST(AgentInstanceTest, copy_constructor) {
   agent.newVariable<int>("int", 1);
   agent.newVariable<unsigned int, 3>("uint3", {2u, 3u, 4u});
   const std::array<unsigned int, 3> ai_uint3_ref = { 0u, 1u, 2u };
+#ifdef USE_GLM
+  agent.newVariable<glm::vec3>("vec3", glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
   // Copying an agent instance retains the values
   AgentInstance ai(agent);
   ai.setVariable<int>("int", 12);
@@ -29,15 +38,25 @@ TEST(AgentInstanceTest, copy_constructor) {
   ASSERT_EQ(ai2.getVariable<int>("int"), 12);
   auto ai2_uint3_check = ai2.getVariable<unsigned int, 3>("uint3");
   ASSERT_EQ(ai2_uint3_check, ai_uint3_ref);
+#ifdef USE_GLM
+  ASSERT_EQ(ai2.getVariable<glm::vec3>("vec3"), glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
   // Copying an agent instance from an AgentVector::Agent retains values
   AgentVector av(agent, 1);
   AgentVector::Agent ava = av.front();
   ava.setVariable<int>("int", 12);
   ava.setVariable<unsigned int, 3>("uint3", ai_uint3_ref);
+#ifdef USE_GLM
+  ava.setVariable<glm::vec3>("vec3", glm::vec3(6.0f, 5.0f, 4.0f));
+#endif
   AgentInstance ai3(ava);
   ASSERT_EQ(ai3.getVariable<int>("int"), 12);
   auto ai2_uint3_check2 = ai3.getVariable<unsigned int, 3>("uint3");
   ASSERT_EQ(ai2_uint3_check2, ai_uint3_ref);
+  ASSERT_EQ(ai2_uint3_check, ai_uint3_ref);
+#ifdef USE_GLM
+  ASSERT_EQ(ai3.getVariable<glm::vec3>("vec3"), glm::vec3(6.0f, 5.0f, 4.0f));
+#endif
 }
 TEST(AgentInstanceTest, move_constructor) {
     ModelDescription model("model");
@@ -45,14 +64,23 @@ TEST(AgentInstanceTest, move_constructor) {
     agent.newVariable<int>("int", 1);
     agent.newVariable<unsigned int, 3>("uint3", { 2u, 3u, 4u });
     const std::array<unsigned int, 3> ai_uint3_ref = { 0u, 1u, 2u };
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
     // Moving an agent instance retains the values
     AgentInstance ai(agent);
     ai.setVariable<int>("int", 12);
     ai.setVariable<unsigned int, 3>("uint3", ai_uint3_ref);
+#ifdef USE_GLM
+    ai.setVariable<glm::vec3>("vec3", glm::vec3(6.0f, 5.0f, 4.0f));
+#endif
     AgentInstance ai2(std::move(ai));
     ASSERT_EQ(ai2.getVariable<int>("int"), 12);
     auto ai2_uint3_check = ai2.getVariable<unsigned int, 3>("uint3");
     ASSERT_EQ(ai2_uint3_check, ai_uint3_ref);
+#ifdef USE_GLM
+    ASSERT_EQ(ai2.getVariable<glm::vec3>("vec3"), glm::vec3(6.0f, 5.0f, 4.0f));
+#endif
 }
 TEST(AgentInstanceTest, copy_assignment_operator) {
     ModelDescription model("model");
@@ -60,26 +88,41 @@ TEST(AgentInstanceTest, copy_assignment_operator) {
     AgentDescription& agent2 = model.newAgent("agent2");
     agent.newVariable<int>("int", 1);
     agent.newVariable<unsigned int, 3>("uint3", { 2u, 3u, 4u });
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
     const std::array<unsigned int, 3> ai_uint3_ref = { 0u, 1u, 2u };
     // Copying an agent instance retains the values
     AgentInstance ai(agent);
     ai.setVariable<int>("int", 12);
     ai.setVariable<unsigned int, 3>("uint3", ai_uint3_ref);
+#ifdef USE_GLM
+    ai.setVariable<glm::vec3>("vec3", glm::vec3(16.0f, 15.0f, 14.0f));
+#endif
     AgentInstance ai2(agent2);
     ai2 = ai;
     ASSERT_EQ(ai2.getVariable<int>("int"), 12);
     auto ai2_uint3_check = ai2.getVariable<unsigned int, 3>("uint3");
     ASSERT_EQ(ai2_uint3_check, ai_uint3_ref);
+#ifdef USE_GLM
+    ASSERT_EQ(ai2.getVariable<glm::vec3>("vec3"), glm::vec3(16.0f, 15.0f, 14.0f));
+#endif
     // Copying an agent instance from an AgentVector::Agent retains values
     AgentVector av(agent, 1);
     AgentVector::Agent ava = av.front();
     ava.setVariable<int>("int", 12);
     ava.setVariable<unsigned int, 3>("uint3", ai_uint3_ref);
+#ifdef USE_GLM
+    ava.setVariable<glm::vec3>("vec3", glm::vec3(6.0f, 5.0f, 4.0f));
+#endif
     AgentInstance ai3(agent2);
     ai3 = ava;
     ASSERT_EQ(ai3.getVariable<int>("int"), 12);
     auto ai2_uint3_check2 = ai3.getVariable<unsigned int, 3>("uint3");
     ASSERT_EQ(ai2_uint3_check2, ai_uint3_ref);
+#ifdef USE_GLM
+    ASSERT_EQ(ai3.getVariable<glm::vec3>("vec3"), glm::vec3(6.0f, 5.0f, 4.0f));
+#endif
 }
 TEST(AgentInstanceTest, move_assignment_operator) {
     ModelDescription model("model");
@@ -87,16 +130,25 @@ TEST(AgentInstanceTest, move_assignment_operator) {
     AgentDescription& agent2 = model.newAgent("agent2");
     agent.newVariable<int>("int", 1);
     agent.newVariable<unsigned int, 3>("uint3", { 2u, 3u, 4u });
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(4.0f, 5.0f, 6.0f));
+#endif
     const std::array<unsigned int, 3> ai_uint3_ref = { 0u, 1u, 2u };
     // Moving an agent instance retains the values
     AgentInstance ai(agent);
     ai.setVariable<int>("int", 12);
     ai.setVariable<unsigned int, 3>("uint3", ai_uint3_ref);
+#ifdef USE_GLM
+    ai.setVariable<glm::vec3>("vec3", glm::vec3(16.0f, 15.0f, 14.0f));
+#endif
     AgentInstance ai2(agent2);
     ai2 = std::move(ai);
     ASSERT_EQ(ai2.getVariable<int>("int"), 12);
     auto ai2_uint3_check = ai2.getVariable<unsigned int, 3>("uint3");
     ASSERT_EQ(ai2_uint3_check, ai_uint3_ref);
+#ifdef USE_GLM
+    ASSERT_EQ(ai2.getVariable<glm::vec3>("vec3"), glm::vec3(16.0f, 15.0f, 14.0f));
+#endif
 }
 TEST(AgentInstanceTest, getsetVariable) {
     const unsigned int i = 15;  // This is a stripped down version of AgentVectorTest::AgentVector_Agent
@@ -107,10 +159,18 @@ TEST(AgentInstanceTest, getsetVariable) {
     agent.newVariable<int, 3>("int3", { 2, 3, 4 });
     agent.newVariable<int, 2>("int2", { 5, 6 });
     agent.newVariable<float>("float", 15.0f);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+    agent.newVariable<glm::ivec3, 3>("ivec3_3", {glm::ivec3(12, 14, 16), glm::ivec3(2, 4, 6), glm::ivec3(22, 24, 26)});
+    agent.newVariable<glm::ivec3, 3>("ivec3_3b", {glm::ivec3(12, 14, 16), glm::ivec3(2, 4, 6), glm::ivec3(22, 24, 26)});
+#endif
 
     // Create pop, variables are as expected
     AgentInstance ai(agent);
     const std::array<int, 3> int3_ref = { 2, 3, 4 };
+#ifdef USE_GLM
+    const std::array<glm::ivec3, 3> vec_array_check = {glm::ivec3(12, 14, 16), glm::ivec3(2, 4, 6), glm::ivec3(22, 24, 26)};
+#endif
     {
         ASSERT_EQ(ai.getVariable<unsigned int>("uint"), 12u);
         const std::array<int, 3> int3_check = ai.getVariable<int, 3>("int3");
@@ -118,6 +178,11 @@ TEST(AgentInstanceTest, getsetVariable) {
         ASSERT_EQ(ai.getVariable<int>("int2", 0), 5);
         ASSERT_EQ(ai.getVariable<int>("int2", 1), 6);
         ASSERT_EQ(ai.getVariable<float>("float"), 15.0f);
+#ifdef USE_GLM
+        ASSERT_EQ(ai.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+        const auto vec_array_test = ai.getVariable<glm::ivec3, 3>("ivec3_3");
+        ASSERT_EQ(vec_array_test, vec_array_check);
+#endif
     }
 
     // Update value
@@ -128,6 +193,12 @@ TEST(AgentInstanceTest, getsetVariable) {
         ai.setVariable<int>("int2", 0, 5 + static_cast<int>(i));
         ai.setVariable<int>("int2", 1, 6 + static_cast<int>(i));
         ai.setVariable<float>("float", 15.0f + static_cast<float>(i));
+#ifdef USE_GLM
+        ai.setVariable<glm::vec3>("vec3", glm::vec3(2.0f + static_cast<float>(i), 4.0f + static_cast<float>(i), 6.0f + static_cast<float>(i)));
+        ai.setVariable<glm::ivec3, 3>("ivec3_3", {glm::ivec3(12, 14, 16) + glm::ivec3(static_cast<int>(i)), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i)), glm::ivec3(22, 24, 26) + glm::ivec3(static_cast<int>(i))});
+        ai.setVariable<glm::ivec3>("ivec3_3b", 1, glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 3));
+        ai.setVariable<glm::ivec3>("ivec3_3b", 2, glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 4));
+#endif
     }
 
     // Check vars now match as expected
@@ -139,6 +210,15 @@ TEST(AgentInstanceTest, getsetVariable) {
         ASSERT_EQ(ai.getVariable<int>("int2", 0), 5 + static_cast<int>(i));
         ASSERT_EQ(ai.getVariable<int>("int2", 1), 6 + static_cast<int>(i));
         ASSERT_EQ(ai.getVariable<float>("float"), 15.0f + static_cast<float>(i));
+#ifdef USE_GLM
+        ASSERT_EQ(ai.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f + static_cast<float>(i), 4.0f + static_cast<float>(i), 6.0f + static_cast<float>(i)));
+        const std::array<glm::ivec3, 3> vec_array_check2 = {glm::ivec3(12, 14, 16) + glm::ivec3(static_cast<int>(i)), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i)), glm::ivec3(22, 24, 26) + glm::ivec3(static_cast<int>(i))};
+        const std::array<glm::ivec3, 3> vec_array_test = ai.getVariable<glm::ivec3, 3>("ivec3_3");
+        ASSERT_EQ(vec_array_test, vec_array_check2);
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 0), glm::ivec3(12, 14, 16));
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 1), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 3));
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 2), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 4));
+#endif
     }
 
     // Check various exceptions
@@ -147,6 +227,9 @@ TEST(AgentInstanceTest, getsetVariable) {
         EXPECT_THROW(ai.setVariable<int>("wrong", 1), exception::InvalidAgentVar);
         // Array passed to non-array method
         EXPECT_THROW(ai.setVariable<int>("int2", 1), exception::InvalidVarType);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.setVariable<glm::vec3>("float", {}), exception::InvalidVarType);
+#endif
         // Wrong type
         EXPECT_THROW(ai.setVariable<int>("float", 1), exception::InvalidVarType);
     }
@@ -168,6 +251,10 @@ TEST(AgentInstanceTest, getsetVariable) {
         // Index out of bounds
         EXPECT_THROW(ai.setVariable<int>("int2", 2, 1), exception::OutOfBoundsException);
         EXPECT_THROW(ai.setVariable<float>("float", 1, 1), exception::OutOfBoundsException);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.setVariable<glm::vec3>("ivec3_3", 4, {}), exception::OutOfBoundsException);
+        EXPECT_THROW(ai.setVariable<glm::vec3>("int3", 1, {}), exception::OutOfBoundsException);
+#endif
         // Wrong type
         EXPECT_THROW(ai.setVariable<int>("float", 0, 1), exception::InvalidVarType);
     }
@@ -176,6 +263,9 @@ TEST(AgentInstanceTest, getsetVariable) {
         EXPECT_THROW(ai.getVariable<int>("wrong"), exception::InvalidAgentVar);
         // Array passed to non-array method
         EXPECT_THROW(ai.getVariable<int>("int2"), exception::InvalidVarType);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.getVariable<glm::vec3>("float"), exception::InvalidVarType);
+#endif
         // Wrong type
         EXPECT_THROW(ai.getVariable<int>("float"), exception::InvalidVarType);
     }
@@ -195,6 +285,10 @@ TEST(AgentInstanceTest, getsetVariable) {
         // Index out of bounds
         EXPECT_THROW(ai.getVariable<int>("int2", 2), exception::OutOfBoundsException);
         EXPECT_THROW(ai.getVariable<float>("float", 1), exception::OutOfBoundsException);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.getVariable<glm::vec3>("ivec3_3", 4), exception::OutOfBoundsException);
+        EXPECT_THROW(ai.getVariable<glm::vec3>("int3", 1), exception::OutOfBoundsException);
+#endif
         // Wrong type
         EXPECT_THROW(ai.getVariable<int>("float", 0), exception::InvalidVarType);
     }

--- a/tests/test_cases/pop/test_agent_vector.cu
+++ b/tests/test_cases/pop/test_agent_vector.cu
@@ -15,6 +15,9 @@ TEST(AgentVectorTest, constructor) {
     agent.newVariable<unsigned int>("uint", 2u);
     agent.newVariable<float>("float", 3.0f);
     agent.newVariable<double>("double", 4.0);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
 
     // Create empty vector
     AgentVector empty_pop(agent);
@@ -29,6 +32,9 @@ TEST(AgentVectorTest, constructor) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 }
 TEST(AgentVectorTest, copy_constructor) {
@@ -40,6 +46,9 @@ TEST(AgentVectorTest, copy_constructor) {
     agent.newVariable<unsigned int>("uint", 2u);
     agent.newVariable<float>("float", 3.0f);
     agent.newVariable<double>("double", 4.0);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
 
     // Create empty vector
     AgentVector base_empty_pop(agent);
@@ -56,6 +65,9 @@ TEST(AgentVectorTest, copy_constructor) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 }
 TEST(AgentVectorTest, move_constructor) {
@@ -67,6 +79,9 @@ TEST(AgentVectorTest, move_constructor) {
     agent.newVariable<unsigned int>("uint", 2u);
     agent.newVariable<float>("float", 3.0f);
     agent.newVariable<double>("double", 4.0);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
 
     // Create empty vector
     AgentVector base_empty_pop(agent);
@@ -83,6 +98,9 @@ TEST(AgentVectorTest, move_constructor) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 }
 TEST(AgentVectorTest, copy_assignment_operator) {
@@ -94,6 +112,9 @@ TEST(AgentVectorTest, copy_assignment_operator) {
     agent.newVariable<unsigned int>("uint", 2u);
     agent.newVariable<float>("float", 3.0f);
     agent.newVariable<double>("double", 4.0);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
 
     // Create empty vector
     AgentVector base_empty_pop(agent);
@@ -111,6 +132,9 @@ TEST(AgentVectorTest, copy_assignment_operator) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 }
 TEST(AgentVectorTest, move_assignment_operator) {
@@ -122,6 +146,9 @@ TEST(AgentVectorTest, move_assignment_operator) {
     agent.newVariable<unsigned int>("uint", 2u);
     agent.newVariable<float>("float", 3.0f);
     agent.newVariable<double>("double", 4.0);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
 
     // Create empty vector
     AgentVector base_empty_pop(agent);
@@ -139,6 +166,9 @@ TEST(AgentVectorTest, move_assignment_operator) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 }
 TEST(AgentVectorTest, at) {
@@ -150,6 +180,9 @@ TEST(AgentVectorTest, at) {
     agent.newVariable<unsigned int>("uint", 2u);
     agent.newVariable<float>("float", 3.0f);
     agent.newVariable<double>("double", 4.0);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
 
     // Create vector with 10 agents, all default init
     AgentVector pop(agent, POP_SIZE);
@@ -160,6 +193,9 @@ TEST(AgentVectorTest, at) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 
     // Create vector with 10 agents, all default init
@@ -171,6 +207,9 @@ TEST(AgentVectorTest, at) {
         ASSERT_EQ(instance.getVariable<unsigned int>("uint"), 2u);
         ASSERT_EQ(instance.getVariable<float>("float"), 3.0f);
         ASSERT_EQ(instance.getVariable<double>("double"), 4.0);
+#ifdef USE_GLM
+        ASSERT_EQ(instance.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+#endif
     }
 
     // Out of bounds exception
@@ -332,6 +371,41 @@ TEST(AgentVectorTest, iterator) {
     }
     ASSERT_EQ(i, 0u);
 }
+#ifdef USE_GLM
+TEST(AgentVectorTest, iterator_GLM) {
+    const unsigned int POP_SIZE = 10;
+    // Test correctness of AgentVector array iterator, and the member functions for creating them.
+    ModelDescription model("model");
+    AgentDescription& agent = model.newAgent("agent");
+    agent.newVariable<glm::uvec3>("uvec3");
+
+    // Create vector with 10 agents, init to their index
+    AgentVector pop(agent, POP_SIZE);
+    ASSERT_EQ(pop.size(), POP_SIZE);
+    for (unsigned int i = 0; i < POP_SIZE; ++i) {
+        pop[i].setVariable<glm::uvec3>("uvec3", glm::uvec3(i +3, i + 6, i));
+    }
+
+    // Iterate vector
+    unsigned int i = 0;
+    for (AgentVector::Agent instance : pop) {
+        auto a = instance.getVariable<glm::uvec3>("uvec3");
+        ASSERT_EQ(instance.getVariable<glm::uvec3>("uvec3"), glm::uvec3(i + 3, i + 6, i));
+        ++i;
+    }
+    ASSERT_EQ(i, pop.size());
+
+    // Test empty is empty
+    AgentVector empty_pop(agent);
+    i = 0;
+    for (AgentVector::Agent instance : empty_pop) {
+        ++i;
+    }
+    ASSERT_EQ(i, 0u);
+}
+#else
+TEST(AgentVectorTest, DISABLED_iterator_glm) { }
+#endif
 TEST(AgentVectorTest, const_iterator) {
     const unsigned int POP_SIZE = 10;
     // Test correctness of AgentVector const_iterator
@@ -1282,10 +1356,18 @@ TEST(AgentVectorTest, AgentVector_Agent) {
     agent.newVariable<int, 3>("int3", {2, 3, 4});
     agent.newVariable<int, 2>("int2", { 5, 6 });
     agent.newVariable<float>("float", 15.0f);
+#ifdef USE_GLM
+    agent.newVariable<glm::vec3>("vec3", glm::vec3(2.0f, 4.0f, 6.0f));
+    agent.newVariable<glm::ivec3, 3>("ivec3_3", {glm::ivec3(12, 14, 16), glm::ivec3(2, 4, 6), glm::ivec3(22, 24, 26)});
+    agent.newVariable<glm::ivec3, 3>("ivec3_3b", {glm::ivec3(12, 14, 16), glm::ivec3(2, 4, 6), glm::ivec3(22, 24, 26)});
+#endif
 
     // Create pop, variables are as expected
     AgentVector pop(agent, POP_SIZE);
     const std::array<int, 3> int3_ref = { 2, 3, 4 };
+#ifdef USE_GLM
+    const std::array<glm::ivec3, 3> vec_array_check = {glm::ivec3(12, 14, 16), glm::ivec3(2, 4, 6), glm::ivec3(22, 24, 26)};
+#endif
     for (unsigned int i = 0; i < POP_SIZE; ++i) {
         AgentVector::Agent ai = pop[i];
         ASSERT_EQ(ai.getVariable<unsigned int>("uint"), 12u);
@@ -1294,6 +1376,14 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         ASSERT_EQ(ai.getVariable<int>("int2", 0), 5);
         ASSERT_EQ(ai.getVariable<int>("int2", 1), 6);
         ASSERT_EQ(ai.getVariable<float>("float"), 15.0f);
+#ifdef USE_GLM
+        ASSERT_EQ(ai.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f, 4.0f, 6.0f));
+        const auto vec_array_test = ai.getVariable<glm::ivec3, 3>("ivec3_3");
+        ASSERT_EQ(vec_array_test, vec_array_check);
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 0), glm::ivec3(12, 14, 16));
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 1), glm::ivec3(2, 4, 6));
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 2), glm::ivec3(22, 24, 26));
+#endif
     }
 
     // Update values
@@ -1305,6 +1395,13 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         ai.setVariable<int>("int2", 0, 5 + static_cast<int>(i));
         ai.setVariable<int>("int2", 1, 6 + static_cast<int>(i));
         ai.setVariable<float>("float", 15.0f + static_cast<float>(i));
+#ifdef USE_GLM
+        ai.setVariable<glm::vec3>("vec3", glm::vec3(2.0f + static_cast<float>(i), 4.0f + static_cast<float>(i), 6.0f + static_cast<float>(i)));
+        ai.setVariable<glm::ivec3, 3>("ivec3_3", {glm::ivec3(12, 14, 16) + glm::ivec3(static_cast<int>(i)), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i)), glm::ivec3(22, 24, 26) + glm::ivec3(static_cast<int>(i))});
+        // Don't update ivec3_3b index 0
+        ai.setVariable<glm::ivec3>("ivec3_3b", 1, glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 3));
+        ai.setVariable<glm::ivec3>("ivec3_3b", 2, glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 4));
+#endif
     }
 
     // Check vars now match as expected
@@ -1317,6 +1414,15 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         ASSERT_EQ(ai.getVariable<int>("int2", 0), 5 + static_cast<int>(i));
         ASSERT_EQ(ai.getVariable<int>("int2", 1), 6 + static_cast<int>(i));
         ASSERT_EQ(ai.getVariable<float>("float"), 15.0f + static_cast<float>(i));
+#ifdef USE_GLM
+        ASSERT_EQ(ai.getVariable<glm::vec3>("vec3"), glm::vec3(2.0f + static_cast<float>(i), 4.0f + static_cast<float>(i), 6.0f + static_cast<float>(i)));
+        const std::array<glm::ivec3, 3> vec_array_check2 = {glm::ivec3(12, 14, 16) + glm::ivec3(static_cast<int>(i)), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i)), glm::ivec3(22, 24, 26) + glm::ivec3(static_cast<int>(i))};
+        const std::array<glm::ivec3, 3> vec_array_test = ai.getVariable<glm::ivec3, 3>("ivec3_3");
+        ASSERT_EQ(vec_array_test, vec_array_check2);
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 0), glm::ivec3(12, 14, 16));
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 1), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 3));
+        ASSERT_EQ(ai.getVariable<glm::ivec3>("ivec3_3b", 2), glm::ivec3(2, 4, 6) + glm::ivec3(static_cast<int>(i) * 4));
+#endif
     }
 
     // Check various exceptions
@@ -1326,6 +1432,9 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         EXPECT_THROW(ai.setVariable<int>("wrong", 1), exception::InvalidAgentVar);
         // Array passed to non-array method
         EXPECT_THROW(ai.setVariable<int>("int2", 1), exception::InvalidVarType);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.setVariable<glm::vec3>("float", {}), exception::InvalidVarType);
+#endif
         // Wrong type
         EXPECT_THROW(ai.setVariable<int>("float", 1), exception::InvalidVarType);
     }
@@ -1347,6 +1456,10 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         // Index out of bounds
         EXPECT_THROW(ai.setVariable<int>("int2", 2, 1), exception::OutOfBoundsException);
         EXPECT_THROW(ai.setVariable<float>("float", 1, 1), exception::OutOfBoundsException);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.setVariable<glm::ivec3>("ivec3_3", 4, {}), exception::OutOfBoundsException);
+        EXPECT_THROW(ai.setVariable<glm::ivec3>("int3", 1, {}), exception::OutOfBoundsException);
+#endif
         // Wrong type
         EXPECT_THROW(ai.setVariable<int>("float", 0, 1), exception::InvalidVarType);
     }
@@ -1355,6 +1468,9 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         EXPECT_THROW(ai.getVariable<int>("wrong"), exception::InvalidAgentVar);
         // Array passed to non-array method
         EXPECT_THROW(ai.getVariable<int>("int2"), exception::InvalidVarType);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.getVariable<glm::vec3>("float"), exception::InvalidVarType);
+#endif
         // Wrong type
         EXPECT_THROW(ai.getVariable<int>("float"), exception::InvalidVarType);
     }
@@ -1374,6 +1490,10 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         // Index out of bounds
         EXPECT_THROW(ai.getVariable<int>("int2", 2), exception::OutOfBoundsException);
         EXPECT_THROW(ai.getVariable<float>("float", 1), exception::OutOfBoundsException);
+#ifdef USE_GLM
+        EXPECT_THROW(ai.getVariable<glm::vec3>("ivec3_3", 4), exception::OutOfBoundsException);
+        EXPECT_THROW(ai.getVariable<glm::vec3>("int3", 1), exception::OutOfBoundsException);
+#endif
         // Wrong type
         EXPECT_THROW(ai.getVariable<int>("float", 0), exception::InvalidVarType);
     }

--- a/tests/test_cases/runtime/messaging/test_brute_force.cu
+++ b/tests/test_cases/runtime/messaging/test_brute_force.cu
@@ -38,6 +38,7 @@ FLAMEGPU_AGENT_FUNCTION(InFunction, MessageBruteForce, MessageNone) {
         sum += x;
         product *= x;
         product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
     }
     FLAMEGPU->setVariable<int>("sum", sum);
     FLAMEGPU->setVariable<int>("product", product);
@@ -51,6 +52,7 @@ FLAMEGPU_AGENT_FUNCTION(InFunction2, MessageBruteForce, MessageNone) {
         sum += x;
         product *= x;
         product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
     }
     FLAMEGPU->setVariable<int>("sum", sum);
     FLAMEGPU->setVariable<int>("product", product);
@@ -91,6 +93,7 @@ TEST(TestMessage_BruteForce, Mandatory1) {
         sum += x;
         product *= x;
         product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
         ai.setVariable<int>("x", x);
         ai.setVariable<int>("sum", 0);
         ai.setVariable<int>("product", 1);
@@ -133,15 +136,20 @@ TEST(TestMessage_BruteForce, Mandatory2) {
     int product = 1;
     for (AgentVector::Agent ai : pop) {
         const int x = dist(rng);
-        sum += x;
-        product *= x;
-        product = product > 1000000 ? 1 : product;
-        sum += (x + 1);
-        product *= (x + 1);
-        product = product > 1000000 ? 1 : product;
         ai.setVariable<int>("x", x);
         ai.setVariable<int>("sum", 0);
         ai.setVariable<int>("product", 1);
+        sum += x;
+        product *= x;
+        product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
+    }
+    for (AgentVector::Agent ai : pop) {
+        const int x = ai.getVariable<int>("x");
+        sum += (x + 1);
+        product *= (x + 1);
+        product = product > 1000000 ? 1 : product;
+        product = product < -1000000 ? -1 : product;
     }
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);
     lo.addAgentFunction(fo);
@@ -188,6 +196,7 @@ TEST(TestMessage_BruteForce, Optional1) {
             sum += x;
             product *= x;
             product = product > 1000000 ? 1 : product;
+            product = product < -1000000 ? -1 : product;
         }
         ai.setVariable<int>("x", x);
         ai.setVariable<int>("sum", 0);
@@ -233,6 +242,7 @@ TEST(TestMessage_BruteForce, Optional2) {
             sum += x;
             product *= x;
             product = product > 1000000 ? 1 : product;
+            product = product < -1000000 ? -1 : product;
         }
         ai.setVariable<int>("x", x);
         ai.setVariable<int>("sum", 0);
@@ -245,6 +255,7 @@ TEST(TestMessage_BruteForce, Optional2) {
             sum += (x + 1);
             product *= (x + 1);
             product = product > 1000000 ? 1 : product;
+            product = product < -1000000 ? -1 : product;
         }
     }
     LayerDescription &lo = m.newLayer(OUT_LAYER_NAME);

--- a/tests/test_cases/runtime/test_device_api.cu
+++ b/tests/test_cases/runtime/test_device_api.cu
@@ -187,7 +187,7 @@ TEST(DeviceAPITest, ArraySet_glm) {
     ModelDescription model("model");
     AgentDescription& agent = model.newAgent("agent_name");
     agent.newVariable<float>("x");
-    agent.newVariable<int, 4>("array_var");
+    agent.newVariable<glm::ivec4>("array_var");
     agent.newVariable<float>("y");
     agent.newVariable<int>("id");
     // Do nothing, but ensure variables are made available on device
@@ -219,7 +219,7 @@ TEST(DeviceAPITest, ArraySet_glm) {
         EXPECT_EQ(instance.getVariable<float>("y"), 14.0f);
         int j = instance.getVariable<int>("id");
         // Check array sets are correct
-        auto output_array = instance.getVariable<int, 4>("array_var");
+        auto output_array = instance.getVariable<glm::ivec4>("array_var");
         EXPECT_EQ(output_array[0], 2 + j);
         EXPECT_EQ(output_array[1], 4 + j);
         EXPECT_EQ(output_array[2], 8 + j);
@@ -230,7 +230,7 @@ TEST(DeviceAPITest, ArrayGet_glm) {
     ModelDescription model("model");
     AgentDescription& agent = model.newAgent("agent_name");
     agent.newVariable<float>("x");
-    agent.newVariable<int, 4>("array_var");
+    agent.newVariable<glm::ivec4>("array_var");
     agent.newVariable<float>("y");
     agent.newVariable<int>("id");
     agent.newVariable<int>("a1");
@@ -245,7 +245,7 @@ TEST(DeviceAPITest, ArrayGet_glm) {
     for (int i = 0; i < static_cast<int>(AGENT_COUNT); i++) {
         AgentVector::Agent instance = init_population[i];
         instance.setVariable<float>("x", 12.0f);
-        instance.setVariable<int, 4>("array_var", { 2 + i, 4 + i, 8 + i, 16 + i });
+        instance.setVariable<glm::ivec4>("array_var", glm::ivec4(2 + i, 4 + i, 8 + i, 16 + i));
         instance.setVariable<float>("y", 14.0f);
         instance.setVariable<int>("id", i);
     }

--- a/tests/test_cases/runtime/test_device_environment.cu
+++ b/tests/test_cases/runtime/test_device_environment.cu
@@ -535,15 +535,15 @@ FLAMEGPU_AGENT_FUNCTION(get_array_glm, MessageNone, MessageNone) {
 }
 TEST_F(DeviceEnvironmentTest, Get_array_glm) {
     // Setup agent fn
-    ms->agent.newVariable<float, 3>("k");
+    ms->agent.newVariable<glm::vec3>("k");
     AgentFunctionDescription& deviceFn = ms->agent.newFunction("device_function", get_array_glm);
     LayerDescription& devicefn_layer = ms->model.newLayer("devicefn_layer");
     devicefn_layer.addAgentFunction(deviceFn);
     // Setup environment
-    const std::array<float, 3> t_in = { 12.0f, -12.5f, 13.0f };
-    ms->env.newProperty<float, 3>("k", t_in);
+    const glm::vec3 t_in = { 12.0f, -12.5f, 13.0f };
+    ms->env.newProperty<glm::vec3>("k", t_in);
     ms->run();
-    const std::array<float, 3> t_out = ms->population->at(0).getVariable<float, 3>("k");
+    const glm::vec3 t_out = ms->population->at(0).getVariable<glm::vec3>("k");
     ASSERT_EQ(t_in, t_out);
 }
 const char* rtc_get_array_glm = R"###(
@@ -558,11 +558,11 @@ FLAMEGPU_AGENT_FUNCTION(get_array_glm, flamegpu::MessageNone, flamegpu::MessageN
 TEST(RTCDeviceEnvironmentTest, Get_array_glm) {
     ModelDescription model("device_env_test");
     // Setup environment
-    const std::array<float, 3> t_in = { 12.0f, -12.5f, 13.0f };
-    model.Environment().newProperty<float, 3>("k", t_in);
+    const glm::vec3 t_in = { 12.0f, -12.5f, 13.0f };
+    model.Environment().newProperty<glm::vec3>("k", t_in);
     // Setup agent fn
     AgentDescription &agent = model.newAgent("agent");
-    agent.newVariable<float, 3>("k");
+    agent.newVariable<glm::vec3>("k");
     AgentFunctionDescription& deviceFn = agent.newRTCFunction("device_function", rtc_get_array_glm);
     LayerDescription& devicefn_layer = model.newLayer("devicefn_layer");
     devicefn_layer.addAgentFunction(deviceFn);
@@ -573,10 +573,11 @@ TEST(RTCDeviceEnvironmentTest, Get_array_glm) {
     cudaSimulation.setPopulationData(population);
     ASSERT_NO_THROW(cudaSimulation.simulate());
     ASSERT_NO_THROW(cudaSimulation.getPopulationData(population));
-    const std::array<float, 3> t_out = population.at(0).getVariable<float, 3>("k");
+    const glm::vec3 t_out = population.at(0).getVariable<glm::vec3>("k");
     ASSERT_EQ(t_in, t_out);
 }
 #else
-
+TEST(DeviceEnvironmentTest, DISABLED_Get_array_glm) {}
+TEST(RTCDeviceEnvironmentTest, DISABLED_Get_array_glm) {}
 #endif
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/test_host_environment.cu
+++ b/tests/test_cases/runtime/test_host_environment.cu
@@ -41,6 +41,9 @@ class MiniSim {
         ed.newProperty<uint64_t>("uint64_t_", static_cast<uint64_t>(TEST_VALUE));
         ed.newProperty<float>("read_only", static_cast<float>(TEST_VALUE), true);
         ed.newProperty<bool>("bool", true);
+#ifdef USE_GLM
+        ed.newProperty<glm::vec3>("vec3_", static_cast<glm::vec3>(TEST_VALUE));
+#endif
 
         ed.newProperty<float, TEST_ARRAY_LEN>("float_a_", makeInit<float>());
         ed.newProperty<double, TEST_ARRAY_LEN>("double_a_", makeInit<double>());
@@ -54,13 +57,16 @@ class MiniSim {
         ed.newProperty<uint64_t, TEST_ARRAY_LEN>("uint64_t_a_", makeInit<uint64_t>());
         ed.newProperty<int, TEST_ARRAY_LEN>("read_only_a", makeInit<int>(), true);
         ed.newProperty<bool, 3>("bool_a", {true, false, true});
+#ifdef USE_GLM
+        ed.newProperty<glm::vec3, TEST_ARRAY_LEN>("vec3_a_", makeInit<glm::vec3>());
+#endif
     }
     ~MiniSim() { delete population;  }
     template <typename T>
     static std::array<T, TEST_ARRAY_LEN> makeInit(int offset = 0) {
         std::array<T, TEST_ARRAY_LEN> init;
         for (int i = 0; i < TEST_ARRAY_LEN; ++i)
-            init[i] = static_cast<T>(i + 1 + offset);
+            init[i] = T{static_cast<typename type_decode<T>::type_t>(i + 1 + offset)};
         return init;
     }
     void run(int steps = 2) {
@@ -417,6 +423,7 @@ FLAMEGPU_STEP_FUNCTION(get_set_array_element_uint64_t) {
 
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_float) {
     uint64_t _a = static_cast<uint64_t>(TEST_VALUE);
+    int32_t _a2 = static_cast<int32_t>(TEST_VALUE);
     std::array<float, TEST_ARRAY_LEN> b;
     std::array<uint64_t, TEST_ARRAY_LEN> _b;
     for (int i = 0; i < TEST_ARRAY_LEN; ++i) {
@@ -429,7 +436,8 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_float) {
     */
     auto setArray = &HostEnvironment::setProperty<uint64_t, TEST_ARRAY_LEN>;
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("float_", _a), exception::InvalidEnvPropertyType);
-    // EXPECT_THROW(FLAMEGPU->environment.set<uint64_t>("float_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
+    EXPECT_THROW(FLAMEGPU->environment.setProperty<int32_t>("float_", _a2), exception::InvalidEnvPropertyType);
+    // EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("float_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
     EXPECT_THROW((FLAMEGPU->environment.*setArray)("float_a_", _b), exception::InvalidEnvPropertyType);
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("float_a_", 0, _a), exception::InvalidEnvPropertyType);
 }
@@ -447,7 +455,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_double) {
     */
     auto setArray = &HostEnvironment::setProperty<uint64_t, TEST_ARRAY_LEN>;
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("double_", _a), exception::InvalidEnvPropertyType);
-    // EXPECT_THROW(FLAMEGPU->environment.set<uint64_t>("double_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
+    // EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("double_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
     EXPECT_THROW((FLAMEGPU->environment.*setArray)("double_a_", _b), exception::InvalidEnvPropertyType);
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("double_a_", 0, _a), exception::InvalidEnvPropertyType);
 }
@@ -465,12 +473,13 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_int8_t) {
     */
     auto setArray = &HostEnvironment::setProperty<uint64_t, TEST_ARRAY_LEN>;
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("int8_t_", _a), exception::InvalidEnvPropertyType);
-    // EXPECT_THROW(FLAMEGPU->environment.set<uint64_t>("int8_t_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
+    // EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("int8_t_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
     EXPECT_THROW((FLAMEGPU->environment.*setArray)("int8_t_a_", _b), exception::InvalidEnvPropertyType);
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("int8_t_a_", 0, _a), exception::InvalidEnvPropertyType);
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_uint8_t) {
     uint64_t _a = static_cast<uint64_t>(TEST_VALUE);
+    int8_t _a2 = static_cast<int8_t>(TEST_VALUE);
     std::array<uint8_t, TEST_ARRAY_LEN> b;
     std::array<uint64_t, TEST_ARRAY_LEN> _b;
     for (int i = 0; i < TEST_ARRAY_LEN; ++i) {
@@ -483,7 +492,8 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_uint8_t) {
     */
     auto setArray = &HostEnvironment::setProperty<uint64_t, TEST_ARRAY_LEN>;
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("uint8_t_", _a), exception::InvalidEnvPropertyType);
-    // EXPECT_THROW(FLAMEGPU->environment.set<uint64_t>("uint8_t_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
+    EXPECT_THROW(FLAMEGPU->environment.setProperty<int8_t>("uint8_t_", _a2), exception::InvalidEnvPropertyType);
+    // EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("uint8_t_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
     EXPECT_THROW((FLAMEGPU->environment.*setArray)("uint8_t_a_", _b), exception::InvalidEnvPropertyType);
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("uint8_t_a_", 0, _a), exception::InvalidEnvPropertyType);
 }
@@ -525,6 +535,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_uint16_t) {
 }
 FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_int32_t) {
     uint64_t _a = static_cast<uint64_t>(TEST_VALUE);
+    uint32_t _a2 = static_cast<uint32_t>(TEST_VALUE);
     std::array<int32_t, TEST_ARRAY_LEN> b;
     std::array<uint64_t, TEST_ARRAY_LEN> _b;
     for (int i = 0; i < TEST_ARRAY_LEN; ++i) {
@@ -537,6 +548,7 @@ FLAMEGPU_STEP_FUNCTION(ExceptionPropertyType_int32_t) {
     */
     auto setArray = &HostEnvironment::setProperty<uint64_t, TEST_ARRAY_LEN>;
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("int32_t_", _a), exception::InvalidEnvPropertyType);
+    EXPECT_THROW(FLAMEGPU->environment.setProperty<uint32_t>("int32_t_", _a2), exception::InvalidEnvPropertyType);
     // EXPECT_THROW(FLAMEGPU->environment.set<uint64_t>("int32_t_a_", _b), exception::InvalidEnvPropertyType);  // Doesn't build on Travis
     EXPECT_THROW((FLAMEGPU->environment.*setArray)("int32_t_a_", _b), exception::InvalidEnvPropertyType);
     EXPECT_THROW(FLAMEGPU->environment.setProperty<uint64_t>("int32_t_a_", 0, _a), exception::InvalidEnvPropertyType);
@@ -1236,6 +1248,100 @@ TEST_F(HostEnvironmentTest, BoolWorks) {
     // Test Something
     ms->run(1);
 }
+
+#ifdef USE_GLM
+FLAMEGPU_STEP_FUNCTION(get_set_vec3_t) {
+// Test Set + Get (Description set value)
+EXPECT_EQ(FLAMEGPU->environment.setProperty<glm::vec3>("vec3_", glm::vec3(static_cast<float>(TEST_VALUE) * 2)), glm::vec3(static_cast<float>(TEST_VALUE)));
+// Test Get (Host func set value)
+EXPECT_EQ(FLAMEGPU->environment.getProperty<glm::vec3>("vec3_"), glm::vec3(static_cast<float>(TEST_VALUE) * 2));
+// Reset for next iteration
+FLAMEGPU->environment.setProperty<glm::vec3>("vec3_", glm::vec3(static_cast<float>(TEST_VALUE)));
+}
+
+FLAMEGPU_STEP_FUNCTION(get_set_array_vec3) {
+    std::array<glm::vec3, TEST_ARRAY_LEN> init1 = MiniSim::makeInit<glm::vec3>();
+    std::array<glm::vec3, TEST_ARRAY_LEN> init2 = MiniSim::makeInit<glm::vec3>(TEST_ARRAY_OFFSET);
+    // Test Set + Get (Description set value)
+    std::array<glm::vec3, TEST_ARRAY_LEN> t = FLAMEGPU->environment.setProperty<glm::vec3, TEST_ARRAY_LEN>("vec3_a_", init2);
+    for (int i = 0; i < TEST_ARRAY_LEN; ++i) {
+        EXPECT_EQ(t[i], init1[i]);
+    }
+    // Test Get (Host func set value)
+    t = FLAMEGPU->environment.getProperty<glm::vec3, TEST_ARRAY_LEN>("vec3_a_");
+    for (int i = 0; i < TEST_ARRAY_LEN; ++i) {
+        EXPECT_EQ(t[i], init2[i]);
+    }
+    // Reset for next iteration
+    FLAMEGPU->environment.setProperty<glm::vec3, TEST_ARRAY_LEN>("vec3_a_", init1);
+}
+FLAMEGPU_STEP_FUNCTION(get_set_array_element_vec3) {
+    std::array<glm::vec3, TEST_ARRAY_LEN> init1 = MiniSim::makeInit<glm::vec3>();
+    // Test Set + Get (Description set value)
+    EXPECT_EQ(FLAMEGPU->environment.setProperty<glm::vec3>("vec3_a_", TEST_ARRAY_LEN - 1, glm::vec3(static_cast<float>(TEST_VALUE) * 2)), init1[TEST_ARRAY_LEN - 1]);
+    // Test Get (Host func set value)
+    EXPECT_EQ(FLAMEGPU->environment.getProperty<glm::vec3>("vec3_a_", TEST_ARRAY_LEN - 1), glm::vec3(static_cast<float>(TEST_VALUE) * 2));
+    // Reset for next iteration
+    FLAMEGPU->environment.setProperty<glm::vec3>("vec3_a_", TEST_ARRAY_LEN - 1, init1[TEST_ARRAY_LEN - 1]);
+}
+TEST_F(HostEnvironmentTest, Get_SetGet_glm_t) {
+    ms->model.addStepFunction(get_set_vec3_t);
+    // Test Something
+    ms->run();
+}
+
+TEST_F(HostEnvironmentTest, Get_SetGetarray_glm) {
+    ms->model.addStepFunction(get_set_array_vec3);
+    // Test Something
+    ms->run();
+}
+TEST_F(HostEnvironmentTest, Get_SetGetarray_element_glm) {
+    ms->model.addStepFunction(get_set_array_element_vec3);
+    // Test Something
+    ms->run();
+}
+FLAMEGPU_STEP_FUNCTION(ExceptionPropertyLength_vec3) {
+    std::array<glm::vec3, TEST_ARRAY_LEN> b;
+    std::array<glm::vec3, 1> _b1 = {};
+    std::array<glm::vec3, TEST_ARRAY_LEN + 1> _b2;
+    std::array<glm::vec3, TEST_ARRAY_LEN * 2> _b3;
+    /**
+     * It is necessary to use function pointers for any functions that are templated with 2 args and overloaded
+     * They don't build on Travis with implied template args
+     */
+    auto setArray1 = &HostEnvironment::setProperty<glm::vec3, TEST_ARRAY_LEN>;
+    auto setArray2 = &HostEnvironment::setProperty<glm::vec3, 1>;
+    auto setArray3 = &HostEnvironment::setProperty<glm::vec3, TEST_ARRAY_LEN + 1>;
+    auto setArray4 = &HostEnvironment::setProperty<glm::vec3, TEST_ARRAY_LEN * 2>;
+    EXPECT_NO_THROW((FLAMEGPU->environment.*setArray1)("vec3_a_", b));
+    EXPECT_THROW((FLAMEGPU->environment.*setArray2)("vec3_a_", _b1), exception::OutOfBoundsException);
+    EXPECT_THROW((FLAMEGPU->environment.*setArray3)("vec3_a_", _b2), exception::OutOfBoundsException);
+    EXPECT_THROW((FLAMEGPU->environment.*setArray4)("vec3_a_", _b3), exception::OutOfBoundsException);
+}
+FLAMEGPU_STEP_FUNCTION(ExceptionPropertyRange_vec3) {
+    glm::vec3 c = static_cast<glm::vec3>(TEST_VALUE);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_THROW(FLAMEGPU->environment.setProperty<glm::vec3>("vec3_a_", TEST_ARRAY_LEN + i, c), exception::OutOfBoundsException);
+        EXPECT_THROW(FLAMEGPU->environment.getProperty<glm::vec3>("vec3_a_", TEST_ARRAY_LEN + i), exception::OutOfBoundsException);
+    }
+}
+TEST_F(HostEnvironmentTest, ExceptionPropertyLength_vec3_t) {
+    ms->model.addStepFunction(ExceptionPropertyRange_vec3);
+    // Test Something
+    ms->run(1);
+}
+TEST_F(HostEnvironmentTest, ExceptionPropertyRange_vec3_t) {
+    ms->model.addStepFunction(ExceptionPropertyRange_vec3);
+    // Test Something
+    ms->run(1);
+}
+#else
+TEST_F(HostEnvironmentTest, DISABLED_Get_SetGet_glm_t) { }
+TEST_F(HostEnvironmentTest, DISABLED_Get_SetGetarray_glm) { }
+TEST_F(HostEnvironmentTest, DISABLED_Get_SetGetarray_element_glm) { }
+TEST_F(HostEnvironmentTest, DISABLED_ExceptionPropertyLength_vec3_t) { }
+TEST_F(HostEnvironmentTest, DISABLED_ExceptionPropertyRange_vec3_t) { }
+#endif
 
 
 FLAMEGPU_STEP_FUNCTION(reserved_name_set_step) {

--- a/tests/test_cases/runtime/test_subenvironment_manager.cu
+++ b/tests/test_cases/runtime/test_subenvironment_manager.cu
@@ -508,7 +508,7 @@ TEST(SubEnvironmentManagerTest, StepCounterNotMapped) {
     {
         // Define SubModel which simply steps multiple times
         m2.addExitCondition(ExitAt10);
-        auto& a = m2.newAgent("agent");
+        m2.newAgent("agent");
     }
     ModelDescription m("host");
     auto& a = m.newAgent("agent");
@@ -541,7 +541,7 @@ TEST(SubEnvironmentManagerTest, CantMapReserved) {
     {
         // Define SubModel which simply steps multiple times
         m2.addExitCondition(ExitAt10);
-        auto& a = m2.newAgent("agent");
+        m2.newAgent("agent");
     }
     ModelDescription m("host");
     auto& a = m.newAgent("agent");


### PR DESCRIPTION
By using `type_decode<glm::vec3>` the base type and length can be extracted. The same `type_decode` works on the native types, e.g. `float`, reporting them with a length of 1.

This requires some thorough testing, as it's possible I've missed stuff. I will probably need to add some extra tests.

## Testing: 

- [x] `AgentDescription`
- [x] `MessageDescription`
- [x] `EnvironmentDescription`
    - [ ]  macro property?
- [x] Device Agent *(DeviceAPI can't type check, so has much weaker checks, no code changes required)*
- [x] Device New Agent *(DeviceAPI can't type check, so has much weaker checks, no code changes required)*
- [x] Device Environment *(DeviceAPI can't type check, so has much weaker checks, no code changes required)*
    - [ ]  macro property?
- [x] Host New Agent
- [x] Host Agent reduce *(Only custom transform and reduce are suitable for vec types)*
- [x] `HostEnvironment`
    - [ ]  macro property?
- [x] `AgentVector::Agent`
- [x] `AgentInstance`
- [x] `CUDASimulation` (set/get environment)
- [x] `RunPlan` ?
- [ ] Python stuff?
   
Closes #809