### PR TITLE
Drop python 3.6 from wheel generation

### DIFF
--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         sudo apt-get install python3-venv
         python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade 'setuptools; python_version >= "3.6"' 'setuptools<51.3.0; python_version < "3.6" and python_version >= "3.0"'
+        python3 -m pip install --upgrade setuptools
 
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -22,9 +22,9 @@ defaults:
 # + Thorough Windows builds
 #   + Oldest and newest cuda, lots of arch, vis off, tests on
 # + Wheel producing manylinux builds
-#   + CUDA 11.0 and 11.2, py 3.6-9, vis on/off, py only.
+#   + CUDA 11.0 and 11.2, py 3.7-10, vis on/off, py only.
 # + Wheel producing Windows builds
-#   + CUDA 11.0 and 11.2, py 3.6-9, vis on/off, py only.
+#   + CUDA 11.0 and 11.2, py 3.7-10, vis on/off, py only.
 # + Draft github release workflow.
 
 jobs:
@@ -104,7 +104,7 @@ jobs:
       run: |
         sudo apt-get install python3-venv
         python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade 'setuptools; python_version >= "3.6"' 'setuptools<51.3.0; python_version < "3.6" and python_version >= "3.0"'
+        python3 -m pip install --upgrade setuptools
 
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}
@@ -297,7 +297,6 @@ jobs:
           - "3.9"
           - "3.8"
           - "3.7"
-          - "3.6"
         config:
           - name: "Release"
             config: "Release"
@@ -453,7 +452,6 @@ jobs:
           - "3.9"
           - "3.8"
           - "3.7"
-          - "3.6"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         sudo apt-get install python3-venv
         python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade 'setuptools; python_version >= "3.6"' 'setuptools<51.3.0; python_version < "3.6" and python_version >= "3.0"'
+        python3 -m pip install --upgrade setuptools
 
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Optionally:
 
 + [cpplint](https://github.com/cpplint/cpplint) for linting code
 + [Doxygen](http://www.doxygen.nl/) to build the documentation
-+ [Python](https://www.python.org/) `>= 3.6` for python integration
++ [Python](https://www.python.org/) `>= 3.7` for python integration
 + [swig](http://www.swig.org/) `>= 4.0.2` for python integration
   + Swig `4.x` will be automatically downloaded by CMake if not provided (if possible).
 + [FLAMEGPU2-visualiser](https://github.com/FLAMEGPU/FLAMEGPU2-visualiser) dependencies


### PR DESCRIPTION
Python 3.6 went EOL 2021-12-23

Also removes CI workaround for installing a usable version of setuptools

Part of #886