### PR TITLE
(Experimental) Hostapi message

### DIFF
--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -64,9 +64,18 @@ FLAMEGPU_STEP_FUNCTION(Validation) {
     prevTotalDrift = totalDrift;
     // printf("Avg Drift: %g\n", totalDrift / FLAMEGPU->agent("Circle").count());
     printf("%.2f%% Drift correct\n", 100 * driftDropped / static_cast<float>(driftDropped + driftIncreased));
+
+    // Change radius
+    static float radius_swap = 4.0f;
+    if (!((FLAMEGPU->getStepCounter()+1) % 200)) {
+        auto msg = FLAMEGPU->message<flamegpu::MessageSpatial3D>("location");
+        const float t = msg.getRadius();
+        msg.setRadius(radius_swap);
+        radius_swap = t;
+    }
 }
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("Circles_BruteForce_example");
+    flamegpu::ModelDescription model("Circles_Spatial3D_example");
 
     const unsigned int AGENT_COUNT = 16384;
     const float ENV_MAX = static_cast<float>(floor(cbrt(AGENT_COUNT)));

--- a/include/flamegpu/gpu/CUDAMessageList.h
+++ b/include/flamegpu/gpu/CUDAMessageList.h
@@ -10,14 +10,6 @@ namespace flamegpu {
 class CUDAScatter;
 class CUDAMessage;
 
-/**
- * Map used to map a variable name to buffer
- */
-typedef std::map <std::string, void*> CUDAMessageMap;
-/**
- * Key Value pair of CUDAMessageMap
- */
-typedef std::pair <std::string, void*> CUDAMessageMapPair;
 
 /**
  * This is the internal device memory handler for CUDAMessage
@@ -25,9 +17,17 @@ typedef std::pair <std::string, void*> CUDAMessageMapPair;
  */
 class CUDAMessageList {
  public:
-     /**
-      * Initially allocates message lists based on cuda_message.getMaximumListSize()
-      */
+    /**
+     * Map used to map a variable name to buffer
+     */
+    typedef std::map<std::string, void*> MessageMap;
+    /**
+     * Key Value pair of CUDAMessageMap
+     */
+    typedef std::pair<std::string, void*> MessageMapPair;
+    /**
+     * Initially allocates message lists based on cuda_message.getMaximumListSize()
+     */
     explicit CUDAMessageList(CUDAMessage& cuda_message, CUDAScatter &scatter, cudaStream_t stream, unsigned int streamId);
     /**
      * Frees all message list memory
@@ -93,40 +93,40 @@ class CUDAMessageList {
     /**
      * @return Returns the map<variable_name, device_ptr> for reading message data
      */
-    const CUDAMessageMap &getReadList() { return d_list; }
+    const MessageMap &getReadList() { return d_list; }
     /**
      * @return Returns the map<variable_name, device_ptr> for writing message data (aka swap buffers)
      */
-    const CUDAMessageMap &getWriteList() { return d_swap_list; }
+    const MessageMap &getWriteList() { return d_swap_list; }
 
  protected:
     /**
      * Allocates device memory for the provided message list
      * @param memory_map Message list to perform operation on
      */
-    void allocateDeviceMessageList(CUDAMessageMap &memory_map);
+    void allocateDeviceMessageList(MessageMap &memory_map);
     /**
      * Frees device memory for the provided message list
      * @param memory_map Message list to perform operation on
      */
-    void releaseDeviceMessageList(CUDAMessageMap &memory_map);
+    void releaseDeviceMessageList(MessageMap &memory_map);
     /**
      * Zeros device memory for the provided message list
      * @param memory_map Message list to perform operation on
      * @param stream The CUDAStream to use for CUDA operations
      * @param skip_offset Number of items at the start of the list to not zero
      */
-    void zeroDeviceMessageList_async(CUDAMessageMap &memory_map, cudaStream_t stream, unsigned int skip_offset = 0);
+    void zeroDeviceMessageList_async(MessageMap &memory_map, cudaStream_t stream, unsigned int skip_offset = 0);
 
  private:
      /**
       * Message storage for reading
       */
-    CUDAMessageMap d_list;
+    MessageMap d_list;
     /**
      * Message storage for writing
      */
-    CUDAMessageMap d_swap_list;
+    MessageMap d_swap_list;
     /**
      * Parent which this provides storage for
      */

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D.h
@@ -25,6 +25,7 @@ class MessageSpatial3D {
     struct Data;        // Forward declare inner classes
     class Description;  // Forward declare inner classes
     class CUDAModelHandler;
+    class HostAPI;
     // Device
     class In;
     class Out;

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
@@ -4,11 +4,12 @@
 #include <memory>
 #include <string>
 
-#include "flamegpu/gpu/CUDAMessage.h"
 #include "flamegpu/util/nvtx.h"
 #include "flamegpu/runtime/messaging/MessageSpatial3D.h"
 #include "flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h"
 #include "flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h"
+
+class CUDAMessage;
 
 namespace flamegpu {
 
@@ -17,6 +18,8 @@ namespace flamegpu {
  * Allocates memory for and constructs PBM
  */
 class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
+    friend class MessageSpatial3D::HostAPI;
+
  public:
     /**
      * Constructor
@@ -60,6 +63,10 @@ class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Returns a pointer to the metadata struct, this is required for reading the message data
      */
     const void *getMetaDataDevicePtr() const override { return d_data; }
+    /**
+     * On next PBM rebuild the pbm may be reallocated and metadata updated on device
+     */
+    void setMetadataChangedFlag() { metadata_changed_flag = true; }
 
  private:
     /**
@@ -79,6 +86,10 @@ class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Number of bins, arrays are +1 this length
      */
     unsigned int binCount = 0;
+    /**
+     * Number of bins in hd_data.PBM
+     */
+    unsigned int allocated_binCount = 0;
     /**
      * Size of currently allocated temp storage memory for cub
      */
@@ -111,6 +122,10 @@ class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * Owning CUDAMessage, provides access to message storage etc
      */
     CUDAMessage &sim_message;
+    /**
+     * If true, PBM rebuild will realloc a different sized PBM first
+     */
+    bool metadata_changed_flag;
 };
 
 /**
@@ -199,6 +214,47 @@ class MessageSpatial3D::Description : public MessageBruteForce::Description {
     float getMaxX() const;
     float getMaxY() const;
     float getMaxZ() const;
+};
+
+class MessageSpatial3D::HostAPI {
+    CUDAMessage &cudaMessage;
+    CUDAModelHandler &messageHandler;
+public:
+    HostAPI(CUDAMessage &_cudaMessage, CUDAModelHandler &_messageHandler)
+        : cudaMessage(_cudaMessage)
+        , messageHandler(_messageHandler) { }
+    void setRadius(const float& r);
+    void setMinX(const float& x);
+    void setMinY(const float& y);
+    void setMinZ(const float& z);
+    void setMin(const float& x, const float& y, const float& z);
+    void setMaxX(const float& x);
+    void setMaxY(const float& y);
+    void setMaxZ(const float& z);
+    void setMax(const float& x, const float& y, const float& z);
+    void clearMessages();
+
+    float getRadius() const {
+        return messageHandler.hd_data.radius;
+    }
+    float getMinX() const {
+        return messageHandler.hd_data.min[0];
+    }
+    float getMinY() const {
+        return messageHandler.hd_data.min[1];
+    }
+    float getMinZ() const {
+        return messageHandler.hd_data.min[2];
+    }
+    float getMaxX() const {
+        return messageHandler.hd_data.max[0];
+    }
+    float getMaxY() const {
+        return messageHandler.hd_data.max[1];
+    }
+    float getMaxZ() const {
+        return messageHandler.hd_data.max[2];
+    }
 };
 
 }  // namespace flamegpu

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1524,7 +1524,7 @@ void CUDASimulation::initialiseSingletons() {
         cudaStream_t stream_0 = getStream(0);
 
         // Pass created RandomManager to host api
-        host_api = std::make_unique<HostAPI>(*this, singletons->rng, singletons->scatter, agentOffsets, agentData, singletons->environment, macro_env, 0, stream_0);  // Host fns are currently all serial
+        host_api = std::make_unique<HostAPI>(*this, singletons->rng, singletons->scatter, agentOffsets, agentData, message_map, singletons->environment, macro_env, 0, stream_0);  // Host fns are currently all serial
 
         for (auto &cm : message_map) {
             cm.second->init(singletons->scatter, 0, stream_0);

--- a/src/flamegpu/runtime/HostAPI.cu
+++ b/src/flamegpu/runtime/HostAPI.cu
@@ -12,6 +12,7 @@ HostAPI::HostAPI(CUDASimulation &_agentModel,
     CUDAScatter &_scatter,
     const AgentOffsetMap &_agentOffsets,
     AgentDataMap &_agentData,
+    std::unordered_map<std::string, std::unique_ptr<CUDAMessage>> &_messageMap,
     const std::shared_ptr<EnvironmentManager>& env,
     CUDAMacroEnvironment &macro_env,
     const unsigned int& _streamId,
@@ -19,6 +20,7 @@ HostAPI::HostAPI(CUDASimulation &_agentModel,
     : random(rng)
     , environment(_agentModel.getInstanceID(), env, macro_env)
     , agentModel(_agentModel)
+    , messageMap(_messageMap)
     , d_output_space(nullptr)
     , d_output_space_size(0)
     , agentOffsets(_agentOffsets)


### PR DESCRIPTION
Experimental branch testing something @AshurstJ thought was already possible.

Only adds Spatial3D support currently. It appears to work, but not had any thorough testing.

Easier than expected (in this case), as `CUDAMessage` already has the rebuild PBM flag method.

Not really a fan of the repetition of all the `Msg::Description` methods on the `Msg::HostAPI` object though. Can't simply provide desc, as this would expose the variable methods and wouldn't trigger the flags which need to be set on change. Some kind of shared class?/multi inheritance?


Relates #710