### PR TITLE
Add Python 3.11 to CI including wheel generation

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -293,6 +293,7 @@ jobs:
             hostcxx: devtoolset-8
             os: ubuntu-20.04
         python: 
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
@@ -448,6 +449,7 @@ jobs:
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -38,7 +38,7 @@ jobs:
             hostcxx: devtoolset-9
             os: ubuntu-20.04
         python: 
-          - "3.10"
+          - "3.11"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
             hostcxx: gcc-8
             os: ubuntu-20.04
         python: 
-          - "3.8"
+          - "3.11"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -38,7 +38,7 @@ jobs:
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
-          - "3.10"
+          - "3.11"
         config:
           - name: "Release"
             config: "Release"


### PR DESCRIPTION
Python 3.11 is now fully released, so adds to Manylinux + Windows CI, and the wheel generation matrix in the draft-release CI. 

Closes #886