### PR TITLE
Replace cbrt() with sqrtf() in Circles examples.

### DIFF
--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -26,9 +26,9 @@ FLAMEGPU_AGENT_FUNCTION(move, flamegpu::MessageBruteForce, flamegpu::MessageNone
             float x21 = x2 - x1;
             float y21 = y2 - y1;
             float z21 = z2 - z1;
-            const float separation = cbrt(x21*x21 + y21*y21 + z21*z21);
+            const float separation = sqrtf(x21*x21 + y21*y21 + z21*z21);
             if (separation < RADIUS && separation > 0.0f) {
-                float k = sinf((separation / RADIUS)*3.141*-2)*REPULSE_FACTOR;
+                float k = sinf((separation / RADIUS)*3.141f*-2)*REPULSE_FACTOR;
                 // Normalise without recalculating separation
                 x21 /= separation;
                 y21 /= separation;
@@ -46,7 +46,7 @@ FLAMEGPU_AGENT_FUNCTION(move, flamegpu::MessageBruteForce, flamegpu::MessageNone
     FLAMEGPU->setVariable<float>("x", x1 + fx);
     FLAMEGPU->setVariable<float>("y", y1 + fy);
     FLAMEGPU->setVariable<float>("z", z1 + fz);
-    FLAMEGPU->setVariable<float>("drift", cbrt(fx*fx + fy*fy + fz*fz));
+    FLAMEGPU->setVariable<float>("drift", sqrtf(fx*fx + fy*fy + fz*fz));
     return flamegpu::ALIVE;
 }
 FLAMEGPU_STEP_FUNCTION(Validation) {

--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -27,9 +27,9 @@ FLAMEGPU_AGENT_FUNCTION(move, flamegpu::MessageSpatial3D, flamegpu::MessageNone)
             float x21 = x2 - x1;
             float y21 = y2 - y1;
             float z21 = z2 - z1;
-            const float separation = cbrt(x21*x21 + y21*y21 + z21*z21);
+            const float separation = sqrtf(x21*x21 + y21*y21 + z21*z21);
             if (separation < RADIUS && separation > 0.0f) {
-                float k = sinf((separation / RADIUS)*3.141*-2)*REPULSE_FACTOR;
+                float k = sinf((separation / RADIUS)*3.141f*-2)*REPULSE_FACTOR;
                 // Normalise without recalculating separation
                 x21 /= separation;
                 y21 /= separation;
@@ -47,7 +47,7 @@ FLAMEGPU_AGENT_FUNCTION(move, flamegpu::MessageSpatial3D, flamegpu::MessageNone)
     FLAMEGPU->setVariable<float>("x", x1 + fx);
     FLAMEGPU->setVariable<float>("y", y1 + fy);
     FLAMEGPU->setVariable<float>("z", z1 + fz);
-    FLAMEGPU->setVariable<float>("drift", cbrt(fx*fx + fy*fy + fz*fz));
+    FLAMEGPU->setVariable<float>("drift", sqrtf(fx*fx + fy*fy + fz*fz));
     return flamegpu::ALIVE;
 }
 FLAMEGPU_STEP_FUNCTION(Validation) {


### PR DESCRIPTION
Use of double function, incorrectly leads to large compute usage.

Also noticed `cbrt()` being used rather than `sqrt()`, a mistake when mapping from glm to raw math, (Presumably it doesn't significantly affect model behaviour as it was using `glm::length()` in fgpu1 models, just awkwardly reduce interaction radius, but haven't tested it).