### PR TITLE
Bugfix: CUDAEnsemble progress printing nolonger jumps backwards.

### DIFF
--- a/include/flamegpu/sim/SimRunner.h
+++ b/include/flamegpu/sim/SimRunner.h
@@ -49,6 +49,7 @@ class SimRunner {
      * @param log_export_queue_mutex This mutex must be locked to access log_export_queue
      * @param log_export_queue_cdn The condition is notified every time a log has been added to the queue
      * @param fast_err_detail Structure to store error details on fast failure for main thread rethrow
+     * @param _total_runners Total number of runners executing
      */
     SimRunner(const std::shared_ptr<const ModelData> _model,
         std::atomic<unsigned int> &_err_ct,
@@ -64,7 +65,8 @@ class SimRunner {
         std::queue<unsigned int> &log_export_queue,
         std::mutex &log_export_queue_mutex,
         std::condition_variable &log_export_queue_cdn,
-        ErrorDetail &fast_err_detail);
+        ErrorDetail &fast_err_detail,
+        unsigned int _total_runners);
     /**
      * Each sim runner takes it's own clone of model description hierarchy, so it can manipulate environment without conflict
      */
@@ -81,6 +83,11 @@ class SimRunner {
      * Per instance unique runner id
      */
     const unsigned int runner_id;
+    /**
+     * Total number of runners executing
+     * This is used to calculate the progress on job completion
+     */
+    const unsigned int total_runners;
     /**
      * Flag for whether to print progress
      */

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -110,7 +110,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     // Init runners, devices * concurrent runs
     std::atomic<unsigned int> err_ct = {0};
     std::atomic<unsigned int> next_run = {0};
-    const size_t TOTAL_RUNNERS = devices.size() * config.concurrent_runs;
+    const unsigned int TOTAL_RUNNERS = static_cast<unsigned int>(devices.size()) * config.concurrent_runs;
     SimRunner *runners = static_cast<SimRunner *>(malloc(sizeof(SimRunner) * TOTAL_RUNNERS));
 
     // Log Time (We can't use CUDA events here, due to device resets)
@@ -127,10 +127,6 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
 
     // Init with placement new
     {
-        if (!config.quiet) {
-            printf("\rCUDAEnsemble progress: %u/%u", 0, static_cast<unsigned int>(plans.size()));
-            fflush(stdout);
-        }
         unsigned int i = 0;
         for (auto &d : devices) {
             for (unsigned int j = 0; j < config.concurrent_runs; ++j) {
@@ -138,7 +134,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
                     step_log_config, exit_log_config,
                     d, j,
                     !config.quiet, config.error_level == EnsembleConfig::Fast,
-                    run_logs, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, fast_err_detail);
+                    run_logs, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, fast_err_detail, TOTAL_RUNNERS);
             }
         }
     }

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -28,11 +28,13 @@ SimRunner::SimRunner(const std::shared_ptr<const ModelData> _model,
     std::queue<unsigned int> &_log_export_queue,
     std::mutex &_log_export_queue_mutex,
     std::condition_variable &_log_export_queue_cdn,
-    ErrorDetail &_fast_err_detail)
+    ErrorDetail &_fast_err_detail,
+    const unsigned int _total_runners)
       : model(_model->clone())
       , run_id(0)
       , device_id(_device_id)
       , runner_id(_runner_id)
+      , total_runners(_total_runners)
       , verbose(_verbose)
       , fail_fast(_fail_fast)
       , err_ct(_err_ct)
@@ -103,7 +105,8 @@ void SimRunner::start() {
             log_export_queue_cdn.notify_one();
             // Print progress to console
             if (verbose) {
-                fprintf(stdout, "\rCUDAEnsemble progress: %u/%u", run_id + 1, static_cast<unsigned int>(plans.size()));
+                const int progress = static_cast<int>(next_run.load()) - static_cast<int>(total_runners) + 1;
+                fprintf(stdout, "\rCUDAEnsemble progress: %d/%u", progress < 1 ? 1 : progress, static_cast<unsigned int>(plans.size()));
                 fflush(stdout);
             }
         } catch(std::exception &e) {


### PR DESCRIPTION
Also removed printing 0/N, as this conflicts with a logging warning, looks a bit dodgy.

Closes #901

-----------

I briefly tested it by modifying one of the examples with this:

```c
#include <thread>
FLAMEGPU_STEP_FUNCTION(Validation) {

    std::this_thread::sleep_for(std::chrono::milliseconds(FLAMEGPU->random.uniform<int>(0, 5000)));
}

...

    flamegpu::CUDAEnsemble ensemble(model);

    flamegpu::RunPlanVector runs(model, 200);
    runs.setSteps(1);
    runs.setRandomSimulationSeed(1, 4);

    ensemble.simulate(runs);

```

Numbers all appeared in order, and last number shown was `200/200` (quickly before it was replaced with the completion message).