### PR TITLE
ImGui support for bespoke interfaces

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 # @todo - If the git version has changed in this file, fetch again? 
-set(DEFAULT_VISUALISATION_GIT_VERSION "ef676da1daf8d8118bc7b2b75ede958c4f08afc9")
+set(DEFAULT_VISUALISATION_GIT_VERSION "3c4d209a0fa8008fbd398095a66afcf085d1bf61")
 set(DEFAULT_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # If overridden by the user, attempt to use that

--- a/examples/boids_bruteforce/src/main.cu
+++ b/examples/boids_bruteforce/src/main.cu
@@ -307,7 +307,7 @@ FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageBruteForce, flamegpu::Messag
 }
 
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("Boids_BruteForce");
+    flamegpu::ModelDescription model("Boids BruteForce");
 
     {   // Location message
         flamegpu::MessageBruteForce::Description &message = model.newMessage("location");
@@ -398,8 +398,20 @@ int main(int argc, const char ** argv) {
         circ_agt.setForwardXVariable("fx");
         circ_agt.setForwardYVariable("fy");
         circ_agt.setForwardZVariable("fz");
-        circ_agt.setModel(flamegpu::visualiser::Stock::Models::ICOSPHERE);
+        circ_agt.setModel(flamegpu::visualiser::Stock::Models::STUNTPLANE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS")/3.0f);
+        // Add a settings UI
+        flamegpu::visualiser::PanelVis ui = visualisation.newUIPanel("Environment");
+        ui.newStaticLabel("Interaction");
+        ui.newEnvironmentPropertyDrag<float>("INTERACTION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("SEPARATION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newStaticLabel("Environment Scalars");
+        ui.newEnvironmentPropertyDrag<float>("TIME_SCALE", 0.0f, 1.0f, 0.0001f);
+        ui.newEnvironmentPropertyDrag<float>("GLOBAL_SCALE", 0.0f, 0.5f, 0.001f);
+        ui.newStaticLabel("Force Scalars");
+        ui.newEnvironmentPropertyDrag<float>("STEER_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("COLLISION_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("MATCH_SCALE", 0.0f, 10.0f, 0.001f);
     }
     visualisation.activate();
 #endif

--- a/examples/boids_bruteforce_dependency_graph/src/main.cu
+++ b/examples/boids_bruteforce_dependency_graph/src/main.cu
@@ -307,7 +307,7 @@ FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageBruteForce, flamegpu::Messag
 }
 
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("Boids_BruteForce_DependencyGraph");
+    flamegpu::ModelDescription model("Boids BruteForce (DependencyGraph)");
 
     {   // Location message
         flamegpu::MessageBruteForce::Description &message = model.newMessage("location");
@@ -392,8 +392,23 @@ int main(int argc, const char ** argv) {
         visualisation.setCameraSpeed(0.002f * envWidth);
         auto &circ_agt = visualisation.addAgent("Boid");
         // Position vars are named x, y, z; so they are used by default
-        circ_agt.setModel(flamegpu::visualiser::Stock::Models::ICOSPHERE);
+        circ_agt.setForwardXVariable("fx");
+        circ_agt.setForwardYVariable("fy");
+        circ_agt.setForwardZVariable("fz");
+        circ_agt.setModel(flamegpu::visualiser::Stock::Models::STUNTPLANE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS")/3.0f);
+        // Add a settings UI
+        flamegpu::visualiser::PanelVis ui = visualisation.newUIPanel("Environment");
+        ui.newStaticLabel("Interaction");
+        ui.newEnvironmentPropertyDrag<float>("INTERACTION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("SEPARATION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newStaticLabel("Environment Scalars");
+        ui.newEnvironmentPropertyDrag<float>("TIME_SCALE", 0.0f, 1.0f, 0.0001f);
+        ui.newEnvironmentPropertyDrag<float>("GLOBAL_SCALE", 0.0f, 0.5f, 0.001f);
+        ui.newStaticLabel("Force Scalars");
+        ui.newEnvironmentPropertyDrag<float>("STEER_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("COLLISION_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("MATCH_SCALE", 0.0f, 10.0f, 0.001f);
     }
     visualisation.activate();
 #endif

--- a/examples/boids_rtc_bruteforce/src/main.cu
+++ b/examples/boids_rtc_bruteforce/src/main.cu
@@ -351,7 +351,7 @@ FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageBruteForce, flamegpu::Messag
 )###";
 
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("Boids_BruteForce");
+    flamegpu::ModelDescription model("Boids BruteForce (RTC)");
 
     {   // Location message
         flamegpu::MessageBruteForce::Description &message = model.newMessage("location");
@@ -443,8 +443,20 @@ int main(int argc, const char ** argv) {
         circ_agt.setForwardXVariable("fx");
         circ_agt.setForwardYVariable("fy");
         circ_agt.setForwardZVariable("fz");
-        circ_agt.setModel(flamegpu::visualiser::Stock::Models::ICOSPHERE);
+        circ_agt.setModel(flamegpu::visualiser::Stock::Models::STUNTPLANE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS")/3.0f);
+        // Add a settings UI
+        flamegpu::visualiser::PanelVis ui = visualisation.newUIPanel("Environment");
+        ui.newStaticLabel("Interaction");
+        ui.newEnvironmentPropertyDrag<float>("INTERACTION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("SEPARATION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newStaticLabel("Environment Scalars");
+        ui.newEnvironmentPropertyDrag<float>("TIME_SCALE", 0.0f, 1.0f, 0.0001f);
+        ui.newEnvironmentPropertyDrag<float>("GLOBAL_SCALE", 0.0f, 0.5f, 0.001f);
+        ui.newStaticLabel("Force Scalars");
+        ui.newEnvironmentPropertyDrag<float>("STEER_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("COLLISION_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("MATCH_SCALE", 0.0f, 10.0f, 0.001f);
     }
     visualisation.activate();
 #endif

--- a/examples/boids_rtc_spatial3D/src/main.cu
+++ b/examples/boids_rtc_spatial3D/src/main.cu
@@ -351,7 +351,7 @@ FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageSpatial3D, flamegpu::Message
 )###";
 
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("Boids_BruteForce");
+    flamegpu::ModelDescription model("Boids Spatial3D (RTC)");
 
     /**
      * GLOBALS
@@ -447,6 +447,18 @@ int main(int argc, const char ** argv) {
         circ_agt.setForwardZVariable("fz");
         circ_agt.setModel(flamegpu::visualiser::Stock::Models::STUNTPLANE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS")/3.0f);
+        // Add a settings UI
+        flamegpu::visualiser::PanelVis ui = visualisation.newUIPanel("Environment");
+        ui.newStaticLabel("Interaction");
+        ui.newEnvironmentPropertyDrag<float>("INTERACTION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("SEPARATION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newStaticLabel("Environment Scalars");
+        ui.newEnvironmentPropertyDrag<float>("TIME_SCALE", 0.0f, 1.0f, 0.0001f);
+        ui.newEnvironmentPropertyDrag<float>("GLOBAL_SCALE", 0.0f, 0.5f, 0.001f);
+        ui.newStaticLabel("Force Scalars");
+        ui.newEnvironmentPropertyDrag<float>("STEER_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("COLLISION_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("MATCH_SCALE", 0.0f, 10.0f, 0.001f);
     }
     visualisation.activate();
 #endif

--- a/examples/boids_spatial3D/src/main.cu
+++ b/examples/boids_spatial3D/src/main.cu
@@ -309,7 +309,7 @@ FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageSpatial3D, flamegpu::Message
 }
 
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("boids_spatial3D");
+    flamegpu::ModelDescription model("Boids Spatial3D");
 
     /**
      * GLOBALS
@@ -408,8 +408,20 @@ int main(int argc, const char ** argv) {
         circ_agt.setForwardXVariable("fx");
         circ_agt.setForwardYVariable("fy");
         circ_agt.setForwardZVariable("fz");
-        circ_agt.setModel(flamegpu::visualiser::Stock::Models::ICOSPHERE);
+        circ_agt.setModel(flamegpu::visualiser::Stock::Models::STUNTPLANE);
         circ_agt.setModelScale(env.getProperty<float>("SEPARATION_RADIUS")/3.0f);
+        // Add a settings UI
+        flamegpu::visualiser::PanelVis ui = visualisation.newUIPanel("Environment");
+        ui.newStaticLabel("Interaction");
+        ui.newEnvironmentPropertyDrag<float>("INTERACTION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("SEPARATION_RADIUS", 0.0f, 0.05f, 0.001f);
+        ui.newStaticLabel("Environment Scalars");
+        ui.newEnvironmentPropertyDrag<float>("TIME_SCALE", 0.0f, 1.0f, 0.0001f);
+        ui.newEnvironmentPropertyDrag<float>("GLOBAL_SCALE", 0.0f, 0.5f, 0.001f);
+        ui.newStaticLabel("Force Scalars");
+        ui.newEnvironmentPropertyDrag<float>("STEER_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("COLLISION_SCALE", 0.0f, 10.0f, 0.001f);
+        ui.newEnvironmentPropertyDrag<float>("MATCH_SCALE", 0.0f, 10.0f, 0.001f);
     }
     visualisation.activate();
 #endif

--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -67,7 +67,7 @@ FLAMEGPU_STEP_FUNCTION(Validation) {
 int main(int argc, const char ** argv) {
     NVTX_RANGE("main");
     NVTX_PUSH("ModelDescription");
-    flamegpu::ModelDescription model("Circles_BruteForce_example");
+    flamegpu::ModelDescription model("Circles BruteForce");
 
     const unsigned int AGENT_COUNT = 16384;
     const float ENV_MAX = static_cast<float>(floor(cbrt(AGENT_COUNT)));

--- a/examples/circles_spatial3D/src/main.cu
+++ b/examples/circles_spatial3D/src/main.cu
@@ -66,7 +66,7 @@ FLAMEGPU_STEP_FUNCTION(Validation) {
     printf("%.2f%% Drift correct\n", 100 * driftDropped / static_cast<float>(driftDropped + driftIncreased));
 }
 int main(int argc, const char ** argv) {
-    flamegpu::ModelDescription model("Circles_BruteForce_example");
+    flamegpu::ModelDescription model("Circles Spatial3D");
 
     const unsigned int AGENT_COUNT = 16384;
     const float ENV_MAX = static_cast<float>(floor(cbrt(AGENT_COUNT)));

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -35,7 +35,7 @@ int main(int argc, const char ** argv) {
     const unsigned int AGENT_COUNT = SQRT_AGENT_COUNT * SQRT_AGENT_COUNT;
     NVTX_RANGE("main");
     NVTX_PUSH("ModelDescription");
-    flamegpu::ModelDescription model("Game_of_Life_example");
+    flamegpu::ModelDescription model("Game of Life");
 
     {   // Location message
         flamegpu::MessageArray2D::Description &message = model.newMessage<flamegpu::MessageArray2D>("is_alive_message");

--- a/examples/sugarscape/src/main.cu
+++ b/examples/sugarscape/src/main.cu
@@ -312,7 +312,7 @@ int main(int argc, const char ** argv) {
         submodel.addExitCondition(MovementExitCondition);
     }
 
-    flamegpu::ModelDescription model("Sugarscape_example");
+    flamegpu::ModelDescription model("Sugarscape");
 
     /**
      * Agents

--- a/examples/swig_boids_spatial3D/boids_spatial3D.py
+++ b/examples/swig_boids_spatial3D/boids_spatial3D.py
@@ -341,7 +341,7 @@ FLAMEGPU_AGENT_FUNCTION(inputdata, flamegpu::MessageSpatial3D, flamegpu::Message
 }
 """
 
-model = pyflamegpu.ModelDescription("Boids_BruteForce");
+model = pyflamegpu.ModelDescription("Boids Spatial3D (Python)");
 
 """
   GLOBALS
@@ -434,6 +434,18 @@ if pyflamegpu.VISUALISATION:
     circ_agt.setForwardZVariable("fz");
     circ_agt.setModel(pyflamegpu.STUNTPLANE);
     circ_agt.setModelScale(env.getPropertyFloat("SEPARATION_RADIUS") /3.0);
+    # Add a settings UI
+    ui = visualisation.newUIPanel("Environment");
+    ui.newStaticLabel("Interaction");
+    ui.newEnvironmentPropertyDragFloat("INTERACTION_RADIUS", 0.0, 0.05, 0.001);
+    ui.newEnvironmentPropertyDragFloat("SEPARATION_RADIUS", 0.0, 0.05, 0.001);
+    ui.newStaticLabel("Environment Scalars");
+    ui.newEnvironmentPropertyDragFloat("TIME_SCALE", 0.0, 1.0, 0.0001);
+    ui.newEnvironmentPropertyDragFloat("GLOBAL_SCALE", 0.0, 0.5, 0.001);
+    ui.newStaticLabel("Force Scalars");
+    ui.newEnvironmentPropertyDragFloat("STEER_SCALE", 0.0, 10.0, 0.001);
+    ui.newEnvironmentPropertyDragFloat("COLLISION_SCALE", 0.0, 10.0, 0.001);
+    ui.newEnvironmentPropertyDragFloat("MATCH_SCALE", 0.0, 10.0, 0.001);
     visualisation.activate();
 
 """

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -51,6 +51,9 @@ class CUDASimulation : public Simulation {
     friend class HostAgentAPI;
     friend class SimRunner;
     friend class CUDAEnsemble;
+#ifdef VISUALISATION
+    friend class visualiser::ModelVis;
+#endif
     /**
      * Map of a number of CUDA agents by name.
      * The CUDA agents are responsible for allocating and managing all the device memory

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -12,6 +12,7 @@
 #include "flamegpu/visualiser/AgentVis.h"
 #include "flamegpu/visualiser/StaticModelVis.h"
 #include "flamegpu/visualiser/LineVis.h"
+#include "flamegpu/visualiser/PanelVis.h"
 #include "flamegpu/visualiser/color/AutoPalette.h"
 #include "flamegpu/visualiser/config/ModelConfig.h"
 
@@ -178,6 +179,13 @@ class ModelVis {
      */
     LineVis newPolylineSketch(float r, float g, float b, float a = 1.0f);
     /**
+     * Add a customisable user interface panel to the visualisation
+     *
+     * Each panel can be moved around the screen/minimised with custom elements representing environment properties added
+     * @param panel_title The string that will be visible in the title of the panel
+     */
+    PanelVis newUIPanel(const std::string& panel_title);
+    /**
      * Sets the visualisation running in a background thread
      */
     void activate() {
@@ -202,10 +210,18 @@ class ModelVis {
      */
     bool isRunning() const;
     /**
+     * Random seed has changed
+     */
+    void updateRandomSeed();
+    /**
      * Updates all agent renders from corresponding
      * @param sc Step count, the step count value shown in visualisation HUD
      */
     void updateBuffers(const unsigned int &sc = UINT_MAX);
+    /**
+     * Singletons have init, so env props are ready to grab
+     */
+    void registerEnvProperties();
 
  private:
     /**
@@ -238,6 +254,10 @@ class ModelVis {
      * Pointer to the visualisation
      */
     std::unique_ptr<FLAMEGPU_Visualisation> visualiser;
+    /**
+     * Only need to register env properties once
+     */
+    bool env_registered = false;
 };
 
 }  // namespace visualiser

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -161,7 +161,7 @@ class ModelVis {
      * @param modelPath Path of the model on disk
      * @param texturePath Optional path to a texture fore the model on disk
      */
-    StaticModelVis addStaticModel(const std::string &modelPath, const std::string &texturePath = "");
+    StaticModelVis newStaticModel(const std::string &modelPath, const std::string &texturePath = "");
     /**
      * Create a new sketch constructed from individual line segments to the visualisation
      * @param r Initial color's red component

--- a/include/flamegpu/visualiser/PanelVis.h
+++ b/include/flamegpu/visualiser/PanelVis.h
@@ -1,0 +1,291 @@
+#ifndef INCLUDE_FLAMEGPU_VISUALISER_PANELVIS_H_
+#define INCLUDE_FLAMEGPU_VISUALISER_PANELVIS_H_
+#include <memory>
+#include <string>
+#include <utility>
+#include <unordered_map>
+#include <set>
+
+#include "flamegpu/model/EnvironmentDescription.h"
+#include "flamegpu/visualiser/config/ModelConfig.h"
+
+namespace flamegpu {
+namespace visualiser {
+
+/**
+ * This class serves as an interface for managing an instance of PanelConfig
+ * It allows elements to be specified for a UI panel for the visualisation
+ */
+class PanelVis {
+ public:
+    /**
+     * @param _m Reference which this interface manages
+     * @param _environment Environment description to be used for validating correctness of requested environment UI elements
+     * @note This should only be constructed by ModelVis
+     * @see ModelVis::newUIPanel()
+     */
+    PanelVis(std::shared_ptr<PanelConfig> _m, std::shared_ptr<EnvironmentDescription> _environment);
+    /**
+     * Add a header to begin a collapsible group of elements
+     *
+     * @param header_text Text of the header
+     * @param begin_open If true, the section will not begin in a collapsed state
+     */
+    void newSection(const std::string& header_text, bool begin_open = true);
+    /**
+     * End a section, the following elements are not part of the previous collapsible section
+     * @note If this is not preceded by a call to newSection() it will have no effect
+     */
+    void newEndSection();
+    /**
+     * Add a label containing a fixed string
+     *
+     * @param label_text Text of the label
+     */
+    void newStaticLabel(const std::string& label_text);
+    /**
+     * Add a separator, creates a horizontal line between two consecutive elements
+     * Useful is organising a single panel into multiple sections
+     */
+    void newSeparator();
+    /**
+     * Add a slider which displays the named environment property and allows it's value to be updated by
+     * dragging a slider through the defined range
+     *
+     * @param property_name Name of the affected environment property
+     * @param min Minimum value of the slider
+     * @param max Maximum value of the slider
+     * @tparam T Type of the named environment property
+     */
+    template<typename T>
+    void newEnvironmentPropertySlider(const std::string &property_name, T min, T max);
+    /**
+     * @copydoc PanelVis::newEnvironmentPropertySlider()
+     * @param index Index of the specified element within the environment property array
+     * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
+     * @note Environment property arrays cannot be added as a whole, each element must be specified individually
+     */
+    template<typename T, EnvironmentManager::size_type N = 0>
+    void newEnvironmentPropertySlider(const std::string& property_name, EnvironmentManager::size_type index, T min, T max);
+    /**
+     * Add a drag element which displays the named environment property (or environment property array element) and allows it's value to be updated by
+     * clicking and dragging the mouse left/right. Double click can also be used to enter a new value via typing.
+     *
+     * @param property_name Name of the affected environment property
+     * @param min Minimum value that can be set
+     * @param max Maximum value that can be set
+     * @param speed Amount the value changes per pixel dragged
+     * @tparam T Type of the named environment property
+     */
+    template<typename T>
+    void newEnvironmentPropertyDrag(const std::string& property_name, T min, T max, float speed);
+    /**
+     * @copydoc PanelVis::newEnvironmentPropertyDrag(const std::string &, T, T, float)
+     * @param index Index of the specified element within the environment property array
+     * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
+     * @note Environment property arrays cannot be added as a whole, each element must be specified individually
+     */
+    template<typename T, EnvironmentManager::size_type N = 0>
+    void newEnvironmentPropertyDrag(const std::string& property_name, EnvironmentManager::size_type index, T min, T max, float speed);
+    /**
+     * Add a input box (with +/- step buttons) which displays the named environment property (or environment property array element) and allows it's value to be updated by
+     * clicking and dragging the mouse left/right. Double click can also be used to enter a new value via typing.
+     *
+     * @param property_name Name of the affected environment property
+     * @param step Change per button click
+     * @param step_fast Change per tick when holding button (?)
+     * @tparam T Type of the named environment property
+     */
+    template<typename T>
+    void newEnvironmentPropertyInput(const std::string& property_name, T step, T step_fast);
+    /**
+     * @copydoc PanelVis::newEnvironmentPropertyInput(const std::string &, T, T)
+     * @param index Index of the specified element within the environment property array
+     * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
+     * @note Environment property arrays cannot be added as a whole, each element must be specified individually
+     */
+    template<typename T, EnvironmentManager::size_type N = 0>
+    void newEnvironmentPropertyInput(const std::string& property_name, EnvironmentManager::size_type index, T step, T step_fast);
+    /**
+     * Add a checkbox element which displays the named environment property (or environment property array element) and allows it's value to be toggled
+     * between 0 and 1 by clicking.
+     *
+     * @param property_name Name of the affected environment property
+     * @tparam T Type of the named environment property
+     * @note This element only supports integer type properties
+     */
+    template<typename T>
+    void newEnvironmentPropertyToggle(const std::string& property_name);
+    /**
+     * @copydoc PanelVis::newEnvironmentPropertyToggle(const std::string &)
+     * @param index Index of the specified element within the environment property array
+     * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
+     * @note Environment property arrays cannot be added as a whole, each element must be specified individually
+     */
+    template<typename T, EnvironmentManager::size_type N = 0>
+    void newEnvironmentPropertyToggle(const std::string& property_name, EnvironmentManager::size_type index);
+
+ private:
+    /**
+     * The model description to validate requests against
+     */
+    const std::unordered_map<std::string, EnvironmentDescription::PropData> env_properties;
+    /**
+     * The panel data which this class acts as an interface for managing
+     */
+    std::shared_ptr<PanelConfig> m;
+    /**
+     * Each property can only be added to a specific panel once
+     * ImGui appears to use their names to classify input, so dupes cause odd behaviour
+     */
+    std::set<std::pair<std::string, EnvironmentManager::size_type>> added_properties;
+};
+template<typename T, EnvironmentManager::size_type N>
+void PanelVis::newEnvironmentPropertySlider(const std::string& property_name, EnvironmentManager::size_type index, T min, T max) {
+    {  // Validate name/type/length
+        const auto it = env_properties.find(property_name);
+        if (it == env_properties.end()) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' was not found, "
+                "in PanelVis::newEnvironmentPropertySlider()\n",
+                property_name.c_str());
+        } else if (it->second.data.type != std::type_index(typeid(T))) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+                "in PanelVis::newEnvironmentPropertySlider()\n",
+                property_name.c_str(), std::type_index(typeid(T)).name(), it->second.data.type.name());
+        } else if (N != 0 && N != it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' length mismatch %u != %u, "
+                "in PanelVis::newEnvironmentPropertySlider()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (index >= it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' index out of bounds %u >= %u, "
+                "in PanelVis::newEnvironmentPropertySlider()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (max < min) {
+            THROW exception::InvalidArgument("max < min, "
+                "in PanelVis::newEnvironmentPropertySlider()\n",
+                property_name.c_str());
+        } else if (!added_properties.insert({property_name, index}).second) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' has already been added to the panel, "
+                "each environment property (or property array element) can only be added to a panel once, "
+                "in PanelVis::newEnvironmentPropertySlider()\n",
+                property_name.c_str());
+        }
+    }
+    std::unique_ptr<PanelElement> ptr = std::unique_ptr<PanelElement>(new EnvPropertySlider<T>(property_name, index, min, max));
+    m->ui_elements.push_back(std::move(ptr));
+}
+template<typename T>
+void PanelVis::newEnvironmentPropertySlider(const std::string& property_name, T min, T max) {
+    newEnvironmentPropertySlider<T, 0>(property_name, 0, min, max);
+}
+template<typename T, EnvironmentManager::size_type N>
+void PanelVis::newEnvironmentPropertyDrag(const std::string& property_name, EnvironmentManager::size_type index, T min, T max, float speed) {
+    {  // Validate name/type/length
+        const auto it = env_properties.find(property_name);
+        if (it == env_properties.end()) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' was not found, "
+                "in PanelVis::newEnvironmentPropertyDrag()\n",
+                property_name.c_str());
+        } else if (it->second.data.type != std::type_index(typeid(T))) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+                "in PanelVis::newEnvironmentPropertyDrag()\n",
+                property_name.c_str(), std::type_index(typeid(T)).name(), it->second.data.type.name());
+        } else if (N != 0 && N != it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' length mismatch %u != %u, "
+                "in PanelVis::newEnvironmentPropertyDrag()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (index >= it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' index out of bounds %u >= %u, "
+                "in PanelVis::newEnvironmentPropertyDrag()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (max < min) {
+            THROW exception::InvalidArgument("max < min, "
+                "in PanelVis::newEnvironmentPropertyDrag()\n",
+                property_name.c_str());
+        } else if (!added_properties.insert({property_name, index}).second) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' has already been added to the panel, "
+                "each environment property (or property array element) can only be added to a panel once, "
+                "in PanelVis::newEnvironmentPropertyDrag()\n",
+                property_name.c_str());
+        }
+    }
+    std::unique_ptr<PanelElement> ptr = std::make_unique<EnvPropertyDrag<T>>(property_name, index, min, max, speed);
+    m->ui_elements.push_back(std::move(ptr));
+}
+template<typename T>
+void PanelVis::newEnvironmentPropertyDrag(const std::string& property_name, T min, T max, float speed) {
+    newEnvironmentPropertyDrag<T, 0>(property_name, 0, min, max, speed);
+}
+template<typename T, EnvironmentManager::size_type N>
+void PanelVis::newEnvironmentPropertyInput(const std::string& property_name, EnvironmentManager::size_type index, T step, T step_fast) {
+    {  // Validate name/type/length
+        const auto it = env_properties.find(property_name);
+        if (it == env_properties.end()) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' was not found, "
+                "in PanelVis::newEnvironmentPropertyInput()\n",
+                property_name.c_str());
+        } else if (it->second.data.type != std::type_index(typeid(T))) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+                "in PanelVis::newEnvironmentPropertyInput()\n",
+                property_name.c_str(), std::type_index(typeid(T)).name(), it->second.data.type.name());
+        } else if (N != 0 && N != it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' length mismatch %u != %u, "
+                "in PanelVis::newEnvironmentPropertyInput()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (index >= it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' index out of bounds %u >= %u, "
+                "in PanelVis::newEnvironmentPropertyInput()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (!added_properties.insert({property_name, index}).second) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' has already been added to the panel, "
+                "each environment property (or property array element) can only be added to a panel once, "
+                "in PanelVis::newEnvironmentPropertyInput()\n",
+                property_name.c_str());
+        }
+    }
+    std::unique_ptr<PanelElement> ptr = std::make_unique<EnvPropertyInput<T>>(property_name, index, step, step_fast);
+    m->ui_elements.push_back(std::move(ptr));
+}
+template<typename T>
+void PanelVis::newEnvironmentPropertyInput(const std::string& property_name, T step, T step_fast) {
+    newEnvironmentPropertyInput<T, 0>(property_name, 0, step, step_fast);
+}
+template<typename T, EnvironmentManager::size_type N>
+void PanelVis::newEnvironmentPropertyToggle(const std::string& property_name, EnvironmentManager::size_type index) {
+    static_assert(std::is_integral<T>::value, "PanelVis::newEnvironmentPropertyToggle() only supports integer type properties.");
+    {  // Validate name/type/length
+        const auto it = env_properties.find(property_name);
+        if (it == env_properties.end()) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' was not found, "
+                "in PanelVis::newEnvironmentToggle()\n",
+                property_name.c_str());
+        } else if (it->second.data.type != std::type_index(typeid(T))) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' type mismatch '%s' != '%s', "
+                "in PanelVis::newEnvironmentToggle()\n",
+                property_name.c_str(), std::type_index(typeid(T)).name(), it->second.data.type.name());
+        } else if (N != 0 && N != it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' length mismatch %u != %u, "
+                "in PanelVis::newEnvironmentToggle()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (index >= it->second.data.elements) {
+            THROW exception::InvalidEnvPropertyType("Environment property '%s' index out of bounds %u >= %u, "
+                "in PanelVis::newEnvironmentToggle()\n",
+                property_name.c_str(), N, it->second.data.elements);
+        } else if (!added_properties.insert({property_name, index}).second) {
+            THROW exception::InvalidEnvProperty("Environment property '%s' has already been added to the panel, "
+                "each environment property (or property array element) can only be added to a panel once, "
+                "in PanelVis::newEnvironmentToggle()\n",
+                property_name.c_str());
+        }
+    }
+    std::unique_ptr<PanelElement> ptr = std::make_unique<EnvPropertyToggle<T>>(property_name, index);
+    m->ui_elements.push_back(std::move(ptr));
+}
+template<typename T>
+void PanelVis::newEnvironmentPropertyToggle(const std::string& property_name) {
+    newEnvironmentPropertyToggle<T, 0>(property_name, 0);
+}
+}  // namespace visualiser
+}  // namespace flamegpu
+
+#endif  // INCLUDE_FLAMEGPU_VISUALISER_PANELVIS_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,6 +298,7 @@ SET(SRC_INCLUDE_VISUALISER
     ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/AgentStateVis.h
     ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/StaticModelVis.h
     ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/LineVis.h
+    ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/PanelVis.h
     ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/color/Color.h
     ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/color/ColorFunction.h
     ${FLAMEGPU_ROOT}/include/flamegpu/visualiser/color/DiscreteColor.h
@@ -314,6 +315,7 @@ set(SRC_FLAMEGPU_VISUALISER
     ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/AgentStateVis.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/StaticModelVis.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/LineVis.cpp
+        ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/PanelVis.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/color/DiscreteColor.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/color/StaticColor.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/visualiser/color/HSVInterpolation.cpp

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1431,9 +1431,11 @@ void CUDASimulation::applyConfig_derived() {
 
     // Handle console_mode
 #ifdef VISUALISATION
-    if (getSimulationConfig().console_mode) {
-        if (visualisation) {
+    if (visualisation) {
+        if (getSimulationConfig().console_mode) {
             visualisation->deactivate();
+        } else {
+            visualisation->updateRandomSeed();
         }
     }
 #endif
@@ -1544,6 +1546,13 @@ void CUDASimulation::initialiseSingletons() {
 
         // Store the WDDM/TCC driver mode status, for timer class decisions. Result is cached in the anon namespace to avoid multiple queries
         deviceUsingWDDM = util::detail::wddm::deviceIsWDDM();
+
+#ifdef VISUALISATION
+        if (visualisation) {
+            visualisation->updateRandomSeed();  // Incase user hasn't triggered applyConfig()
+            visualisation->registerEnvProperties();
+        }
+#endif
 
         singletonsInitialised = true;
     } else {

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -207,7 +207,7 @@ void ModelVis::setBeginPaused(const bool& beginPaused) {
     modelCfg.beginPaused = beginPaused;
 }
 
-StaticModelVis ModelVis::addStaticModel(const std::string &modelPath, const std::string &texturePath) {
+StaticModelVis ModelVis::newStaticModel(const std::string &modelPath, const std::string &texturePath) {
     // Create ModelConfig::StaticModel
     auto m = std::make_shared<ModelConfig::StaticModel>();
     // set modelPath, texturePath

--- a/src/flamegpu/visualiser/PanelVis.cpp
+++ b/src/flamegpu/visualiser/PanelVis.cpp
@@ -1,0 +1,36 @@
+#include <utility>
+
+#include "flamegpu/visualiser/PanelVis.h"
+
+namespace flamegpu {
+namespace visualiser {
+
+PanelVis::PanelVis(std::shared_ptr<PanelConfig> _m, std::shared_ptr<EnvironmentDescription> _environment)
+    : env_properties(_environment->getPropertiesMap())  // For some reason this method returns a copy, not a reference
+    , m(std::move(_m)) {
+    // Rebuild added_properties
+    for (const auto &element : m->ui_elements) {
+        if (const EnvPropertyElement* p = dynamic_cast<EnvPropertyElement*>(element.get())) {
+            added_properties.insert({p->name, p->index});
+        }
+    }
+}
+void PanelVis::newSection(const std::string& header_text, bool begin_open) {
+    std::unique_ptr<PanelElement> ptr = std::make_unique<HeaderElement>(header_text, begin_open);
+    m->ui_elements.push_back(std::move(ptr));
+}
+void PanelVis::newEndSection() {
+    std::unique_ptr<PanelElement> ptr = std::make_unique<EndSectionElement>();
+    m->ui_elements.push_back(std::move(ptr));
+}
+void PanelVis::newStaticLabel(const std::string& label_text) {
+    std::unique_ptr<PanelElement> ptr = std::make_unique<LabelElement>(label_text);
+    m->ui_elements.push_back(std::move(ptr));
+}
+void PanelVis::newSeparator() {
+    std::unique_ptr<PanelElement> ptr = std::make_unique<SeparatorElement>();
+    m->ui_elements.push_back(std::move(ptr));
+}
+
+}  // namespace visualiser
+}  // namespace flamegpu

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -101,6 +101,13 @@ using namespace flamegpu; // @todo - is this required? Ideally it shouldn't be, 
 %template(function ## Double) classfunction<double>;
 %enddef
 
+// Array version, passing default 2nd template arg 0
+%define TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_FLOATS(function, classfunction) 
+// float and double
+%template(function ## Float) classfunction<float, 0>;
+%template(function ## Double) classfunction<double, 0>;
+%enddef
+
 /**
  * TEMPLATE_VARIABLE_INSTANTIATE macro
  * Expands for int types
@@ -117,6 +124,21 @@ using namespace flamegpu; // @todo - is this required? Ideally it shouldn't be, 
 // default int types
 %template(function ## Int) classfunction<int>;
 %template(function ## UInt) classfunction<unsigned int>;
+%enddef
+
+// Array version, passing default 2nd template arg 0
+%define TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_INTS(function, classfunction) 
+// signed ints
+%template(function ## Int16) classfunction<int16_t, 0>;
+%template(function ## Int32) classfunction<int32_t, 0>;
+%template(function ## Int64) classfunction<int64_t, 0>;
+// unsigned ints
+%template(function ## UInt16) classfunction<uint16_t, 0>;
+%template(function ## UInt32) classfunction<uint32_t, 0>;
+%template(function ## UInt64) classfunction<uint64_t, 0>;
+// default int types
+%template(function ## Int) classfunction<int, 0>;
+%template(function ## UInt) classfunction<unsigned int, 0>;
 %enddef
 
 /**
@@ -139,6 +161,19 @@ TEMPLATE_VARIABLE_INSTANTIATE_INTS(function, classfunction)
 //%template(function ## Bool) classfunction<bool>;
 %enddef
 
+// Array version, passing default 2nd template arg 0
+%define TEMPLATE_VARIABLE_ARRAY_INSTANTIATE(function, classfunction) 
+TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_FLOATS(function, classfunction)
+TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_INTS(function, classfunction)
+// char types
+%template(function ## Int8) classfunction<int8_t, 0>;
+%template(function ## UInt8) classfunction<uint8_t, 0>;
+%template(function ## Char) classfunction<char, 0>;
+%template(function ## UChar) classfunction<unsigned char, 0>;
+// bool type (not supported causes error)
+//%template(function ## Bool) classfunction<bool, 0>;
+%enddef
+
 /**
  * Special case of the macro for message types
  * This also maps ID to id_t, this should be synonymous with UInt/unsigned int
@@ -146,6 +181,12 @@ TEMPLATE_VARIABLE_INSTANTIATE_INTS(function, classfunction)
 %define TEMPLATE_VARIABLE_INSTANTIATE_ID(function, classfunction)
 TEMPLATE_VARIABLE_INSTANTIATE(function, classfunction) 
 %template(function ## ID) classfunction<flamegpu::id_t>;
+%enddef
+
+// Array version, passing default 2nd template arg 0
+%define TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_ID(function, classfunction)
+TEMPLATE_VARIABLE_ARRAY_INSTANTIATE(function, classfunction) 
+%template(function ## ID) classfunction<flamegpu::id_t, 0>;
 %enddef
 
 
@@ -891,6 +932,8 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
     %ignore flamegpu::visualiser::Palette::begin;
     %ignore flamegpu::visualiser::Palette::end;
     %ignore flamegpu::visualiser::Palette::colors;  // This is protected, i've no idea why SWIG is trying to wrap it
+    // Mark PanelVis as a class where assignment operator is not supported
+    %feature("valuewrapper") flamegpu::visualiser::PanelVis;
     // Rename directives. These go before any %includes
     // -----------------
     // Director features. These go before the %includes.
@@ -904,6 +947,7 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
     %include "flamegpu/visualiser/AgentStateVis.h"
     %include "flamegpu/visualiser/AgentVis.h"
     %include "flamegpu/visualiser/LineVis.h"
+    %include "flamegpu/visualiser/PanelVis.h"
     %include "flamegpu/visualiser/ModelVis.h"
     %include "flamegpu/visualiser/color/Color.h"
     %include "flamegpu/visualiser/color/ColorFunction.h"
@@ -954,7 +998,17 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
     // Manually create the two DiscretColor templates
     %template(iDiscreteColor) flamegpu::visualiser::DiscreteColor<int32_t>;
     %template(uDiscreteColor) flamegpu::visualiser::DiscreteColor<uint32_t>;
+    TEMPLATE_VARIABLE_INSTANTIATE_ID(newEnvironmentPropertySlider, flamegpu::visualiser::PanelVis::newEnvironmentPropertySlider)
+    TEMPLATE_VARIABLE_INSTANTIATE_ID(newEnvironmentPropertyDrag, flamegpu::visualiser::PanelVis::newEnvironmentPropertyDrag)
+    TEMPLATE_VARIABLE_INSTANTIATE_ID(newEnvironmentPropertyInput, flamegpu::visualiser::PanelVis::newEnvironmentPropertyInput)
+    TEMPLATE_VARIABLE_INSTANTIATE_INTS(newEnvironmentPropertyToggle, flamegpu::visualiser::PanelVis::newEnvironmentPropertyToggle)
+    
+    TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_ID(newEnvironmentPropertySlider, flamegpu::visualiser::PanelVis::newEnvironmentPropertySlider)
+    TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_ID(newEnvironmentPropertyDrag, flamegpu::visualiser::PanelVis::newEnvironmentPropertyDrag)
+    TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_ID(newEnvironmentPropertyInput, flamegpu::visualiser::PanelVis::newEnvironmentPropertyInput)
+    TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_INTS(newEnvironmentPropertyToggle, flamegpu::visualiser::PanelVis::newEnvironmentPropertyToggle)
 
+    
     // Redefine the value to ensure it makes it into the python modules
     #undef VISUALISATION
     #define VISUALISATION true


### PR DESCRIPTION
**Will require updating the CMake vis hash after Vis PR is merged.**

Most development detail can be found in the Vis PR.

I'm happy that this is ready.

Several potential features I've not bothered to implement:
* Allowing users to change the colour scheme (currently it's fixed to ImGui::Dark).
* Allowing users to customise the format string for environment property printing (`%g` is used for floating-point, but this can create unwanted high precision numbers in rare cases)
* Allowing users to manually position panels within the window (they can move them after sim has started)
* Allowing users to mark panels begin collapsed.


Vis PR: https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/100
Docs Pr: https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/110
Ped Nav Example Pr: https://github.com/FLAMEGPU/FLAMEGPU2-pedestrian_navigation-example/pull/1
Ped Nav Example Video: https://youtu.be/9jPfBs81XmE