### PR TITLE
Python 3.7. support for code generator

### DIFF
--- a/tests/swig/python/codegen/test_codegen.py
+++ b/tests/swig/python/codegen/test_codegen.py
@@ -534,7 +534,6 @@ class CodeGenTest(unittest.TestCase):
             # code generate
             code = pyflamegpu.codegen.codegen(tree)
         if EXCEPTION_MSG_CHECKING:
-            print(str(e.value))
             assert exception_str in str(e.value)
            
         

--- a/tests/swig/python/codegen/test_codegen.py
+++ b/tests/swig/python/codegen/test_codegen.py
@@ -534,6 +534,7 @@ class CodeGenTest(unittest.TestCase):
             # code generate
             code = pyflamegpu.codegen.codegen(tree)
         if EXCEPTION_MSG_CHECKING:
+            print(str(e.value))
             assert exception_str in str(e.value)
            
         
@@ -613,7 +614,7 @@ class CodeGenTest(unittest.TestCase):
         self._checkException(py_try, "Exceptions not supported")
 
     def test_bytes(self):
-        self._checkException("b'123'", "Byte strings not supported")
+        self._checkException("b'123'", "Byte strings and Bytes function not supported")
 
     def test_strings(self):
         self._checkException('f"{value}"', "not supported")


### PR DESCRIPTION
Fixes Bug #915 

Mostly a case of Python 3.7 using ast feature depreciated in Python 3.8+. Special cases have been used to detect these for Python 3.7.