### PR TITLE
BugFix: RTC environment get property array required length to be specified.

### DIFF
--- a/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
+++ b/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
@@ -413,7 +413,7 @@ void CurveRTCHost::initHeaderEnvironment(const size_t env_buffer_len) {
                 getEnvArrayVariableImpl << "        if(sizeof(type_decode<T>::type_t) != " << element.second.type_size << ") {\n";
                 getEnvArrayVariableImpl << "            DTHROW(\"Environment array property '%s' type mismatch.\\n\", name);\n";
                 getEnvArrayVariableImpl << "            return {};\n";
-                getEnvArrayVariableImpl << "        } else if (type_decode<T>::len_t * N != " << element.second.elements << ") {\n";
+                getEnvArrayVariableImpl << "        } else if (type_decode<T>::len_t * N != " << element.second.elements << " && N != 0) {\n";  // Special case, env array specifying length is optional as it's not actually required
                 getEnvArrayVariableImpl << "            DTHROW(\"Environment array property '%s' length mismatch.\\n\", name);\n";
                 getEnvArrayVariableImpl << "            return {};\n";
                 getEnvArrayVariableImpl << "        } else if (t_index > " << element.second.elements << " || t_index < index) {\n";

--- a/tests/test_cases/runtime/test_device_environment.cu
+++ b/tests/test_cases/runtime/test_device_environment.cu
@@ -442,6 +442,56 @@ TEST_F(DeviceEnvironmentTest, Get_arrayElement_int64_t) {
     EXPECT_EQ(int64_t_check, _int64_t_out);
     EXPECT_EQ(cudaGetLastError(), CUDA_SUCCESS);
 }
+FLAMEGPU_AGENT_FUNCTION(get_array_shorthand, MessageNone, MessageNone) {
+    FLAMEGPU->setVariable<float, 3>("k", 0, FLAMEGPU->environment.getProperty<float>("k", 0));
+    FLAMEGPU->setVariable<float, 3>("k", 1, FLAMEGPU->environment.getProperty<float>("k", 1));
+    FLAMEGPU->setVariable<float, 3>("k", 2, FLAMEGPU->environment.getProperty<float>("k", 2));
+    return ALIVE;
+}
+TEST_F(DeviceEnvironmentTest, Get_array_shorthand) {
+    // It's no longer necessary to specify env property array length in agent functions when retrieiving them
+    // This test is better ran with SEATBELTS=ON, to catch the seatbelts checking
+    // Setup agent fn
+    ms->agent.newVariable<float, 3>("k");
+    AgentFunctionDescription& deviceFn = ms->agent.newFunction("device_function", get_array_shorthand);
+    LayerDescription& devicefn_layer = ms->model.newLayer("devicefn_layer");
+    devicefn_layer.addAgentFunction(deviceFn);
+    // Setup environment
+    const std::array<float, 3> t_in = { 12.0f, -12.5f, 13.0f };
+    ms->env.newProperty<float, 3>("k", t_in);
+    ms->run();
+    const std::array<float, 3> t_out = ms->population->at(0).getVariable<float, 3>("k");
+    ASSERT_EQ(t_in, t_out);
+}
+const char* rtc_get_array_shorthand = R"###(
+FLAMEGPU_AGENT_FUNCTION(get_array_shorthand, flamegpu::MessageNone, flamegpu::MessageNone) {
+    FLAMEGPU->setVariable<float, 3>("k", 0, FLAMEGPU->environment.getProperty<float>("k", 0));
+    FLAMEGPU->setVariable<float, 3>("k", 1, FLAMEGPU->environment.getProperty<float>("k", 1));
+    FLAMEGPU->setVariable<float, 3>("k", 2, FLAMEGPU->environment.getProperty<float>("k", 2));
+    return flamegpu::ALIVE;
+}
+)###";
+TEST(RTCDeviceEnvironmentTest, get_array_shorthand) {
+    ModelDescription model("device_env_test");
+    // Setup environment
+    const std::array<float, 3> t_in = { 12.0f, -12.5f, 13.0f };
+    model.Environment().newProperty<float, 3>("k", t_in);
+    // Setup agent fn
+    AgentDescription& agent = model.newAgent("agent");
+    agent.newVariable<float, 3>("k");
+    AgentFunctionDescription& deviceFn = agent.newRTCFunction("device_function", rtc_get_array_shorthand);
+    LayerDescription& devicefn_layer = model.newLayer("devicefn_layer");
+    devicefn_layer.addAgentFunction(deviceFn);
+    AgentVector population(agent, 1);
+    // Do Sim
+    CUDASimulation cudaSimulation = CUDASimulation(model);
+    cudaSimulation.SimulationConfig().steps = 2;
+    cudaSimulation.setPopulationData(population);
+    ASSERT_NO_THROW(cudaSimulation.simulate());
+    ASSERT_NO_THROW(cudaSimulation.getPopulationData(population));
+    const std::array<float, 3> t_out = population.at(0).getVariable<float, 3>("k");
+    ASSERT_EQ(t_in, t_out);
+}
 #ifdef USE_GLM
 FLAMEGPU_AGENT_FUNCTION(get_array_glm, MessageNone, MessageNone) {
     glm::vec3 t = FLAMEGPU->environment.getProperty<glm::vec3>("k");


### PR DESCRIPTION
This must have been broken when I previously made length optional.
Spotted by C Borau

Fixed the bug and added rtc/non-rtc tests cases, tested both with Release/Seatbelts=ON.

Trivial small change, should be a quick merge once CI is happy.