### PR TITLE
Remove unused RTCSafeCudaMemcpyToSymbol/Address methods

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -293,29 +293,6 @@ class CUDASimulation : public Simulation {
      */
     visualiser::ModelVis &getVisualisation();
 #endif
-
-    /**
-     * Performs a cudaMemCopyToSymbol in the runtime library and also updates the symbols of any RTC functions (which exist separately within their own cuda module)
-     * Will thrown an error if any of the calls fail.
-     * @param symbol A device symbol
-     * @param rtc_symbol_name The name of the symbol
-     * @param src Source memory address
-     * @param count Size in bytes to copy
-     * @param offset Offset from start of symbol in bytes
-     */
-    void RTCSafeCudaMemcpyToSymbol(const void* symbol, const char* rtc_symbol_name, const void* src, size_t count, size_t offset = 0) const;
-
-    /**
-     * Performs a cudaMemCopy to a pointer in the runtime library and also updates the symbols of any RTC functions (which exist separately within their own cuda module)
-     * Will thrown an error if any of the calls fail.
-     * @param ptr a pointer to a symbol in device memory
-     * @param rtc_symbol_name The name of the symbol
-     * @param src Source memory address
-     * @param count Size in bytes to copy
-     * @param offset Offset from start of symbol in bytes
-     */
-    void RTCSafeCudaMemcpyToSymbolAddress(void* ptr, const char* rtc_symbol_name, const void* src, size_t count, size_t offset = 0) const;
-
    /**
      * Get the duration of the last time RTC was iniitliased 
      * @return elapsed time of last simulation call in seconds.

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1691,40 +1691,6 @@ void CUDASimulation::processHostAgentCreation(const unsigned int &streamId) {
     }
 }
 
-void CUDASimulation::RTCSafeCudaMemcpyToSymbol(const void* symbol, const char* rtc_symbol_name, const void* src, size_t count, size_t offset) const {
-    // make the mem copy to runtime API symbol
-    gpuErrchk(cudaMemcpyToSymbol(symbol, src, count, offset));
-    // loop through agents
-    for (const auto& agent_pair : agent_map) {
-        // loop through any agent functions
-        for (const CUDAAgent::CUDARTCFuncMapPair& rtc_func_pair : agent_pair.second->getRTCFunctions()) {
-            CUdeviceptr rtc_dev_ptr = 0;
-            // get the RTC device symbol
-            rtc_dev_ptr = rtc_func_pair.second->get_global_ptr(rtc_symbol_name);
-            // make the memcpy to the rtc version of the symbol
-            gpuErrchkDriverAPI(cuMemcpyHtoD(rtc_dev_ptr + offset, src, count));
-        }
-    }
-}
-
-void CUDASimulation::RTCSafeCudaMemcpyToSymbolAddress(void* ptr, const char* rtc_symbol_name, const void* src, size_t count, size_t offset) const {
-    // offset the device pointer by casting to char
-    void* offset_ptr = reinterpret_cast<void*>(reinterpret_cast<char*>(ptr) + offset);
-    // make the mem copy to runtime API symbol
-    gpuErrchk(cudaMemcpy(offset_ptr, src, count, cudaMemcpyHostToDevice));
-    // loop through agents
-    for (const auto& agent_pair : agent_map) {
-        // loop through any agent functions
-        for (const CUDAAgent::CUDARTCFuncMapPair& rtc_func_pair : agent_pair.second->getRTCFunctions()) {
-            CUdeviceptr rtc_dev_ptr = 0;
-            // get the RTC device symbol
-            rtc_dev_ptr = rtc_func_pair.second->get_global_ptr(rtc_symbol_name);
-            // make the memcpy to the rtc version of the symbol
-            gpuErrchkDriverAPI(cuMemcpyHtoD(rtc_dev_ptr + offset, src, count));
-        }
-    }
-}
-
 void CUDASimulation::incrementStepCounter() {
     this->step_count++;
     this->singletons->environment->setProperty<unsigned int>("_stepCount", this->step_count);


### PR DESCRIPTION
Removes unused methods which would be default stream copies. 

No point in maintaining unused code.