### PR TITLE
Add missing explicit base class initialiser for ModelData copy ctor

### DIFF
--- a/src/flamegpu/model/ModelData.cpp
+++ b/src/flamegpu/model/ModelData.cpp
@@ -68,7 +68,8 @@ std::shared_ptr<ModelData> ModelData::clone() const {
 }
 
 ModelData::ModelData(const ModelData &other)
-    : initFunctions(other.initFunctions)
+    : std::enable_shared_from_this<ModelData>(other)
+    , initFunctions(other.initFunctions)
     , initFunctionCallbacks(other.initFunctionCallbacks)
     , stepFunctions(other.stepFunctions)
     , stepFunctionCallbacks(other.stepFunctionCallbacks)


### PR DESCRIPTION
This fixes a warning emitted by Wextra.

 Wextra is not being enabled in general due to many warnings which won't be fixed.