### PR TITLE
Add Visual Studio 2022 to the CI build matrix.

### DIFF
--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -25,8 +25,8 @@ jobs:
         cudacxx:
           - cuda: "11.7.0"
             cuda_arch: "35"
-            hostcxx: "Visual Studio 16 2019"
-            os: windows-2019
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "11.0.3"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -35,7 +35,7 @@ jobs:
             os: windows-2022
           - cuda: "11.7.0"
             cuda_arch: "35"
-            hostcxx: "Visual Studio 17 2019"
+            hostcxx: "Visual Studio 16 2019"
             os: windows-2019
           - cuda: "11.0.3"
             cuda_arch: "35"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -35,7 +35,7 @@ jobs:
             os: windows-2022
           - cuda: "11.7.0"
             cuda_arch: "35"
-            hostcxx: "Visual Studio 17 2022"
+            hostcxx: "Visual Studio 17 2019"
             os: windows-2019
           - cuda: "11.0.3"
             cuda_arch: "35"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -31,7 +31,11 @@ jobs:
         cudacxx:
           - cuda: "11.7.0"
             cuda_arch: "35"
-            hostcxx: "Visual Studio 16 2019"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          - cuda: "11.7.0"
+            cuda_arch: "35"
+            hostcxx: "Visual Studio 17 2022"
             os: windows-2019
           - cuda: "11.0.3"
             cuda_arch: "35"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -33,10 +33,6 @@ jobs:
             cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
-          - cuda: "11.7.0"
-            cuda_arch: "35"
-            hostcxx: "Visual Studio 16 2019"
-            os: windows-2019
           - cuda: "11.0.3"
             cuda_arch: "35"
             hostcxx: "Visual Studio 16 2019"

--- a/src/flamegpu/gpu/CUDAFatAgent.cu
+++ b/src/flamegpu/gpu/CUDAFatAgent.cu
@@ -214,7 +214,10 @@ void CUDAFatAgent::processFunctionCondition(const unsigned int &agent_fat_id, co
     gpuErrchk(cudaStreamSynchronize(stream));
     // Use inverted scan results to sort true agents into end of list (and swap buffers)
     const unsigned int conditionpassCount = sm->second->scatterAgentFunctionConditionTrue(conditionFailCount, scatter, streamId, stream);
-    assert(agent_count == conditionpassCount + conditionFailCount);
+    if (agent_count != conditionpassCount + conditionFailCount) {
+        THROW exception::UnknownInternalError("Agent function condition pass + fail counts != agent count, %u + %u != %u this should not happen"
+            ", in CUDAFatAgent::processFunctionCondition()\n", conditionpassCount, conditionFailCount, agent_count);
+    }
 }
 
 void CUDAFatAgent::setConditionState(const unsigned int &agent_fat_id, const std::string &state_name, const unsigned int numberOfDisabled) {

--- a/tests/test_cases/runtime/test_host_agent_creation.cu
+++ b/tests/test_cases/runtime/test_host_agent_creation.cu
@@ -545,7 +545,6 @@ TEST(HostAgentCreationTest, HostAgentBirth_ArrayDefaultWorks) {
     // Check data is correct
     EXPECT_EQ(population.size(), AGENT_COUNT);
     for (const AgentVector::Agent &instance : population) {
-        const unsigned int j = instance.getVariable<unsigned int>("id");
         // Check array sets are correct
         auto array1 = instance.getVariable<int, 4>("array_var");
         auto array2 = instance.getVariable<int, 4>("array_var2");

--- a/tests/test_cases/runtime/test_host_agent_creation.cu
+++ b/tests/test_cases/runtime/test_host_agent_creation.cu
@@ -911,7 +911,6 @@ TEST(HostAgentCreationTest, HostAgentBirth_ArrayDefaultWorks_glm) {
     // Check data is correct
     EXPECT_EQ(population.size(), AGENT_COUNT);
     for (const AgentVector::Agent &instance : population) {
-        const unsigned int j = instance.getVariable<unsigned int>("id");
         // Check array sets are correct
         auto array1 = instance.getVariable<glm::ivec4>("array_var");
         auto array2 = instance.getVariable<glm::ivec4>("array_var2");


### PR DESCRIPTION
Well this works.
Had to fix a single new warning (due to an `assert()` statement making some vars unused in Release mode).
- [x] Need to decide if we want CUDA 11.7 VS2022 & VS2019, or just VS2022 with suffice (as we have CUDA 11.0 VS 2019). The latter seems preferable to me, given sometimes the dependency fetches can be temperamental, so less points of failure seems like a good thing. But will leave the call to @ptheywood.
- [ ] Need to squash this PR.