### PR TITLE
Windows: CUDAEnsemble can block standby whilst running.

### DIFF
--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -66,6 +66,15 @@ class CUDAEnsemble {
          * Defaults to Slow
          */
         ErrorLevel error_level = Slow;
+        /**
+         * Prevents the computer from entering standby whilst the ensemble is running
+         * @note This feature is currently only supported by Windows builds.
+         */
+#ifdef _MSC_VER
+        bool block_standby = true;
+#else
+        const bool block_standby = false;
+#endif
     };
     /**
      * Initialise CUDA Ensemble

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -30,12 +30,24 @@ CUDAEnsemble::CUDAEnsemble(const ModelDescription& _model, int argc, const char*
     initialise(argc, argv);
 }
 CUDAEnsemble::~CUDAEnsemble() {
-    // Nothing to do
+// Call this here incase simulate() exited with an exception
+#ifdef _MSC_VER
+    if (config.block_standby) {
+        // Disable prevention of standby
+        SetThreadExecutionState(ES_CONTINUOUS);
+    }
+#endif
 }
 
 
 
 unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
+#ifdef _MSC_VER
+    if (config.block_standby) {
+        // This thread requires the system continuously until it exits
+        SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+    }
+#endif
     // Validate that RunPlan model matches CUDAEnsemble model
     if (*plans.environment != this->model->environment->properties) {
         THROW exception::InvalidArgument("RunPlan is for a different ModelDescription, in CUDAEnsemble::simulate()");
@@ -194,6 +206,12 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     } else if (config.error_level == EnsembleConfig::Slow && err_ct.load()) {
         THROW exception::EnsembleError("%u/%u runs failed!\n.", err_ct.load(), static_cast<unsigned int>(plans.size()));
     }
+#ifdef _MSC_VER
+    if (config.block_standby) {
+        // Disable prevention of standby
+        SetThreadExecutionState(ES_CONTINUOUS);
+    }
+#endif
 
     return err_ct.load();
 }
@@ -316,6 +334,13 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
             }
             continue;
         }
+        // --standby Disable the blocking of standby
+        if (arg.compare("--standby") == 0) {
+#ifdef _MSC_VER
+            config.block_standby = false;
+#endif
+            continue;
+        }
         fprintf(stderr, "Unexpected argument: %s\n", arg.c_str());
         printHelp(argv[0]);
         return false;
@@ -336,6 +361,9 @@ void CUDAEnsemble::printHelp(const char *executable) {
     printf(line_fmt, "-q, --quiet", "Don't print progress information to console");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
     printf(line_fmt, "-e, --error <error level>", "The error level 0, 1, 2, off, slow or fast");
+#ifdef _MSC_VER
+    printf(line_fmt, "    --standby", "Allow the machine to enter standby during execution");
+#endif
     printf(line_fmt, "", "By default, \"slow\" will be used.");
 }
 void CUDAEnsemble::setStepLog(const StepLoggingConfig &stepConfig) {


### PR DESCRIPTION
This uses Windows API to notify that threads running models inside `CUDAEnsemble` don't want the PC to enter standby.

It can be disabled by setting `block_standby=false` or passing `--standby` or `-s` at runtime. Though I'm not sure why a user would want to do that.

I don't believe there is a similar system wide power mgmt feature on Linux.

------------

This requires a manual test when I have a computer spare to try it on. It may be better to add it to the parent thread temporarily, rather than to the children threads.