### PR TITLE
Update CI to use CUDA 11.8 when testing latest CUDA

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -38,6 +38,8 @@ $CUDA_KNOWN_URLS = @{
     "11.6.1" = "https://developer.download.nvidia.com/compute/cuda/11.6.1/network_installers/cuda_11.6.1_windows_network.exe";
     "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
     "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe";
+    "11.7.1" = "https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe";
+    "11.8.0" = "https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "11.6"
+          - cuda: "11.8"
             cuda_arch: "35 60 80"
             hostcxx: gcc-9
             os: ubuntu-20.04
@@ -184,7 +184,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "11.6.0"
+          - cuda: "11.8.0"
             cuda_arch: "35 60 80"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -30,7 +30,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.7"
+          - cuda: "11.8"
             os: ubuntu-20.04
     env:
       # Define constants

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.7"
+          - cuda: "11.8"
             cuda_arch: "35"
             hostcxx: gcc-11
             os: ubuntu-22.04

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "11.7.0"
+          - cuda: "11.8.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,7 +29,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.7.0"
+          - cuda: "11.8.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022

--- a/cmake/dependencies/Thrust.cmake
+++ b/cmake/dependencies/Thrust.cmake
@@ -21,9 +21,9 @@ find_package(CUDAToolkit REQUIRED)
 # thrust-config.cmake and cub-config.cmake live in different locations with CUDA (on ubuntu) depending on the CUDA version.
 # CUDA 11.3 and 11.4 they can be found in the CUDA Toolkit include directories.
 # CUDA 11.5+ they can be found in lib/cmake or lib64/cmake
-# CUDA 11.6 (and 11.7) ships with CUB 1.15.0 which has a bug when windows.h is included prior to CUB, so don't try to find the regular Thrust/CUB in this case. 
+# CUDA 11.6 - 11.8 ships with CUB 1.15.0 which has a bug when windows.h is included prior to CUB, so don't try to find the regular Thrust/CUB in this case. 
 # Ideally we would detect 1.15.0 and then download the correct version of CUB/Thrust, but getting CMake on windows to behave was proving problematic
-if(NOT (MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.6.0 AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.8.0))
+if(NOT (MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.6.0 AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.9.0))
     find_package(Thrust QUIET CONFIG HINTS ${CUDAToolkit_INCLUDE_DIRS} ${CUDAToolkit_LIBRARY_DIR}/cmake)
     find_package(CUB QUIET CONFIG HINTS ${CUDAToolkit_INCLUDE_DIRS} ${CUDAToolkit_LIBRARY_DIR}/cmake)
 endif()


### PR DESCRIPTION
CUDA 11.8 still ships cub/thrust 1.15 which is broken on Windows (when `windows.h` is included prior to cub/thrust). The version blocking cmake has been updated (assuming the next release will fix it again).