### PR TITLE
Do not install required pip packages on behalf of users

### DIFF
--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -104,8 +104,7 @@ jobs:
       if: ${{ env.PYTHON != '' && env.BUILD_SWIG_PYTHON == 'ON' }}
       run: |
         sudo apt-get install python3-venv
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade setuptools
+        python3 -m pip install --upgrade wheel build setuptools
 
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -103,8 +103,7 @@ jobs:
       if: ${{ env.PYTHON != '' && env.BUILD_SWIG_PYTHON == 'ON' }}
       run: |
         sudo apt-get install python3-venv
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade setuptools
+        python3 -m pip install --upgrade wheel build setuptools
 
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -104,8 +104,7 @@ jobs:
       if: ${{ env.PYTHON != '' && env.BUILD_SWIG_PYTHON == 'ON' }}
       run: |
         sudo apt-get install python3-venv
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade setuptools
+        python3 -m pip install --upgrade wheel build setuptools
 
     - name: Install Visualisation Dependencies
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -99,8 +99,7 @@ jobs:
     - name: Install python dependencies
       if: ${{ env.PYTHON != '' && env.BUILD_SWIG_PYTHON == 'ON' }}
       run: |
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install --upgrade setuptools
+        python3 -m pip install --upgrade wheel build setuptools
 
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -96,6 +96,12 @@ jobs:
       with:
         python-version: ${{ env.PYTHON }}
 
+    - name: Install python dependencies
+      if: ${{ env.PYTHON != '' && env.BUILD_SWIG_PYTHON == 'ON' }}
+      run: |
+        python3 -m pip install --upgrade wheel
+        python3 -m pip install --upgrade setuptools
+
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Building via CMake is a three step process, with slight differences depending on
 2. Configure CMake into the build directory
     + Using the CMake GUI or CLI tools
     + Specifying build options such as the CUDA Compute Capabilities to target, the inclusion of Visualisation or Python components, or performance impacting features such as `SEATBELTS`. See [CMake Configuration Options](#CMake-Configuration-Options) for details of the available configuration options
+    + CMake will automatically find and select compilers, libraries and python interpreters based on current environmental variables and default locations. See [Mastering CMake](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Getting%20Started.html#specifying-the-compiler-to-cmake) for more information.
+        + Python dependencies must be installed in the selected python environment. If needed you can instruct CMake to use a specific python implementation using the `Python_ROOT_DIR` and `Python_Executable` CMake options at configure time.
 3. Build compilation targets using the configured build system
     + See [Available Targets](#Available-targets) for a list of available targets.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Optionally:
 + [cpplint](https://github.com/cpplint/cpplint) for linting code
 + [Doxygen](http://www.doxygen.nl/) to build the documentation
 + [Python](https://www.python.org/) `>= 3.7` for python integration
+  + With `setuptools`, `wheel` and optionally `venv` python packages installed
 + [swig](http://www.swig.org/) `>= 4.0.2` for python integration
   + Swig `4.x` will be automatically downloaded by CMake if not provided (if possible).
 + [FLAMEGPU2-visualiser](https://github.com/FLAMEGPU/FLAMEGPU2-visualiser) dependencies
@@ -159,8 +160,8 @@ cmake --build . --target all
 | `CMAKE_BUILD_TYPE`       | `Release`/`Debug`/`MinSizeRel`/`RelWithDebInfo` | Select the build configuration for single-target generators such as `make`   |
 | `SEATBELTS`              | `ON`/`OFF`        | Enable / Disable additional runtime checks which harm performance but increase usability. Default `ON`     |
 | `CUDA_ARCH`              | `"52 60 70 80"`   | Select [CUDA Compute Capabilities](https://developer.nvidia.com/cuda-gpus) to build/optimise for, as a space or `;` separated list. Defaults to `""` |
-| `BUILD_SWIG_PYTHON`      | `ON`/`OFF`        | Enable Python target `pyflamegpu` via Swig. Default `OFF`                                                  |
-| `BUILD_SWIG_PYTHON_VENV` | `ON`/`OFF`        | Use a python `venv` when building the python Swig target. Default `ON`.                                    |
+| `BUILD_SWIG_PYTHON`      | `ON`/`OFF`        | Enable Python target `pyflamegpu` via Swig. Default `OFF`. Python packages `setuptools` & `wheel` required |
+| `BUILD_SWIG_PYTHON_VENV` | `ON`/`OFF`        | Use a python `venv` when building the python Swig target. Default `ON`. Python package `venv` required     |
 | `BUILD_TESTS`            | `ON`/`OFF`        | Build the C++/CUDA test suite. Default `OFF`.                                                              |
 | `BUILD_TESTS_DEV`        | `ON`/`OFF`        | Build the reduced-scope development test suite. Default `OFF`                                              |
 | `VISUALISATION`          | `ON`/`OFF`        | Enable Visualisation. Default `OFF`.                                                                       |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Optionally:
 + [cpplint](https://github.com/cpplint/cpplint) for linting code
 + [Doxygen](http://www.doxygen.nl/) to build the documentation
 + [Python](https://www.python.org/) `>= 3.7` for python integration
-  + With `setuptools`, `wheel` and optionally `venv` python packages installed
+  + With `setuptools`, `wheel`, `build` and optionally `venv` python packages installed
 + [swig](http://www.swig.org/) `>= 4.0.2` for python integration
   + Swig `4.x` will be automatically downloaded by CMake if not provided (if possible).
 + [FLAMEGPU2-visualiser](https://github.com/FLAMEGPU/FLAMEGPU2-visualiser) dependencies
@@ -160,7 +160,7 @@ cmake --build . --target all
 | `CMAKE_BUILD_TYPE`       | `Release`/`Debug`/`MinSizeRel`/`RelWithDebInfo` | Select the build configuration for single-target generators such as `make`   |
 | `SEATBELTS`              | `ON`/`OFF`        | Enable / Disable additional runtime checks which harm performance but increase usability. Default `ON`     |
 | `CUDA_ARCH`              | `"52 60 70 80"`   | Select [CUDA Compute Capabilities](https://developer.nvidia.com/cuda-gpus) to build/optimise for, as a space or `;` separated list. Defaults to `""` |
-| `BUILD_SWIG_PYTHON`      | `ON`/`OFF`        | Enable Python target `pyflamegpu` via Swig. Default `OFF`. Python packages `setuptools` & `wheel` required |
+| `BUILD_SWIG_PYTHON`      | `ON`/`OFF`        | Enable Python target `pyflamegpu` via Swig. Default `OFF`. Python packages `setuptools`, `build` & `wheel` required |
 | `BUILD_SWIG_PYTHON_VENV` | `ON`/`OFF`        | Use a python `venv` when building the python Swig target. Default `ON`. Python package `venv` required     |
 | `BUILD_TESTS`            | `ON`/`OFF`        | Build the C++/CUDA test suite. Default `OFF`.                                                              |
 | `BUILD_TESTS_DEV`        | `ON`/`OFF`        | Build the reduced-scope development test suite. Default `OFF`                                              |

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -240,6 +240,7 @@ endfunction()
 # Look for required python modules to build the python module, error if they are not found.
 search_python_module(setuptools)
 search_python_module(wheel)
+search_python_module(build)
 
 ## ------
 # Define custom commands to produce files in the current cmake directory, a custom target which the user invokes to build the python wheel with appropraite dependencies configured, and any post-build steps required.
@@ -362,7 +363,7 @@ add_custom_target(${PYTHON_MODULE_TARGET_NAME}
   # Copy the python .pyd/.so file to the working dir
   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PYTHON_SWIG_TARGET_NAME}> ${PYTHON_MODULE_NAME}/$<TARGET_FILE_NAME:${PYTHON_SWIG_TARGET_NAME}>
   # Build the wheel in the working dir
-  COMMAND ${Python3_EXECUTABLE} setup.py bdist_wheel
+  COMMAND ${Python3_EXECUTABLE} -m build --wheel 
   WORKING_DIRECTORY ${PYTHON_LIB_OUTPUT_DIRECTORY}
   BYPRODUCTS
     ${PYTHON_LIB_OUTPUT_DIRECTORY}/${PYTHON_MODULE_NAME}

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -218,8 +218,7 @@ file(GENERATE
 	OUTPUT ${PYTHON_LIB_OUTPUT_DIRECTORY}/${PYTHON_MODULE_NAME}/__init__.py
 	INPUT ${PYTHON_LIB_TEMP_DIRECTORY}/__init__.py.in)
 
-# Function to find if python module MODULE_NAME is available, if not then install it to the Python user install directory.
-# @todo - we should not be performing user installs/ upgrades of setuptools/wheel. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/639
+# Function to find if python module MODULE_NAME is available, and error if it is not available.
 function(search_python_module MODULE_NAME)
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "import ${MODULE_NAME}; print(${MODULE_NAME}.__version__) if hasattr(${MODULE_NAME}, '__version__') else print('Unknown');"
@@ -231,16 +230,14 @@ function(search_python_module MODULE_NAME)
   if(${_RESULT} STREQUAL "0")
     message(STATUS "Found python module: ${MODULE_NAME} (version \"${MODULE_VERSION}\")")
   else()
-    message(WARNING "Can't find python module \"${MODULE_NAME}\", user install it using pip...")
-    execute_process(
-      COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade --user ${MODULE_NAME}
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
+    message(FATAL_ERROR 
+      "  Unable to find required python module \"${MODULE_NAME}\".\n"
+      "  Please install this to your python environment, e.g.\n"
+      "    python3 -m pip install ${MODULE_NAME}")
   endif()
 endfunction()
 
-# Look for required python modules to build the python module
-# @todo - Do not install into the --user see https://github.com/FLAMEGPU/FLAMEGPU2/issues/639. Either error, or let python error saying wheel is missing instead (or create and use a venv).
+# Look for required python modules to build the python module, error if they are not found.
 search_python_module(setuptools)
 search_python_module(wheel)
 
@@ -383,8 +380,8 @@ add_dependencies(${PYTHON_MODULE_TARGET_NAME} ${PYTHON_SWIG_TARGET_NAME})
 
 # Build Virtual Environment for python testing and install the packaged wheel
 if(BUILD_SWIG_PYTHON_VENV)
-	# Look for python module venv
-	search_python_module(venv) # @todo - do not install if missing, configuration error instead?
+	# Look for python module venv, error if not found
+	search_python_module(venv)
 	# Testing using a virtual environment
 	set(VENV_EXECUTABLE ${Python3_EXECUTABLE} -m venv)
 	set(VENV_DIR ${PYTHON_LIB_OUTPUT_DIRECTORY}/venv)


### PR DESCRIPTION
Emit a CMake Fatal Error during configuraition for missing required python packages, rather than installing them into the users environment.

Wheel, setuptools and optionall venv are requred.

Installing into --user automatically would fail in some cases, and installing not into user into a not-generated venv is bad form.

Closes #639

Also switches from the deprectaed `setup.py install` to use `build --wheel`. 
Closes #947.