### PR TITLE
Visualise Random Seed and Environment Properties

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -51,6 +51,9 @@ class CUDASimulation : public Simulation {
     friend class HostAgentAPI;
     friend class SimRunner;
     friend class CUDAEnsemble;
+#ifdef VISUALISATION
+    friend class visualiser::ModelVis;
+#endif
     /**
      * Map of a number of CUDA agents by name.
      * The CUDA agents are responsible for allocating and managing all the device memory

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -206,6 +206,10 @@ class ModelVis {
      * @param sc Step count, the step count value shown in visualisation HUD
      */
     void updateBuffers(const unsigned int &sc = UINT_MAX);
+    /**
+     * Random seed has changed
+     */
+    void updateRandomSeed();
 
  private:
     /**

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -210,6 +210,10 @@ class ModelVis {
      * Random seed has changed
      */
     void updateRandomSeed();
+    /**
+     * Singletons have init, so env props are ready to grab
+     */
+    void registerEnvProperties();
 
  private:
     /**
@@ -242,6 +246,10 @@ class ModelVis {
      * Pointer to the visualisation
      */
     std::unique_ptr<FLAMEGPU_Visualisation> visualiser;
+    /**
+     * Only need to register env properties once
+     */
+    bool env_registered = false;
 };
 
 }  // namespace visualiser

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1431,9 +1431,11 @@ void CUDASimulation::applyConfig_derived() {
 
     // Handle console_mode
 #ifdef VISUALISATION
-    if (getSimulationConfig().console_mode) {
-        if (visualisation) {
-            visualisation->deactivate();
+    if (visualisation) {
+        if (getSimulationConfig().console_mode) {
+                visualisation->deactivate();
+        } else {
+            visualisation->updateRandomSeed();
         }
     }
 #endif
@@ -1544,6 +1546,12 @@ void CUDASimulation::initialiseSingletons() {
 
         // Store the WDDM/TCC driver mode status, for timer class decisions. Result is cached in the anon namespace to avoid multiple queries
         deviceUsingWDDM = util::detail::wddm::deviceIsWDDM();
+
+#ifdef VISUALISATION
+        if (visualisation) {
+            visualisation->updateRandomSeed();  // Incase user hasn't triggered applyConfig()
+        }
+#endif
 
         singletonsInitialised = true;
     } else {

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1550,6 +1550,7 @@ void CUDASimulation::initialiseSingletons() {
 #ifdef VISUALISATION
         if (visualisation) {
             visualisation->updateRandomSeed();  // Incase user hasn't triggered applyConfig()
+            visualisation->registerEnvProperties();
         }
 #endif
 

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -65,6 +65,7 @@ void ModelVis::_activate() {
     if ((!visualiser || !visualiser->isRunning()) && !model.getSimulationConfig().console_mode) {
         // Init visualiser
         visualiser = std::make_unique<FLAMEGPU_Visualisation>(modelCfg);  // Window resolution
+        visualiser->setRandomSeed(model.getSimulationConfig().random_seed);
         for (auto &agent : agents) {
             // If x and y aren't set, throw exception
             if (agent.second.core_tex_buffers.find(TexBufferConfig::Position_x) == agent.second.core_tex_buffers.end() &&
@@ -124,6 +125,13 @@ void ModelVis::updateBuffers(const unsigned int &sc) {
             a.second.updateBuffers(visualiser);
         }
         visualiser->releaseMutex();
+    }
+}
+
+void ModelVis::updateRandomSeed() {
+    if (visualiser) {
+        // Yolo thread safety, shouldn't matter if random seed is printed wrong for a single frame
+        visualiser->setRandomSeed(model.getSimulationConfig().random_seed);
     }
 }
 

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -79,7 +79,18 @@ void ModelVis::_activate() {
             }
             agent.second.initBindings(visualiser);
         }
+        env_registered = false;
+        registerEnvProperties();
         visualiser->start();
+    }
+}
+void ModelVis::registerEnvProperties() {
+    if (model.singletons && !env_registered) {
+        char * const host_env_origin = const_cast<char *>(static_cast<const char *>(model.singletons->environment->getHostBuffer()));
+        for (const auto& prop : model.singletons->environment->getPropertiesMap()) {
+            visualiser->registerEnvironmentProperty(prop.first, host_env_origin + prop.second.offset, prop.second.type, prop.second.elements, prop.second.isConst);
+        }
+        env_registered = true;
     }
 }
 


### PR DESCRIPTION
A draft of it now works

F1 for the existing debug menu, with random seed added
![image](https://user-images.githubusercontent.com/742154/183263751-0a9f3611-f851-484c-89a5-0528dd195691.png)

F2 for environment properties which update with the model (albeit no thread safety reading the data ptrs from vis thread)
![image](https://user-images.githubusercontent.com/742154/183263759-80f40b50-022f-4527-af68-f7c37714bd80.png)

- [ ] Seems worth hiding ones that begin with `_` given they're supposed to be internal.
- [ ] I think if they have a huge array it will wrap, but should probably test this (I may need to specify max width of the box)
- [ ] I need to add some kind of scroll if they have loads (e.g. primage).
- [ ] Will need to update CMake to point to new Vis hash when that is ready (reason CI is failing).

Matching vis PR: https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/94
