### PR TITLE
Breaking Change: CUDASimulation::initialise() now allows you set defaults

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -386,11 +386,6 @@ class CUDASimulation : public Simulation {
      * @see Simulation::printHelp()
      */
     void printHelp_derived() override;
-    /**
-     * Called at the start of Simulation::initialise(int, const char**) to reset runner specific config struct
-     * @see Simulation::initialise(int, const char**)
-     */
-    void resetDerivedConfig() override;
 
  private:
     /**

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -136,7 +136,6 @@ class Simulation {
     virtual void applyConfig_derived() = 0;
     virtual bool checkArgs_derived(int argc, const char** argv, int &i) = 0;
     virtual void printHelp_derived() = 0;
-    virtual void resetDerivedConfig() = 0;
     /**
      * Returns the unique instance id of this CUDASimulation instance
      */

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -63,6 +63,7 @@ CUDASimulation::CUDASimulation(const std::shared_ptr<const ModelData> &_model)
     , elapsedSecondsExitFunctions(0.)
     , elapsedSecondsRTCInitialisation(0.)
     , macro_env(*_model->environment, *this)
+    , config({})
     , run_log(std::make_unique<RunLog>())
     , streams(std::vector<cudaStream_t>())
     , singletons(nullptr)
@@ -1606,14 +1607,6 @@ void CUDASimulation::initialiseRTC() {
         }
     }
 }
-
-void CUDASimulation::resetDerivedConfig() {
-    bool is_ensemble = getCUDAConfig().is_ensemble;
-    this->config = CUDASimulation::Config();
-    CUDAConfig().is_ensemble = is_ensemble;
-    resetStepCounter();
-}
-
 
 CUDASimulation::Config &CUDASimulation::CUDAConfig() {
     return config;

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -22,6 +22,7 @@ Simulation::Simulation(const std::shared_ptr<const ModelData> &_model)
     : model(_model->clone())
     , submodel(nullptr)
     , mastermodel(nullptr)
+    , config({})
     , instance_id(get_instance_id())
     , maxLayerWidth((*model).getMaxLayerWidth()) { }
 
@@ -29,13 +30,12 @@ Simulation::Simulation(const std::shared_ptr<SubModelData> &submodel_desc, CUDAS
     : model(submodel_desc->submodel)
     , submodel(submodel_desc)
     , mastermodel(master_model)
+    , config({})
     , instance_id(get_instance_id())
     , maxLayerWidth(submodel_desc->submodel->getMaxLayerWidth()) { }
 
 void Simulation::initialise(int argc, const char** argv) {
     NVTX_RANGE("Simulation::initialise");
-    config = Config();  // Reset to defaults
-    resetDerivedConfig();
     // check input args
     if (argc)
         if (!checkArgs(argc, argv))

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -95,9 +95,9 @@ TEST(TestSimulation, ArgParse_inputfile_long) {
     EXPECT_EQ(c.getSimulationConfig().input_file, "");
     EXPECT_THROW(c.initialise(sizeof(argv)/sizeof(char*), argv), exception::UnsupportedFileType);  // cant detect filetype
     EXPECT_EQ(c.getSimulationConfig().input_file, argv[2]);
-    // Blank init resets value to default
-    c.initialise(0, nullptr);
-    EXPECT_EQ(c.getSimulationConfig().input_file, "");
+    // Blank init does not reset value to default
+    EXPECT_THROW(c.initialise(0, nullptr), exception::UnsupportedFileType);  // cant detect filetype
+    EXPECT_EQ(c.getSimulationConfig().input_file, argv[2]);
 }
 TEST(TestSimulationDeathTest, ArgParse_inputfile_short) {
     ModelDescription m(MODEL_NAME);
@@ -113,9 +113,9 @@ TEST(TestSimulation, ArgParse_steps_long) {
     EXPECT_EQ(c.getSimulationConfig().steps, 1u);
     c.initialise(sizeof(argv) / sizeof(char*), argv);
     EXPECT_EQ(c.getSimulationConfig().steps, 12u);
-    // Blank init resets value to default
+    // Blank does not reset value to default
     c.initialise(0, nullptr);
-    EXPECT_EQ(c.getSimulationConfig().steps, 1u);
+    EXPECT_EQ(c.getSimulationConfig().steps, 12u);
 }
 TEST(TestSimulation, ArgParse_steps_short) {
     ModelDescription m(MODEL_NAME);
@@ -124,9 +124,9 @@ TEST(TestSimulation, ArgParse_steps_short) {
     EXPECT_EQ(c.getSimulationConfig().steps, 1u);
     c.initialise(sizeof(argv) / sizeof(char*), argv);
     EXPECT_EQ(c.getSimulationConfig().steps, 12u);
-    // Blank init resets value to default
+    // Blank does not reset value to default
     c.initialise(0, nullptr);
-    EXPECT_EQ(c.getSimulationConfig().steps, 1u);
+    EXPECT_EQ(c.getSimulationConfig().steps, 12u);
 }
 TEST(TestSimulation, ArgParse_randomseed_long) {
     ModelDescription m(MODEL_NAME);
@@ -135,9 +135,9 @@ TEST(TestSimulation, ArgParse_randomseed_long) {
     EXPECT_NE(c.getSimulationConfig().random_seed, 12u);
     c.initialise(sizeof(argv) / sizeof(char*), argv);
     EXPECT_EQ(c.getSimulationConfig().random_seed, 12u);
-    // Blank init resets value to default
+    // Blank does not reset value to default
     c.initialise(0, nullptr);
-    EXPECT_NE(c.getSimulationConfig().random_seed, 12u);
+    EXPECT_EQ(c.getSimulationConfig().random_seed, 12u);
 }
 TEST(TestSimulation, ArgParse_randomseed_short) {
     ModelDescription m(MODEL_NAME);
@@ -146,9 +146,9 @@ TEST(TestSimulation, ArgParse_randomseed_short) {
     EXPECT_NE(c.getSimulationConfig().random_seed, 12u);
     c.initialise(sizeof(argv) / sizeof(char*), argv);
     EXPECT_EQ(c.getSimulationConfig().random_seed, 12u);
-    // Blank init resets value to default
+    // Blank does not reset value to default
     c.initialise(0, nullptr);
-    EXPECT_NE(c.getSimulationConfig().random_seed, 12u);
+    EXPECT_EQ(c.getSimulationConfig().random_seed, 12u);
 }
 TEST(TestCUDASimulation, ArgParse_device_long) {
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
@@ -160,10 +160,10 @@ TEST(TestCUDASimulation, ArgParse_device_long) {
     // As can set to a valid device, we haven't build code for
     EXPECT_THROW(c.initialise(sizeof(argv) / sizeof(char*), argv), exception::InvalidCUDAdevice);
     EXPECT_EQ(c.getCUDAConfig().device_id, 1200);
-    // Blank init resets value to default
+    // Blank init does not reset value to default
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
-    c.initialise(0, nullptr);
-    EXPECT_EQ(c.getCUDAConfig().device_id, 0);
+    EXPECT_THROW(c.initialise(0, nullptr), exception::InvalidCUDAdevice);
+    EXPECT_EQ(c.getCUDAConfig().device_id, 1200);
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
 }
 TEST(TestCUDASimulation, ArgParse_device_short) {
@@ -176,10 +176,10 @@ TEST(TestCUDASimulation, ArgParse_device_short) {
     // As can set to a valid device, we haven't build code for
     EXPECT_THROW(c.initialise(sizeof(argv) / sizeof(char*), argv), exception::InvalidCUDAdevice);
     EXPECT_EQ(c.getCUDAConfig().device_id, 1200);
-    // Blank init resets value to default
+    // Blank init does not reset value to default
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
-    c.initialise(0, nullptr);
-    EXPECT_EQ(c.getCUDAConfig().device_id, 0);
+    EXPECT_THROW(c.initialise(0, nullptr), exception::InvalidCUDAdevice);
+    EXPECT_EQ(c.getCUDAConfig().device_id, 1200);
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
 }
 FLAMEGPU_AGENT_FUNCTION(SetGetFn, MessageNone, MessageNone) {


### PR DESCRIPTION
This matches the behaviour of `CUDAEnsemble`.

Ran tests, updated the broken ones and ran again.

Pairs with docs PR: https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/88

Closes #755