### PR TITLE
Only emit GCC 9 + CUDA 11.0 + c++17 dev warning once

### DIFF
--- a/cmake/CheckCompilerFunctionality.cmake
+++ b/cmake/CheckCompilerFunctionality.cmake
@@ -66,6 +66,46 @@ function(CheckCompilerFunctionality)
         endif()
     endif()
 
+    # GCC 9 + CUDA 11.0 + std=c++17 errors when attempting to compile std::vector<std::tuple<>>::push_back.
+    # This is the only known bad combination, but let's check more often just in case.
+    # We no longer use this (intentionally) so if the error occurs emit a warning but not error?
+    # See https://github.com/FLAMEGPU/FLAMEGPU2/issues/575,  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100102 
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # Try to compile the test case file for inclusion of chrono.
+        if(NOT DEFINED GCC_CUDA_VECTOR_TUPLE_PUSHBACK)
+            # CUDA must be available.
+            enable_language(CUDA)
+            # Disable CMAKE_CUDA_ARCHTIECTURES if not already controlled. This is scoped to the function so safe to control.
+            if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES OR "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
+                set(CMAKE_CUDA_ARCHITECTURES "OFF")
+            endif()
+            try_compile(
+                GCC_CUDA_VECTOR_TUPLE_PUSHBACK
+                "${CMAKE_CURRENT_BINARY_DIR}/try_compile"
+                "${CMAKE_CURRENT_LIST_DIR}/CheckCompilerFunctionality/CheckVectorTuplePushBack.cu"
+                CXX_STANDARD 17
+                CUDA_STANDARD 17
+                CXX_STANDARD_REQUIRED "ON"
+            )
+        endif()
+        # If an error occured while building MWE emit a dev warning. 
+        if(NOT GCC_CUDA_VECTOR_TUPLE_PUSHBACK)
+            # If the GCC versions is known to be bad, give an appropriate error
+            message(AUTHOR_WARNING
+                "std::vector<std::tuple<>>::push_back cannot be compiled with ${CMAKE_CUDA_COMPILER_ID} ${CMAKE_CUDA_COMPILER_VERSION} and ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} with --std=c++17.\n"
+                "Consider using a different ${CMAKE_CUDA_COMPILER_ID} and ${CMAKE_CXX_COMPILER_ID} combination as errors may be encountered.\n"
+                "See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650")
+            # Not erroring, so don't change the output value, just emit the above developer warning
+        
+        # The compilation error is somewhat tempremental, so always emit a warning for the known bad combination
+        elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0" AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.1" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9" AND CMAKE_CXX_COMILER_VERSION VERSION_LESS "10")
+            message(AUTHOR_WARNING 
+                "CUDA 11.0 with g++ 9 in c++17 mode may encounter compiler segmentation faults with 'std::vector<std::tuple<...>>::push_back'.\n"
+                "Consider using CUDA 11.1+ or gcc 8 to avoid potential issues.\n"
+                "See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650")
+        endif()
+    endif()
+
     # If we made it this far, set the result variable to be truthy
     set(CheckCompilerFunctionality_RESULT "YES" PARENT_SCOPE)
 endfunction()

--- a/cmake/CheckCompilerFunctionality/CheckVectorTuplePushBack.cu
+++ b/cmake/CheckCompilerFunctionality/CheckVectorTuplePushBack.cu
@@ -1,0 +1,11 @@
+// GCC 9 + CUDA 11.0 + --std=c++17 errors during complation of std::vector<std::tuple<>>::push_back. 
+// Test this for the configured CUDA, incase it is OK on the given system
+// See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650 for more information 
+#include <tuple>
+#include <vector>
+
+int main (int argc, char * argv[]) {
+    std::vector<std::tuple<float>> v;
+    std::tuple<float> t = {1.f};
+    v.push_back(t);  // segmentation fault
+}

--- a/cmake/cxxstd.cmake
+++ b/cmake/cxxstd.cmake
@@ -23,21 +23,6 @@ if(NOT FLAMEGPU_CXX_STD)
 
     # Set a cmake variable so this is only calcualted once, and can be applied afterwards.
     set(FLAMEGPU_CXX_STD 17)
-
-    # Emit a developer warning if using CUDA 11.0 and GCC 9 in c++17 mode re std::vector<std::tuple<...>>::push_back
-    # @todo - promote this to a try compile, and issue the (author) warning if the erorr is encountered?
-    if( CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0"
-        AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.1"
-        AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9"
-        AND CMAKE_CXX_COMILER_VERSION VERSION_LESS "10"
-        AND (FLAMEGPU_CXX_STD EQUAL 17 OR CMAKE_CUDA_STANDARD EQUAL 17))
-        # https://github.com/FLAMEGPU/FLAMEGPU2/issues/650
-        message(AUTHOR_WARNING 
-            "CUDA 11.0 with g++ 9 in c++17 mode may encounter compiler segmentation faults with 'std::vector<std::tuple<...>>::push_back'.\n"
-            "Consider using CUDA 11.1+ or gcc 8 to avoid potential issues.\n"
-            "See https://github.com/FLAMEGPU/FLAMEGPU2/issues/650 for more information.")
-    endif()
 endif()
 
 # @future - set this on a per target basis using set_target_properties?


### PR DESCRIPTION
Also tests for it, but still emits the warning for the known bad combination (it's tempremental

Closes #870