### PR TITLE
WIP Ensemble Benchmark optimisations

### DIFF
--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -169,7 +169,7 @@ class CUDAAgent : public AgentInterface {
      * @param stream CUDA stream to be used for async CUDA operations
      * @see HostAgentAPI::sort(const std::string &, HostAgentAPI::Order, int, int)
      */
-    void scatterSort(const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void scatterSort_async(const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Allocates a buffer for storing new agents into and
      * uses the cuRVE runtime to map variables for use with an agent function that has device agent birth
@@ -178,9 +178,11 @@ class CUDAAgent : public AgentInterface {
      * @param maxLen The maximum number of new agents (this will be the size of the agent state executing func)
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
+     * @param stream The CUDA stream used to execute the initialisation of the new agent databuffers
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
+     * @note This method is async, the stream used it not synchronised
      */
-    void mapNewRuntimeVariables(const CUDAAgent& func_agent, const AgentFunctionData& func, const unsigned int &maxLen, CUDAScatter &scatter, const unsigned int &instance_id, const unsigned int &streamId);
+    void mapNewRuntimeVariables_async(const CUDAAgent& func_agent, const AgentFunctionData& func, unsigned int maxLen, CUDAScatter &scatter, unsigned int instance_id, cudaStream_t stream, unsigned int streamId);
     /**
      * Uses the cuRVE runtime to unmap the variables used by agent birth and
      * releases the buffer that was storing the data
@@ -286,8 +288,9 @@ class CUDAAgent : public AgentInterface {
     /**
      * Assigns IDs to any agents who's ID has the value ID_NOT_SET
      * @param hostapi HostAPI object, this is used to provide cub temp storage
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void assignIDs(HostAPI &hostapi);
+    void assignIDs(HostAPI &hostapi, cudaStream_t stream);
     /**
      * Used to allow HostAgentAPI to store a persistent DeviceAgentVector
      * @param state_name Agent state to affect
@@ -310,7 +313,7 @@ class CUDAAgent : public AgentInterface {
      * Validates all IDs for contained agents, if any share an ID (which is not ID_NOT_SET) an exception is thrown
      * @throws exception::AgentIDCollision If the contained agent populations contain multiple agents with the same ID
      */
-    void validateIDCollisions() const;
+    void validateIDCollisions(cudaStream_t stream) const;
     /**
      * Sums the size required for all variables
      */

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -101,7 +101,7 @@ class CUDAAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void scatterSort_async(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
      * The device buffer must be packed in the same format as CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)

--- a/include/flamegpu/gpu/CUDAFatAgent.h
+++ b/include/flamegpu/gpu/CUDAFatAgent.h
@@ -161,8 +161,9 @@ class CUDAFatAgent {
     /**
      * Assigns IDs to any agents who's ID has the value ID_NOT_SET
      * @param hostapi HostAPI object, this is used to provide cub temp storage
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void assignIDs(HostAPI& hostapi);
+    void assignIDs(HostAPI& hostapi, cudaStream_t stream);
     /**
      * Resets the flag agent_ids_have_init
      */

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -229,7 +229,7 @@ class CUDAFatAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void scatterSort(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void scatterSort_async(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Set the number of disabled agents within the state list
      * Updates member var disabledAgents and data_condition for every item inside variables_unique

--- a/include/flamegpu/gpu/CUDAMacroEnvironment.h
+++ b/include/flamegpu/gpu/CUDAMacroEnvironment.h
@@ -95,15 +95,16 @@ class CUDAMacroEnvironment {
     /**
      * Performs CUDA allocations, and registers CURVE variables
      */
-    void init();
+    void init(cudaStream_t stream);
     /**
      * Performs CUDA allocations, and registers CURVE variables
      * Initialises submodel mappings too
      * @param mapping The SubEnvironment mapping info
      * @param master_macro_env The master model's macro env to map sub macro properties with
+     * @param stream The CUDAStream to use for CUDA operations
      * @note This must be called after the master model CUDAMacroEnvironment has init
      */
-    void init(const SubEnvironmentData& mapping, const CUDAMacroEnvironment& master_macro_env);
+    void init(const SubEnvironmentData& mapping, const CUDAMacroEnvironment& master_macro_env, cudaStream_t stream);
     /**
      * Release all CUDA allocations, and unregisters CURVE variables
      */

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -62,16 +62,18 @@ class CUDAMessage {
      * This allocates and initialises any CUDA data structures for reading the messagelist, and sets them asthough the messagelist were empty.
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId);
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Updates message_count to equal newSize, internally reallocates buffer space if more space is required
      * @param newSize The number of messages that the buffer should be capable of storing
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
+     * @param stream The CUDAStream to use for CUDA operations
      * @param streamId Index of stream specific structures used
      * @param keepLen Number of existing messages worth of data to retain through the resize
      */
-    void resize(unsigned int newSize, CUDAScatter &scatter, const unsigned int &streamId, const unsigned int &keepLen = 0);
+    void resize(unsigned int newSize, CUDAScatter &scatter, cudaStream_t stream, unsigned int streamId, unsigned int keepLen = 0);
     /**
      * Uses the cuRVE runtime to map the variables used by the agent function to the cuRVE library so that can be accessed by name within a n agent function
      * The read runtime variables are to be used when reading messages
@@ -87,9 +89,10 @@ class CUDAMessage {
      * @param cuda_agent Agent which owns the agent function (condition) being mapped, if RTC function this holds the RTC header
      * @param writeLen The number of messages to be output, as the length isn't updated till after output
      * @param instance_id The CUDASimulation instance_id of the parent instance. This is added to the hash, to differentiate instances
+     * @param stream The CUDAStream to use for CUDA operations
      * @note swap() or scatter() should be called after the agent function has written messages
      */
-    void mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &writeLen, const unsigned int &instance_id) const;
+    void mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &writeLen, const unsigned int &instance_id, cudaStream_t stream) const;
     /**
      * Uses the cuRVE runtime to unmap the variables used by the agent function to the cuRVE
      * library so that they are unavailable to be accessed by name within an agent function.
@@ -105,10 +108,11 @@ class CUDAMessage {
      * @param isOptional If optional newMessageCount will be reduced based on scan_flag[streamId]
      * @param newMessageCount The number of output messages (including optional messages which were not output)
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
+     * @param stream The CUDAStream to use for CUDA operations
      * @param streamId Index of stream specific structures used
      * @throw exception::InvalidCudaMessage If this is called before the internal buffers have been allocated
      */
-    void swap(bool isOptional, const unsigned int &newMessageCount, CUDAScatter &scatter, const unsigned int &streamId);
+    void swap(bool isOptional, unsigned int newMessageCount, CUDAScatter &scatter, cudaStream_t stream, unsigned int streamId);
     /**
      * Basic list swap with no additional actions
      */
@@ -132,7 +136,7 @@ class CUDAMessage {
     /** 
      * Zero all message variable data.
      */
-    void zeroAllMessageData();
+    void zeroAllMessageData(cudaStream_t stream);
 
  private:
      /**

--- a/include/flamegpu/gpu/CUDAMessageList.h
+++ b/include/flamegpu/gpu/CUDAMessageList.h
@@ -28,7 +28,7 @@ class CUDAMessageList {
      /**
       * Initially allocates message lists based on cuda_message.getMaximumListSize()
       */
-    explicit CUDAMessageList(CUDAMessage& cuda_message, CUDAScatter &scatter, const unsigned int &streamId);
+    explicit CUDAMessageList(CUDAMessage& cuda_message, CUDAScatter &scatter, cudaStream_t stream, unsigned int streamId);
     /**
      * Frees all message list memory
      */
@@ -54,16 +54,17 @@ class CUDAMessageList {
      * Resize the internal message list buffers to the length of the parent CUDAMessage
      * Retain keep_len items from d_list during the resize (d_swap_list data is lost)
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
+     * @param stream The CUDAStream to use for CUDA operations
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param keep_len If specified, number of items to retain through the resize
      * @throw If keep_len exceeds the new buffer length
      * @note This class has no way of knowing if keep_len exceeds the old buffer length size
      */
-    void resize(CUDAScatter& scatter, const unsigned int& streamId = 0, const unsigned int& keep_len = 0);
+    void resize(CUDAScatter& scatter, cudaStream_t stream, unsigned int streamId = 0, unsigned int keep_len = 0);
     /**
      * Memset all variable arrays in each list to 0
      */
-    void zeroMessageData();
+    void zeroMessageData(cudaStream_t stream);
     /**
      * Swap d_list and d_swap_list
      */
@@ -72,21 +73,23 @@ class CUDAMessageList {
      * Perform a compaction using d_message_scan_flag and d_message_position
      * @param newCount Number of new messages to be scattered
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
+     * @param stream The CUDAStream to use for CUDA operations
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param append If true scattered messages will append to the existing message list, otherwise truncate
      * @return Total number of messages now in list (includes old + new counts if appending)
      */
-    virtual unsigned int scatter(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId, const bool &append);
+    virtual unsigned int scatter(unsigned int newCount, CUDAScatter &scatter, cudaStream_t stream, unsigned int streamId, bool append);
     /**
      * Copy all message data from d_swap_list to d_list
      * This ALWAYS performs and append to the existing message list count
      * Used by swap() when appending messagelists
      * @param newCount Number of new messages to be scattered
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
+     * @param stream The CUDAStream to use for CUDA operations
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @return Total number of messages now in list (includes old + new counts)
      */
-    virtual unsigned int scatterAll(const unsigned int &newCount, CUDAScatter &scatter, const unsigned int &streamId);
+    virtual unsigned int scatterAll(unsigned int newCount, CUDAScatter &scatter, cudaStream_t stream, unsigned int streamId);
     /**
      * @return Returns the map<variable_name, device_ptr> for reading message data
      */
@@ -97,22 +100,23 @@ class CUDAMessageList {
     const CUDAMessageMap &getWriteList() { return d_swap_list; }
 
  protected:
-     /**
-      * Allocates device memory for the provided message list
-      * @param memory_map Message list to perform operation on
-      */
-     void allocateDeviceMessageList(CUDAMessageMap &memory_map);
-     /**
-      * Frees device memory for the provided message list
-      * @param memory_map Message list to perform operation on
-      */
-     void releaseDeviceMessageList(CUDAMessageMap &memory_map);
-     /**
-      * Zeros device memory for the provided message list
-      * @param memory_map Message list to perform operation on
-      * @param skip_offset Number of items at the start of the list to not zero
-      */
-     void zeroDeviceMessageList(CUDAMessageMap &memory_map, const unsigned int& skip_offset = 0);
+    /**
+     * Allocates device memory for the provided message list
+     * @param memory_map Message list to perform operation on
+     */
+    void allocateDeviceMessageList(CUDAMessageMap &memory_map);
+    /**
+     * Frees device memory for the provided message list
+     * @param memory_map Message list to perform operation on
+     */
+    void releaseDeviceMessageList(CUDAMessageMap &memory_map);
+    /**
+     * Zeros device memory for the provided message list
+     * @param memory_map Message list to perform operation on
+     * @param stream The CUDAStream to use for CUDA operations
+     * @param skip_offset Number of items at the start of the list to not zero
+     */
+    void zeroDeviceMessageList_async(CUDAMessageMap &memory_map, cudaStream_t stream, unsigned int skip_offset = 0);
 
  private:
      /**

--- a/include/flamegpu/gpu/CUDAScanCompaction.h
+++ b/include/flamegpu/gpu/CUDAScanCompaction.h
@@ -1,5 +1,6 @@
 #ifndef INCLUDE_FLAMEGPU_GPU_CUDASCANCOMPACTION_H_
 #define INCLUDE_FLAMEGPU_GPU_CUDASCANCOMPACTION_H_
+#include <driver_types.h>
 
 namespace flamegpu {
 
@@ -74,8 +75,10 @@ struct CUDAScanCompactionConfig {
     void resize_scan_flag(const unsigned int& count);
     /**
      * Reset all data inside the two scan buffers to 0
+     * @param stream The CUDA stream used to execute the memset
+     * @note This method is async, the cuda stream is not synchronised
      */
-    void zero_scan_flag();
+    void zero_scan_flag_async(cudaStream_t stream);
 };
 
 /**
@@ -127,9 +130,11 @@ class CUDAScanCompaction {
     /**
      * Reset all scan flags in the buffer for the specified stream and type to zero
      * @param type The type of the scan flag buffer to be zerod
+     * @param stream The CUDA stream used to execute the memset
      * @param streamId The stream index of the scan flag buffer to be zerod
+     * @note This method is async, the cuda stream is not synchronised
      */
-    void zero(const Type& type, const unsigned int& streamId);
+    void zero_async(const Type& type, cudaStream_t stream, unsigned int streamId);
     /**
      * Returns a const reference to the scan flag config structure for the specified stream and type
      * @param type The type of the scan flag buffer to return

--- a/include/flamegpu/gpu/CUDAScatter.cuh
+++ b/include/flamegpu/gpu/CUDAScatter.cuh
@@ -139,12 +139,18 @@ class CUDAScatter {
      * @param scatterData Vector of scatter configuration for each variable to be scattered
      * @param itemCount Total number of items in input array to consider
      */
+    void scatterPosition_async(
+        unsigned int streamResourceId,
+        cudaStream_t stream,
+        Type messageOrAgent,
+        const std::vector<ScatterData>& scatterData,
+        unsigned int itemCount);
     void scatterPosition(
-        const unsigned int &streamResourceId,
-        const cudaStream_t &stream,
-        const Type &messageOrAgent,
+        unsigned int streamResourceId,
+        cudaStream_t stream,
+        Type messageOrAgent,
         const std::vector<ScatterData> &scatterData,
-        const unsigned int &itemCount);
+        unsigned int itemCount);
     /**
      * Returns the final CUDAScanCompaction::position item 
      * Same value as scatter, - scatter_a__count
@@ -244,19 +250,32 @@ class CUDAScatter {
      * @param itemCount Total number of items in input array to consider
      * @param out_index_offset The offset to be applied to the ouput index (e.g. if out already contains data)
      */
-    void broadcastInit(
-        const unsigned int &streamResourceId,
-        const cudaStream_t &stream,
+    void broadcastInit_async(
+        unsigned int streamResourceId,
+        cudaStream_t stream,
         const std::list<std::shared_ptr<VariableBuffer>> &vars,
-        const unsigned int &itemCount,
-        const unsigned int out_index_offset);
+        unsigned int itemCount,
+        unsigned int out_index_offset);
     void broadcastInit(
-        const unsigned int &streamResourceId,
-        const cudaStream_t &stream,
+        unsigned int streamResourceId,
+        cudaStream_t stream,
+        const std::list<std::shared_ptr<VariableBuffer>>& vars,
+        unsigned int itemCount,
+        unsigned int out_index_offset);
+    void broadcastInit_async(
+        unsigned int streamResourceId,
+        cudaStream_t stream,
+        const VariableMap& vars,
+        void* const d_newBuff,
+        unsigned int itemCount,
+        unsigned int out_index_offset);
+    void broadcastInit(
+        unsigned int streamResourceId,
+        cudaStream_t stream,
         const VariableMap &vars,
         void * const d_newBuff,
-        const unsigned int &itemCount,
-        const unsigned int out_index_offset);
+        unsigned int itemCount,
+        unsigned int out_index_offset);
     /**
      * Used to reorder array messages based on __INDEX variable, that variable is not sorted
      * Also throws exception if any indexes are repeated

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -50,6 +50,7 @@ class CUDASimulation : public Simulation {
      */
     friend class HostAgentAPI;
     friend class SimRunner;
+    friend class CUDAEnsemble;
     /**
      * Map of a number of CUDA agents by name.
      * The CUDA agents are responsible for allocating and managing all the device memory
@@ -72,6 +73,8 @@ class CUDASimulation : public Simulation {
      * CUDA runner specific config
      */
     struct Config {
+        friend class SimRunner;
+        friend class CUDASimulation;
         /**
          * GPU to execute model on
          * Defaults to device 0, this is most performant device as detected by CUDA
@@ -82,6 +85,12 @@ class CUDASimulation : public Simulation {
          * Defaults to enabled.
          */
         bool inLayerConcurrency = true;
+
+     private:
+        /**
+         * Internal property set by SimRunner to adjust some features required for ensemble performance
+         */
+        bool is_ensemble = false;
     };
     /**
      * Initialise cuda runner
@@ -107,6 +116,11 @@ class CUDASimulation : public Simulation {
      * @todo Move common components (init list and initOffsetsAndMap()) into a common/shared constructor
      */
     CUDASimulation(const std::shared_ptr<SubModelData>& submodel_desc, CUDASimulation *master_model);
+    /**
+     * Called by the destructor (and CUDAEnsembles to purge singletons on exit)
+     * @note It only purges singletons on the active CUDA device
+     */
+    static void purgeSingletons();
 
  public:
     /**

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -507,7 +507,7 @@ class CUDASimulation : public Simulation {
      * Spatially sort the agents.
      * This should only be called within step();
      */
-    void spatialSortAgent(const std::string& funcName, const std::string& agentName, const std::string& state, const int mode);
+    void spatialSortAgent_async(const std::string& funcName, const std::string& agentName, const std::string& state, const int mode, cudaStream_t stream, unsigned int streamId);
 
     constexpr static int Agent2D = 0;
     constexpr static int Agent3D = 1;

--- a/include/flamegpu/runtime/detail/curve/curve.cuh
+++ b/include/flamegpu/runtime/detail/curve/curve.cuh
@@ -616,11 +616,12 @@ class Curve {
 #endif
     /**
      * Initialises cuRVE on the currently active device.
+     * @param stream CUDA stream to be uses for cudaMemset
      * 
      * @note Not yet aware if the device has been reset.
      * @todo Need to add a device-side check for initialisation.
      */
-    void initialiseDevice();
+    void initialiseDevice(cudaStream_t stream);
     /**
      * Has access to call purge
      */
@@ -628,8 +629,9 @@ class Curve {
     /**
      * Wipes out host mirrors of device memory
      * Only really to be used after calls to cudaDeviceReset()
+     * @param stream CUDA stream to be passed to initialiseDevice()
      */
-    __host__ void purge();
+    __host__ void purge(cudaStream_t stream);
 
  protected:
     /**

--- a/include/flamegpu/runtime/detail/curve/curve_rtc.cuh
+++ b/include/flamegpu/runtime/detail/curve/curve_rtc.cuh
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_DETAIL_CURVE_CURVE_RTC_CUH_
 #define INCLUDE_FLAMEGPU_RUNTIME_DETAIL_CURVE_CURVE_RTC_CUH_
 
+#include <driver_types.h>
 #include <array>
 #include <cstring>
 #include <string>
@@ -199,8 +200,10 @@ class CurveRTCHost {
     /**
      * Copy h_data_buffer to device
      * @param instance The compiled RTC agent function instance to copy the environment cache to
+     * @param stream The CUDA stream used for the cuda memcpy
+     * @note This is async, the stream is non synchronised
      */
-    void updateDevice(const jitify::experimental::KernelInstantiation& instance);
+    void updateDevice_async(const jitify::experimental::KernelInstantiation& instance, cudaStream_t stream);
 
  protected:
    /**

--- a/include/flamegpu/runtime/messaging/MessageArray/MessageArrayHost.h
+++ b/include/flamegpu/runtime/messaging/MessageArray/MessageArrayHost.h
@@ -33,21 +33,22 @@ class MessageArray::CUDAModelHandler : public MessageSpecialisationHandler {
      * Allocates message buffers, and memsets data to 0
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Sort messages according to index
      * Detect and report any duplicate indicies/gaps
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
      * Releases memory for the constructed index.
      */

--- a/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DHost.h
@@ -34,21 +34,22 @@ class MessageArray2D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Allocates message buffers, and memsets data to 0
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Sort messages according to index
      * Detect and report any duplicate indicies/gaps
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
      * Releases memory for the constructed index.
      */

--- a/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DHost.h
@@ -34,21 +34,22 @@ class MessageArray3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Allocates message buffers, and memsets data to 0
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Sort messages according to index
      * Detect and report any duplicate indicies/gaps
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
      * Releases memory for the constructed index.
      */

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
@@ -44,20 +44,21 @@ class MessageBruteForce::CUDAModelHandler : public MessageSpecialisationHandler 
      * Sets data asthough message list is empty
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Updates the length of the messagelist stored on device
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
      * Releases memory for the constructed index.
      */

--- a/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketHost.h
@@ -34,21 +34,22 @@ class MessageBucket::CUDAModelHandler : public MessageSpecialisationHandler {
     * Sets data asthough message list is empty
     * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
     * @param streamId Index of stream specific structures used
+     * @param stream The CUDAStream to use for CUDA operations
     */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Reconstructs the partition boundary matrix
      * This should be called before reading newly output messages
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
     * Allocates memory for the constructed index.
     * The memory allocation is checked by build index.
     */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
     * Releases memory for the constructed index.
     */

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h
@@ -36,21 +36,22 @@ class MessageSpatial2D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Sets data asthough message list is empty
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Reconstructs the partition boundary matrix
      * This should be called before reading newly output messages
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
      * Releases memory for the constructed index.
      */
@@ -67,7 +68,7 @@ class MessageSpatial2D::CUDAModelHandler : public MessageSpecialisationHandler {
      * So this is only called from the constructor.
      * If it were called elsewhere, it would need to be changed to resize d_histogram too
      */
-    void resizeCubTemp();
+    void resizeCubTemp(cudaStream_t stream);
     /**
      * Resizes the key value store, this scales with agent count
      * @param newSize The new number of agents to represent

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
@@ -37,21 +37,22 @@ class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Sets data asthough message list is empty
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void init(CUDAScatter &scatter, const unsigned int &streamId) override;
+    void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Reconstructs the partition boundary matrix
      * This should be called before reading newly output messages
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) override;
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) override;
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    void allocateMetaDataDevicePtr() override;
+    void allocateMetaDataDevicePtr(cudaStream_t stream) override;
     /**
      * Releases memory for the constructed index.
      */
@@ -68,7 +69,7 @@ class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * So this is only called from the constructor.
      * If it were called elsewhere, it would need to be changed to resize d_histogram too
      */
-    void resizeCubTemp();
+    void resizeCubTemp(cudaStream_t stream);
     /**
      * Resizes the key value store, this scales with agent count
      * @param newSize The new number of agents to represent

--- a/include/flamegpu/runtime/messaging/MessageSpecialisationHandler.h
+++ b/include/flamegpu/runtime/messaging/MessageSpecialisationHandler.h
@@ -23,21 +23,22 @@ class MessageSpecialisationHandler {
      * Allocate and fill metadata, as though message list was empty
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId Index of stream specific structures used
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    virtual void init(CUDAScatter &scatter, const unsigned int &streamId) = 0;
+    virtual void init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) = 0;
     /**
      * Constructs an index for the message data structure (e.g. Partition boundary matrix for spatial message types)
      * This is called the first time messages are read, after new messages have been output
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
-     * @param stream CUDA stream to be used for async CUDA operations
+     * @param stream The CUDAStream to use for CUDA operations
      */
-    virtual void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) { }
+    virtual void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) { }
     /**
      * Allocates memory for the constructed index.
      * The memory allocation is checked by build index.
      */
-    virtual void allocateMetaDataDevicePtr() { }
+    virtual void allocateMetaDataDevicePtr(cudaStream_t stream) { }
     /**
      * Releases memory for the constructed index.
      */

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -62,7 +62,7 @@ class RandomManager {
      *     while(length*shrinkModifier>_length)
      *       length*=shrinkModifier
      */
-    curandState *resize(const size_type &_length);
+    curandState *resize(size_type _length, cudaStream_t stream);
     /**
      * Accessors
      */
@@ -120,7 +120,7 @@ class RandomManager {
      * If shrinking, 'deallocated' curand states are backed up to host until next required,
      *  this prevents them being reinitialised with the same seed.
      */
-    void resizeDeviceArray(const size_type &_length);
+    void resizeDeviceArray(const size_type &_length, cudaStream_t stream);
     /**
      * Host copy of 'deallocated' curand states
      * When the device array shrinks in size, shrunk away curand states are stored here

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -167,8 +167,8 @@ void CUDAAgentStateList::scatterHostCreation(const unsigned int& newSize, char* 
     // Update number of alive agents
     parent_list->setAgentCount(parent_list->getSize() + newSize);
 }
-void CUDAAgentStateList::scatterSort(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
-    parent_list->scatterSort(scatter, streamId, stream);
+void CUDAAgentStateList::scatterSort_async(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
+    parent_list->scatterSort_async(scatter, streamId, stream);
 }
 unsigned int CUDAAgentStateList::scatterNew(void * d_newBuff, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
     if (newSize) {

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -156,6 +156,12 @@ void CUDAEnsemble::simulate(const RunPlanVector &plans) {
     ensemble_timer.stop();
     ensemble_elapsed_time = ensemble_timer.getElapsedSeconds();
 
+    // Purge singletons on every used CUDA device
+    for (auto d = devices.begin(); d != devices.end(); ++d) {
+        gpuErrchk(cudaSetDevice(*d));
+        CUDASimulation::purgeSingletons();
+    }
+
     // Ensemble has finished, print summary
     if (!config.quiet) {
         printf("\rCUDAEnsemble completed %u runs successfully!\n", static_cast<unsigned int>(plans.size() - err_ct));

--- a/src/flamegpu/gpu/CUDAFatAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAFatAgentStateList.cu
@@ -207,7 +207,7 @@ void CUDAFatAgentStateList::setDisabledAgents(const unsigned int &numberOfDisabl
         v->data_condition = data_p + (numberOfDisabled * v->type_size * v->elements);
     }
 }
-void CUDAFatAgentStateList::scatterSort(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAFatAgentStateList::scatterSort_async(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
     // This is not designed to run when there are disabled agents
     assert(disabledAgents == 0);
     // Build scatter data
@@ -221,7 +221,7 @@ void CUDAFatAgentStateList::scatterSort(CUDAScatter &scatter, const unsigned int
         // Pre update data_condition
         v->data_condition = out_p;
     }
-    scatter.scatterPosition(streamId, stream, CUDAScatter::Type::MESSAGE_OUTPUT, sd, aliveAgents);
+    scatter.scatterPosition_async(streamId, stream, CUDAScatter::Type::MESSAGE_OUTPUT, sd, aliveAgents);
 }
 void CUDAFatAgentStateList::initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
     if (initCount && exclusionSet.size()) {

--- a/src/flamegpu/gpu/CUDAScanCompaction.cu
+++ b/src/flamegpu/gpu/CUDAScanCompaction.cu
@@ -19,10 +19,10 @@ void CUDAScanCompaction::resize(const unsigned int& newCount, const Type& type, 
     configs[type][streamId].resize_scan_flag(newCount);
 }
 
-void CUDAScanCompaction::zero(const Type& type, const unsigned int& streamId) {
+void CUDAScanCompaction::zero_async(const Type& type, cudaStream_t stream, unsigned int streamId) {
     assert(streamId < MAX_STREAMS);
     assert(type < MAX_TYPES);
-    configs[type][streamId].zero_scan_flag();
+    configs[type][streamId].zero_scan_flag_async(stream);
 }
 
 const CUDAScanCompactionConfig &CUDAScanCompaction::getConfig(const Type& type, const unsigned int& streamId) {
@@ -48,12 +48,12 @@ void CUDAScanCompactionConfig::free_scan_flag() {
     }
 }
 
-void CUDAScanCompactionConfig::zero_scan_flag() {
+void CUDAScanCompactionConfig::zero_scan_flag_async(cudaStream_t stream) {
     if (d_ptrs.position) {
-        gpuErrchk(cudaMemset(d_ptrs.position, 0, scan_flag_len * sizeof(unsigned int)));  // @todo - make this async + streamSync for less ensbemble blocking.
+        gpuErrchk(cudaMemsetAsync(d_ptrs.position, 0, scan_flag_len * sizeof(unsigned int), stream));
     }
     if (d_ptrs.scan_flag) {
-        gpuErrchk(cudaMemset(d_ptrs.scan_flag, 0, scan_flag_len * sizeof(unsigned int)));  // @todo - make this async + streamSync for less ensbemble blocking.
+        gpuErrchk(cudaMemsetAsync(d_ptrs.scan_flag, 0, scan_flag_len * sizeof(unsigned int), stream));
     }
 }
 

--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -172,11 +172,20 @@ unsigned int CUDAScatter::scatter(
     return rtn + scatter_all_count;
 }
 void CUDAScatter::scatterPosition(
-    const unsigned int &streamResourceId,
-    const cudaStream_t &stream,
-    const Type &messageOrAgent,
+    unsigned int streamResourceId,
+    cudaStream_t stream,
+    Type messageOrAgent,
+    const std::vector<ScatterData>& sd,
+    unsigned int itemCount) {
+    scatterPosition_async(streamResourceId, stream, messageOrAgent, sd, itemCount);
+    gpuErrchk(cudaStreamSynchronize(stream));
+}
+void CUDAScatter::scatterPosition_async(
+    unsigned int streamResourceId,
+    cudaStream_t stream,
+    Type messageOrAgent,
     const std::vector<ScatterData> &sd,
-    const unsigned int &itemCount) {
+    unsigned int itemCount) {
     int blockSize = 0;  // The launch configurator returned block size
     int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
     int gridSize = 0;  // The actual grid size needed, based on input size
@@ -193,7 +202,6 @@ void CUDAScatter::scatterPosition(
         scan.Config(messageOrAgent, streamResourceId).d_ptrs.position,
         streamResources[streamResourceId].d_data, static_cast<unsigned int>(sd.size()));
     gpuErrchkLaunch();
-    gpuErrchk(cudaStreamSynchronize(stream));  // @todo - async + sync variants.
 }
 unsigned int CUDAScatter::scatterCount(
     const unsigned int &streamResourceId,
@@ -399,11 +407,20 @@ __global__ void broadcastInitKernel(
     memcpy(out_ptr, in_ptr, type_len);
 }
 void CUDAScatter::broadcastInit(
-    const unsigned int &streamResourceId,
-    const cudaStream_t &stream,
+    unsigned int streamResourceId,
+    cudaStream_t stream,
     const std::list<std::shared_ptr<VariableBuffer>> &vars,
-    const unsigned int &inCount,
-    const unsigned int outIndexOffset) {
+    unsigned int inCount,
+    unsigned int outIndexOffset) {
+    broadcastInit_async(streamResourceId, stream, vars, inCount, outIndexOffset);
+    gpuErrchk(cudaStreamSynchronize(stream));
+}
+void CUDAScatter::broadcastInit_async(
+    unsigned int streamResourceId,
+    cudaStream_t stream,
+    const std::list<std::shared_ptr<VariableBuffer>>& vars,
+    unsigned int inCount,
+    unsigned int outIndexOffset) {
     // No variables means no work to do
     if (vars.size() == 0) return;
     // 1 thread per agent variable
@@ -445,15 +462,24 @@ void CUDAScatter::broadcastInit(
         streamResources[streamResourceId].d_data + offset, static_cast<unsigned int>(sd.size()),
         outIndexOffset);
     gpuErrchkLaunch();
-    gpuErrchk(cudaStreamSynchronize(stream));  // @todo - async + sync variants.
 }
 void CUDAScatter::broadcastInit(
-    const unsigned int &streamResourceId,
-    const cudaStream_t &stream,
+    unsigned int streamResourceId,
+    cudaStream_t stream,
+    const VariableMap& vars,
+    void* const d_newBuff,
+    unsigned int inCount,
+    unsigned int outIndexOffset) {
+    broadcastInit_async(streamResourceId, stream, vars, d_newBuff, inCount, outIndexOffset);
+    gpuErrchk(cudaStreamSynchronize(stream));
+}
+void CUDAScatter::broadcastInit_async(
+    unsigned int streamResourceId,
+    cudaStream_t stream,
     const VariableMap &vars,
     void * const d_newBuff,
-    const unsigned int &inCount,
-    const unsigned int outIndexOffset) {
+    unsigned int inCount,
+    unsigned int outIndexOffset) {
     // 1 thread per agent variable
     const unsigned int threadCount = static_cast<unsigned int>(vars.size()) * inCount;
     int blockSize = 0;  // The launch configurator returned block size
@@ -496,7 +522,6 @@ void CUDAScatter::broadcastInit(
         streamResources[streamResourceId].d_data + offset, static_cast<unsigned int>(sd.size()),
         outIndexOffset);
     gpuErrchkLaunch();
-    gpuErrchk(cudaStreamSynchronize(stream));  // @todo - async + sync variants.
 }
 __global__ void reorder_array_messages(
     const unsigned int threadCount,

--- a/src/flamegpu/runtime/HostAgentAPI.cu
+++ b/src/flamegpu/runtime/HostAgentAPI.cu
@@ -26,7 +26,7 @@ __global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount
     }
 }
 
-void HostAgentAPI::fillTIDArray(unsigned int *buffer, const unsigned int &threadCount, const cudaStream_t &stream) {
+void HostAgentAPI::fillTIDArray_async(unsigned int *buffer, unsigned int threadCount, cudaStream_t stream) {
     initToThreadIndex<<<(threadCount/512)+1, 512, 0, stream>>>(buffer, threadCount);
     gpuErrchkLaunch();
 }
@@ -38,7 +38,7 @@ __global__ void sortBuffer_kernel(char *dest, char*src, unsigned int *position, 
     }
 }
 
-void HostAgentAPI::sortBuffer(void *dest, void*src, unsigned int *position, const size_t &typeLen, const unsigned int &threadCount, const cudaStream_t &stream) {
+void HostAgentAPI::sortBuffer_async(void *dest, void*src, unsigned int *position, size_t typeLen, unsigned int threadCount, cudaStream_t stream) {
     sortBuffer_kernel<<<(threadCount/512)+1, 512, 0, stream >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
     gpuErrchkLaunch();
 }

--- a/src/flamegpu/runtime/detail/curve/curve.cu
+++ b/src/flamegpu/runtime/detail/curve/curve.cu
@@ -41,12 +41,12 @@ std::mutex Curve::instance_mutex;
 __host__ Curve::Curve() :
     deviceInitialised(false) {
 }
-__host__ void Curve::purge() {
+__host__ void Curve::purge(cudaStream_t stream) {
     auto lock = std::unique_lock<std::shared_timed_mutex>(mutex);
     deviceInitialised = false;
-    initialiseDevice();
+    initialiseDevice(stream);
 }
-__host__ void Curve::initialiseDevice() {
+__host__ void Curve::initialiseDevice(cudaStream_t stream) {
     // Don't lock mutex here, do it in the calling method
     if (!deviceInitialised) {
         unsigned int *_d_hashes;
@@ -66,10 +66,10 @@ __host__ void Curve::initialiseDevice() {
         memset(h_sizes, 0, sizeof(size_t)*MAX_VARIABLES);
 
         // initialise data to 0 on device
-        gpuErrchk(cudaMemset(_d_hashes, 0, sizeof(unsigned int)*MAX_VARIABLES));
-        gpuErrchk(cudaMemset(_d_variables, 0, sizeof(void*)*MAX_VARIABLES));
-        gpuErrchk(cudaMemset(_d_lengths, 0, sizeof(unsigned int)*MAX_VARIABLES));
-        gpuErrchk(cudaMemset(_d_sizes, 0, sizeof(size_t)*MAX_VARIABLES));
+        gpuErrchk(cudaMemsetAsync(_d_hashes, 0, sizeof(unsigned int)*MAX_VARIABLES, stream));
+        gpuErrchk(cudaMemsetAsync(_d_variables, 0, sizeof(void*)*MAX_VARIABLES, stream));
+        gpuErrchk(cudaMemsetAsync(_d_lengths, 0, sizeof(unsigned int)*MAX_VARIABLES, stream));
+        gpuErrchk(cudaMemsetAsync(_d_sizes, 0, sizeof(size_t)*MAX_VARIABLES, stream));
     }
     deviceInitialised = true;
 }

--- a/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
+++ b/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
@@ -212,7 +212,7 @@ CurveRTCHost::CurveRTCHost() : header(CurveRTCHost::curve_rtc_dynamic_h_template
 }
 
 CurveRTCHost::~CurveRTCHost() {
-    free(h_data_buffer);
+    gpuErrchk(cudaFreeHost(h_data_buffer));
 }
 
 void CurveRTCHost::registerAgentVariable(const char* variableName, const char* type, size_t type_size, unsigned int elements, bool read, bool write) {
@@ -944,7 +944,7 @@ void CurveRTCHost::initDataBuffer() {
         THROW exception::InvalidOperation("CurveRTCHost::initDataBuffer() should only be called once, during the init chain.\n");
     }
     // Alloc buffer
-    h_data_buffer = static_cast<char*>(malloc(data_buffer_size));
+    gpuErrchk(cudaMallocHost(&h_data_buffer, data_buffer_size));
     // Notify all variables of their ptr to store data in cache
     size_t ct = 0;
     for (auto &element : agent_variables) {
@@ -1044,11 +1044,11 @@ void CurveRTCHost::updateEnvCache(const char *env_ptr) {
         memcpy(h_data_buffer, env_ptr, EnvironmentManager::MAX_BUFFER_SIZE);
     }
 }
-void CurveRTCHost::updateDevice(const jitify::experimental::KernelInstantiation& instance) {
+void CurveRTCHost::updateDevice_async(const jitify::experimental::KernelInstantiation& instance, cudaStream_t stream) {
     // The namespace is required here, but not in other uses of getVariableSymbolName.
     std::string cache_var_name = std::string("flamegpu::detail::curve::") + getVariableSymbolName();
     CUdeviceptr d_var_ptr = instance.get_global_ptr(cache_var_name.c_str());
-    gpuErrchkDriverAPI(cuMemcpyHtoD(d_var_ptr, h_data_buffer, data_buffer_size));
+    gpuErrchkDriverAPI(cuMemcpyHtoDAsync(d_var_ptr, h_data_buffer, data_buffer_size, stream));
 }
 
 }  // namespace curve

--- a/src/flamegpu/runtime/messaging/MessageArray2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray2D.cu
@@ -24,10 +24,10 @@ MessageArray2D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
     hd_metadata.length = d.dimensions[0] * d.dimensions[1];
 }
 
-void MessageArray2D::CUDAModelHandler::init(CUDAScatter &scatter, const unsigned int &streamId) {
-    allocateMetaDataDevicePtr();
+void MessageArray2D::CUDAModelHandler::init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
+    allocateMetaDataDevicePtr(stream);
     // Allocate messages
-    this->sim_message.resize(hd_metadata.length, scatter, streamId);
+    this->sim_message.resize(hd_metadata.length, scatter, stream, streamId);
     this->sim_message.setMessageCount(hd_metadata.length);
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -35,14 +35,16 @@ void MessageArray2D::CUDAModelHandler::init(CUDAScatter &scatter, const unsigned
     for (auto &var : this->sim_message.getMessageDescription().variables) {
         // Elements is harmless, futureproof for arrays support
         // hd_metadata.length is used, as message array can be longer than message count
-        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
-        gpuErrchk(cudaMemset(read_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemsetAsync(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemsetAsync(read_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
     }
+    gpuErrchk(cudaStreamSynchronize(stream));
 }
-void MessageArray2D::CUDAModelHandler::allocateMetaDataDevicePtr() {
+void MessageArray2D::CUDAModelHandler::allocateMetaDataDevicePtr(cudaStream_t stream) {
     if (d_metadata == nullptr) {
         gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
-        gpuErrchk(cudaMemcpy(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+        gpuErrchk(cudaMemcpyAsync(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+        gpuErrchk(cudaStreamSynchronize(stream));
     }
 }
 
@@ -58,7 +60,7 @@ void MessageArray2D::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_write_flag = nullptr;
     d_write_flag_len = 0;
 }
-void MessageArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void MessageArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -66,7 +68,7 @@ void MessageArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const un
     for (auto &var : this->sim_message.getMessageDescription().variables) {
         // Elements is harmless, futureproof for arrays support
         // hd_metadata.length is used, as message array can be longer than message count
-        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemsetAsync(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length, stream));
     }
 
     // Reorder messages
@@ -91,6 +93,7 @@ void MessageArray2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const un
         this->sim_message.setMessageCount(hd_metadata.length);
     // Detect errors
     // TODO
+    gpuErrchk(cudaStreamSynchronize(stream));  // Redundant: Array msg reorder has a sync
 }
 
 

--- a/src/flamegpu/runtime/messaging/MessageArray3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray3D.cu
@@ -24,10 +24,10 @@ MessageArray3D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
     hd_metadata.length = d.dimensions[0] * d.dimensions[1] * d.dimensions[2];
 }
 
-void MessageArray3D::CUDAModelHandler::init(CUDAScatter &scatter, const unsigned int &streamId) {
-    allocateMetaDataDevicePtr();
+void MessageArray3D::CUDAModelHandler::init(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
+    allocateMetaDataDevicePtr(stream);
     // Allocate messages
-    this->sim_message.resize(hd_metadata.length, scatter, streamId);
+    this->sim_message.resize(hd_metadata.length, scatter, stream, streamId);
     this->sim_message.setMessageCount(hd_metadata.length);
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -35,14 +35,16 @@ void MessageArray3D::CUDAModelHandler::init(CUDAScatter &scatter, const unsigned
     for (auto &var : this->sim_message.getMessageDescription().variables) {
         // Elements is harmless, futureproof for arrays support
         // hd_metadata.length is used, as message array can be longer than message count
-        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
-        gpuErrchk(cudaMemset(read_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemsetAsync(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length, stream));
+        gpuErrchk(cudaMemsetAsync(read_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length, stream));
     }
+    gpuErrchk(cudaStreamSynchronize(stream));
 }
-void MessageArray3D::CUDAModelHandler::allocateMetaDataDevicePtr() {
+void MessageArray3D::CUDAModelHandler::allocateMetaDataDevicePtr(cudaStream_t stream) {
     if (d_metadata == nullptr) {
         gpuErrchk(cudaMalloc(&d_metadata, sizeof(MetaData)));
-        gpuErrchk(cudaMemcpy(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice));
+        gpuErrchk(cudaMemcpyAsync(d_metadata, &hd_metadata, sizeof(MetaData), cudaMemcpyHostToDevice, stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
     }
 }
 
@@ -58,7 +60,7 @@ void MessageArray3D::CUDAModelHandler::freeMetaDataDevicePtr() {
     d_write_flag = nullptr;
     d_write_flag_len = 0;
 }
-void MessageArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void MessageArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     // Zero the output arrays
     auto &read_list = this->sim_message.getReadList();
@@ -66,7 +68,7 @@ void MessageArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const un
     for (auto &var : this->sim_message.getMessageDescription().variables) {
         // Elements is harmless, futureproof for arrays support
         // hd_metadata.length is used, as message array can be longer than message count
-        gpuErrchk(cudaMemset(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length));
+        gpuErrchk(cudaMemsetAsync(write_list.at(var.first), 0, var.second.type_size * var.second.elements * hd_metadata.length, stream));
     }
 
     // Reorder messages
@@ -91,6 +93,7 @@ void MessageArray3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const un
         this->sim_message.setMessageCount(hd_metadata.length);
     // Detect errors
     // TODO
+    gpuErrchk(cudaStreamSynchronize(stream));  // Redundant: Array msg reorder has a sync
 }
 
 

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -58,19 +58,21 @@ __global__ void atomicHistogram2D(
     bin_sub_index[index] = bin_idx;
 }
 
-void MessageSpatial2D::CUDAModelHandler::init(CUDAScatter &, const unsigned int &) {
-    allocateMetaDataDevicePtr();
+void MessageSpatial2D::CUDAModelHandler::init(CUDAScatter &, unsigned int, cudaStream_t stream) {
+    allocateMetaDataDevicePtr(stream);
     // Set PBM to 0
-    gpuErrchk(cudaMemset(hd_data.PBM, 0x00000000, (binCount + 1) * sizeof(unsigned int)));
+    gpuErrchk(cudaMemsetAsync(hd_data.PBM, 0x00000000, (binCount + 1) * sizeof(unsigned int), stream));
+    gpuErrchk(cudaStreamSynchronize(stream));  // This could probably be skipped/delayed safely
 }
 
-void MessageSpatial2D::CUDAModelHandler::allocateMetaDataDevicePtr() {
+void MessageSpatial2D::CUDAModelHandler::allocateMetaDataDevicePtr(cudaStream_t stream) {
     if (d_data == nullptr) {
         gpuErrchk(cudaMalloc(&d_histogram, (binCount + 1) * sizeof(unsigned int)));
         gpuErrchk(cudaMalloc(&hd_data.PBM, (binCount + 1) * sizeof(unsigned int)));
         gpuErrchk(cudaMalloc(&d_data, sizeof(MetaData)));
-        gpuErrchk(cudaMemcpy(d_data, &hd_data, sizeof(MetaData), cudaMemcpyHostToDevice));
-        resizeCubTemp();
+        gpuErrchk(cudaMemcpyAsync(d_data, &hd_data, sizeof(MetaData), cudaMemcpyHostToDevice, stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+        resizeCubTemp(stream);
     }
 }
 
@@ -95,7 +97,7 @@ void MessageSpatial2D::CUDAModelHandler::freeMetaDataDevicePtr() {
     }
 }
 
-void MessageSpatial2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void MessageSpatial2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
     NVTX_RANGE("MessageSpatial2D::CUDAModelHandler::buildIndex");
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
@@ -124,9 +126,9 @@ void MessageSpatial2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, const 
     }
 }
 
-void MessageSpatial2D::CUDAModelHandler::resizeCubTemp() {
+void MessageSpatial2D::CUDAModelHandler::resizeCubTemp(cudaStream_t stream) {
     size_t bytesCheck = 0;
-    gpuErrchk(cub::DeviceScan::ExclusiveSum(nullptr, bytesCheck, hd_data.PBM, d_histogram, binCount + 1));
+    gpuErrchk(cub::DeviceScan::ExclusiveSum(nullptr, bytesCheck, hd_data.PBM, d_histogram, binCount + 1, stream));
     if (bytesCheck > d_CUB_temp_storage_bytes) {
         if (d_CUB_temp_storage) {
             gpuErrchk(cudaFree(d_CUB_temp_storage));

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -81,6 +81,7 @@ void SimRunner::start() {
             simulation->SimulationConfig().verbose = false;
             simulation->SimulationConfig().timing = false;
             simulation->CUDAConfig().device_id = this->device_id;
+            simulation->CUDAConfig().is_ensemble = true;
             simulation->applyConfig();
             // Set the step config directly, to bypass validation
             simulation->step_log_config = step_log_config;


### PR DESCRIPTION
Most of this branch is removal of default stream usage.
In a few places, have also started making async versions of methods to later support in-layer concurrency.

Included in the second commit, required for peak ensemble performance:
* Removal of CUDA event timing during ensembles (this implicitly uses default stream blocking stuff to ensure greatest precision).
* Removal of CUDA device reset from CUDASimulation destructor (this exists for cleanliness, however adds a 250ms cost per run in 1x concurrent ensembles, making speed ups 'false')

This is the latest ensemble bench graph, collected using 3090 RTX on waimeu (and the 2 above noted changes not in this branch). Note the axis `E` now refers to the number of concurrent runs configured within the `CUDAEnsemble`. Now we are getting results we can understand, with high concurrent stream utilisation, it would appear we need to increase the population sizes. My hypothesis is that the speedup is more tightly linked to input kernel duration than population size.

As noted in the Slack thread, using `taskset 1,3,5 ./ensemble_benchmark` or similar, we can test how the benchmark performs with less CPU cores (than threads).

![image](https://user-images.githubusercontent.com/742154/165513731-c3e87a63-d4b2-4d7f-813a-a1f38fb37f41.png)
