### PR TITLE
Add support for agents to be coloured with array variables

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 # @todo - If the git version has changed in this file, fetch again? 
-set(DEFAULT_VISUALISATION_GIT_VERSION "1077d64544e4f8c3ea437023ec10bcffe405954d")
+set(DEFAULT_VISUALISATION_GIT_VERSION "3e230bc908856129789342da7d73275b51991ddd")
 set(DEFAULT_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # If overridden by the user, attempt to use that

--- a/include/flamegpu/visualiser/color/ColorFunction.h
+++ b/include/flamegpu/visualiser/color/ColorFunction.h
@@ -16,9 +16,10 @@ class ColorFunction {
      * Returns GLSL source code for a function with the prototype
      * vec4 calculateColor()
      * It may optionally also include a definition for a uniform samplerBuffer
-     * If a uniform samplerBuffer is included, it's identifier should be returned by getSamplerName() 
+     * If a uniform samplerBuffer is included, it's identifier should be returned by getSamplerName()
+     * @param variable_array_len Length of the variable array
      */
-    virtual std::string getSrc() const = 0;
+    virtual std::string getSrc(unsigned int variable_array_len) const = 0;
     /**
      * If the shader source contains a samplerBuffer definition (e.g. of a single float/int)
      * This should be the identifier so that the buffer can be bound to it
@@ -33,10 +34,27 @@ class ColorFunction {
     virtual std::string getAgentVariableName() const { return ""; }
     /**
      * If the shader source contains a samplerBuffer definition
+     * This should be the name of the index of the element within the agent variable (0 if it's not an array variable)
+     */
+    virtual unsigned int getAgentArrayVariableElement() const { return element; }
+    /**
+     * If the shader source contains a samplerBuffer definition
      * This should be the type of the agent variable so that the buffer can be bound to it
      * Otherwise void typeid is returned.
      */
     virtual std::type_index getAgentVariableRequiredType() const { return std::type_index(typeid(void)); }
+    /**
+     * Specify the array variable's element to use
+     * @param _element Index of the element within the array variable
+     * @note Calling this is not required if the agent variable is not an array variable
+     */
+    void setAgentArrayVariableElement(const unsigned int _element) { element = _element; }
+
+ protected:
+    /**
+     * The element of the array variable to use (else 0 if not array variable)
+     */
+    unsigned int element = 0;
 };
 
 }  // namespace visualiser

--- a/include/flamegpu/visualiser/color/DiscreteColor.h
+++ b/include/flamegpu/visualiser/color/DiscreteColor.h
@@ -64,8 +64,9 @@ class DiscreteColor : public ColorFunction, public std::map<T, Color> {
      *       default: return vec4(0, 1, 0, 1);
      *     }
      * }
+     * @param array_len Length of the variable array
      */
-    std::string getSrc() const override;
+    std::string getSrc(unsigned int array_len) const override;
     /**
      * Always returns "color_arg"
      */
@@ -105,7 +106,7 @@ typedef DiscreteColor<uint32_t> uDiscreteColor;
 typedef DiscreteColor<int32_t> iDiscreteColor;
 // Define this here, so the static assert can give a better compile error for unwanted template instantiations
 template<typename T>
-std::string DiscreteColor<T>::getSrc() const {
+std::string DiscreteColor<T>::getSrc(const unsigned int array_len) const {
     static_assert(std::is_same<T, int32_t>::value || std::is_same<T, uint32_t>::value, "T must be of type int32_t or uint32_t");
     // Validate colors
     if (!validate()) {
@@ -116,9 +117,9 @@ std::string DiscreteColor<T>::getSrc() const {
     ss << "vec4 calculateColor() {" << "\n";
     // Fetch discrete value
     if (std::is_same<T, int32_t>::value) {
-        ss << "    const int category = floatBitsToInt(texelFetch(color_arg, gl_InstanceID).x);" << "\n";
+        ss << "    const int category = floatBitsToInt(texelFetch(color_arg, gl_InstanceID * " << array_len << " + " << element << ").x);" << "\n";
     } else if (std::is_same<T, uint32_t>::value) {
-        ss << "    const unsigned int category = floatBitsToUint(texelFetch(color_arg, gl_InstanceID).x);" << "\n";
+        ss << "    const unsigned int category = floatBitsToUint(texelFetch(color_arg, gl_InstanceID * " << array_len << " + " << element << ").x);" << "\n";
     }
     // Select the desired color
     ss << "    switch (category) {" << "\n";

--- a/include/flamegpu/visualiser/color/HSVInterpolation.h
+++ b/include/flamegpu/visualiser/color/HSVInterpolation.h
@@ -54,8 +54,9 @@ class HSVInterpolation : public ColorFunction {
     HSVInterpolation& setWrapHue(const bool& _wrapHue);
     /**
      * Returns GLSL for a function that returns a color based on the configured HSV interpolation
+     * @param array_len Length of the variable array
      */
-    std::string getSrc() const override;
+    std::string getSrc(unsigned int array_len) const override;
     /**
      * Always returns "color_arg"
      */

--- a/include/flamegpu/visualiser/color/StaticColor.h
+++ b/include/flamegpu/visualiser/color/StaticColor.h
@@ -28,9 +28,13 @@ class StaticColor : public ColorFunction {
      *   return vec4(1.0, 0.0, 0.0, 1.0);
      * }
      */
-    std::string getSrc() const override;
+    std::string getSrc(unsigned int) const override;
 
  private:
+    /**
+     * Not possible where variable isn't used, so hide
+     */
+    using ColorFunction::setAgentArrayVariableElement;
     /**
      * Shader controls RGBA values, but currently we only expose RGB (A support is somewhat untested)
      */

--- a/include/flamegpu/visualiser/color/ViridisInterpolation.h
+++ b/include/flamegpu/visualiser/color/ViridisInterpolation.h
@@ -39,8 +39,9 @@ class ViridisInterpolation : public ColorFunction {
     ViridisInterpolation& setBounds(const float& min_bound, const float& max_bound);
     /**
      * Returns GLSL for a function that returns a color based on the configured HSV interpolation
+     * @param array_len Length of the variable array
      */
-    std::string getSrc() const override;
+    std::string getSrc(unsigned int array_len) const override;
     /**
      * Always returns "color_arg"
      */

--- a/src/flamegpu/visualiser/color/HSVInterpolation.cpp
+++ b/src/flamegpu/visualiser/color/HSVInterpolation.cpp
@@ -60,7 +60,7 @@ HSVInterpolation& HSVInterpolation::setWrapHue(const bool& _wrapHue) {
     wrap_hue = _wrapHue;
     return *this;
 }
-std::string HSVInterpolation::getSrc() const {
+std::string HSVInterpolation::getSrc(const unsigned int array_len) const {
 static const char* HEADER = R"###(
 uniform samplerBuffer color_arg;
 //hsv(0-360,0-1,0-1)
@@ -94,7 +94,7 @@ vec3 hsv2rgb(vec3 hsv) {
     ss << HEADER;
     ss << "vec4 calculateColor() {" << "\n";
     // Fetch the modifier from texture cache
-    ss << "    float modifier = texelFetch(color_arg, gl_InstanceID).x;" << "\n";
+    ss << "    float modifier = texelFetch(color_arg, gl_InstanceID * " << array_len << " + " << element << ").x;" << "\n";
     // Clamp the modifier to bounds
     ss << "    modifier = clamp(modifier, float(" << min_bound << "), float(" << max_bound << "));" << "\n";
     // Scale modifier to range [0.0, 1.0]

--- a/src/flamegpu/visualiser/color/StaticColor.cpp
+++ b/src/flamegpu/visualiser/color/StaticColor.cpp
@@ -15,7 +15,7 @@ StaticColor::StaticColor(const Color& _rgba)
             "in StaticColor::StaticColor\n");
     }
 }
-std::string StaticColor::getSrc() const {
+std::string StaticColor::getSrc(unsigned int) const {
     std::stringstream ss;
     ss << "vec4 calculateColor() {" << "\n";
     ss << "    return vec4(" << rgba[0] << ", " << rgba[1] << ", " << rgba[2] << ", " << 1.0f << ");" << "\n";

--- a/src/flamegpu/visualiser/color/ViridisInterpolation.cpp
+++ b/src/flamegpu/visualiser/color/ViridisInterpolation.cpp
@@ -26,7 +26,7 @@ ViridisInterpolation& ViridisInterpolation::setBounds(const float& _min_bound, c
     return *this;
 }
 
-std::string ViridisInterpolation::getSrc() const {
+std::string ViridisInterpolation::getSrc(const unsigned int array_len) const {
     static const std::array<const Color, 256> &raw_colors = rawColors();
     std::stringstream ss;
     ss << "uniform samplerBuffer color_arg;" << "\n";
@@ -44,7 +44,7 @@ std::string ViridisInterpolation::getSrc() const {
     ss << "}" << "\n";
     ss << "vec4 calculateColor() {" << "\n";
     // Fetch the modifier from texture cache
-    ss << "    float modifier = texelFetch(color_arg, gl_InstanceID).x;" << "\n";
+    ss << "    float modifier = texelFetch(color_arg, gl_InstanceID * " << array_len << " + " << element << ").x;" << "\n";
     // Clamp the modifier to bounds
     ss << "    modifier = clamp(modifier, float(" << min_bound << "), float(" << max_bound << "));" << "\n";
     // Scale modifier to range [0.0, 255.0]


### PR DESCRIPTION
Carlos wanted it, didn't take long.

Simply call `setAgentArrayVariableElement()` with the index of the element (default 0) on the `ColorFunction` before passing it to `setColor()`.

This required an update to the visualiser too (See https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/90), which should be merged first, so that CMake can be updated to point to the new Visualiser version before this is merged.

CI failing bc it's pointed at old vis.