### PR TITLE
Update visualiser dependency version

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 # @todo - If the git version has changed in this file, fetch again? 
-set(DEFAULT_VISUALISATION_GIT_VERSION "2bf3078b303c83e084ba91db7882e7ea9e7c0dbb")
+set(DEFAULT_VISUALISATION_GIT_VERSION "af604a581c95c0db2104e29c2febd01b8d1520f1")
 set(DEFAULT_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # If overridden by the user, attempt to use that


### PR DESCRIPTION
This includes a bugfix where null agents would be rendered if an agent population declined.