### PR TITLE
Address CMake 3.24 warnings from new policy

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 # @todo - If the git version has changed in this file, fetch again? 
-set(DEFAULT_VISUALISATION_GIT_VERSION "3e230bc908856129789342da7d73275b51991ddd")
+set(DEFAULT_VISUALISATION_GIT_VERSION "31cefa01020542528e199ec78a7cf2319a843009")
 set(DEFAULT_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # If overridden by the user, attempt to use that

--- a/cmake/dependencies/glm.cmake
+++ b/cmake/dependencies/glm.cmake
@@ -2,6 +2,11 @@
 # glm #
 #######
 
+# As the URL method is used for download, set the policy if available
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
 

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -15,6 +15,11 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
+# As the URL method is used for download, set the policy if available
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 # Find Python3, optionally an exact version for windows CI, or use in manylinux
 if(PYTHON3_EXACT_VERSION)
     set(PYTHON3_EXACT_VERSION_ARG ${PYTHON3_EXACT_VERSION} EXACT)


### PR DESCRIPTION
+ [x] Set new policy in FLAMEGPU2 repository where `URL` based fetch-content are used
+ [x] Set new policy in FLAMEGPU2-visualiser repository where `URL` based fetch-content are used (https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/95)
+ [x] Update visualiser hash once merged into vis master 

---

This is required for visuialiser CI. Actual builds still work fine with CMake 3.24 without this change, just warnings are emitted.

The new policy behaviour is a good thing to adopt. 