### PR TITLE
BugFix: Agent sorting would sometimes incorrectly calculate end bit for cub::DeviceRadixSort

### DIFF
--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -544,8 +544,9 @@ void CUDASimulation::spatialSortAgent_async(const std::string& funcName, const s
     gpuErrchkLaunch();
 
     assert(host_api);
-    // Calculate max bit
-    const int max_bit = static_cast<int>(ceil(log2(gridDim.x * gridDim.y * gridDim.z)));
+    // Calculate max bit (cub::DeviceRadixSort end bit is exclusive and 0-indexed)
+    // https://math.stackexchange.com/a/160299/126129
+    const int max_bit = static_cast<int>(floor(log2(gridDim.x * gridDim.y * gridDim.z))) + 1;
     host_api->agent(agentName).sort_async<unsigned int>("_auto_sort_bin_index", HostAgentAPI::Asc, 0, max_bit, stream, streamId);
 }
 


### PR DESCRIPTION
My maths was bad: https://math.stackexchange.com/a/160299/126129

Was failing for the case `static_cast<int>(ceil(log2(1 * 1 * 1)) == 0` during Circles-benchmark.

Other cases where `compMul(gridDim) == pow(2, N)`, for integer values of `N` were also affected by a soft failure, where the max bit was not included in the sort criteria. In these specific cases however, when the max bit was set, it was the only bit set. This would essentially lead the sort to treating the maximum and minimum bins as the same bin. Relative to the total number of grid bins, this may have negligible impact to performance.