### PR TITLE
Update Jitify dependency

### DIFF
--- a/cmake/dependencies/Jitify.cmake
+++ b/cmake/dependencies/Jitify.cmake
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0079 NEW)
 FetchContent_Declare(
     jitify
     GIT_REPOSITORY https://github.com/NVIDIA/jitify.git
-    GIT_TAG        7b724609f7134d3e216678bb20b74edb187fbcaa
+    GIT_TAG        cd6b56bf0c63fcce74a59cd021bf63e5c2a32c73
     SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/jitify-src/jitify
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON


### PR DESCRIPTION
This Jitify update introduces further system header shims, required for full GLM functionality.
`std::numeric_limits<unsigned int>::is_iec559` was missing, which GLM required for it's vector equality.