### PR TITLE
Removal of Pointless References in Function Args

### DIFF
--- a/examples/host_functions/src/main.cu
+++ b/examples/host_functions/src/main.cu
@@ -3,11 +3,11 @@
 const unsigned int AGENT_COUNT = 1024;
 
 FLAMEGPU_AGENT_FUNCTION(device_function, flamegpu::MessageNone, flamegpu::MessageNone) {
-    const float &prop_float = FLAMEGPU->environment.getProperty<float>("float");
-    const int16_t &prop_int16 = FLAMEGPU->environment.getProperty<int16_t>("int16_t");
-    const uint64_t &prop_uint64_0 = FLAMEGPU->environment.getProperty<uint64_t, 3>("uint64_t", 0);
-    const uint64_t &prop_uint64_1 = FLAMEGPU->environment.getProperty<uint64_t, 3>("uint64_t", 1);
-    const uint64_t &prop_uint64_2 = FLAMEGPU->environment.getProperty<uint64_t, 3>("uint64_t", 2);
+    const float prop_float = FLAMEGPU->environment.getProperty<float>("float");
+    const int16_t prop_int16 = FLAMEGPU->environment.getProperty<int16_t>("int16_t");
+    const uint64_t prop_uint64_0 = FLAMEGPU->environment.getProperty<uint64_t, 3>("uint64_t", 0);
+    const uint64_t prop_uint64_1 = FLAMEGPU->environment.getProperty<uint64_t, 3>("uint64_t", 1);
+    const uint64_t prop_uint64_2 = FLAMEGPU->environment.getProperty<uint64_t, 3>("uint64_t", 2);
     if (blockIdx.x * blockDim.x + threadIdx.x == 0) {
         printf("Agent Function[Thread 0]! Properties(Float: %g, int16: %hd, uint64[3]: {%llu, %llu, %llu})\n", prop_float, prop_int16, prop_uint64_0, prop_uint64_1, prop_uint64_2);
     }

--- a/include/flamegpu/exception/FLAMEGPUDeviceException.cuh
+++ b/include/flamegpu/exception/FLAMEGPUDeviceException.cuh
@@ -23,8 +23,8 @@ class DeviceExceptionManager {
      * Free all device memory
      */
     ~DeviceExceptionManager();
-    DeviceExceptionBuffer *getDevicePtr(unsigned int streamId, const cudaStream_t &stream);
-    void checkError(const std::string &function, unsigned int streamId, const cudaStream_t &stream);
+    DeviceExceptionBuffer *getDevicePtr(unsigned int streamId, cudaStream_t stream);
+    void checkError(const std::string &function, unsigned int streamId, cudaStream_t stream);
 
  private:
     /**

--- a/include/flamegpu/exception/FLAMEGPUDeviceException.cuh
+++ b/include/flamegpu/exception/FLAMEGPUDeviceException.cuh
@@ -23,8 +23,8 @@ class DeviceExceptionManager {
      * Free all device memory
      */
     ~DeviceExceptionManager();
-    DeviceExceptionBuffer *getDevicePtr(const unsigned int &streamId, const cudaStream_t &stream);
-    void checkError(const std::string &function, const unsigned int &streamId, const cudaStream_t &stream);
+    DeviceExceptionBuffer *getDevicePtr(unsigned int streamId, const cudaStream_t &stream);
+    void checkError(const std::string &function, unsigned int streamId, const cudaStream_t &stream);
 
  private:
     /**

--- a/include/flamegpu/exception/FLAMEGPUDeviceException_device.cuh
+++ b/include/flamegpu/exception/FLAMEGPUDeviceException_device.cuh
@@ -112,7 +112,7 @@ class DeviceException {
      * This is required to process var args, it performs recursion to scrape of each arg
      */
     template<typename T, typename... Args>
-    __device__ void subformat_recurse(DeviceExceptionBuffer *buff, const T &t, Args... args) {
+    __device__ void subformat_recurse(DeviceExceptionBuffer *buff, const T t, Args... args) {
         // Call subformat with T
         subformat(buff, t);
         // Recurse with the rest of the list

--- a/include/flamegpu/exception/FLAMEGPUException.h
+++ b/include/flamegpu/exception/FLAMEGPUException.h
@@ -38,7 +38,7 @@ class FLAMEGPUException : public std::exception {
     /**
      * Sets internal members file and line, which are used by constructor
      */
-     static void setLocation(const char *_file, const unsigned int &_line);
+     static void setLocation(const char *_file, unsigned int _line);
 
  protected:
     /**

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -81,7 +81,7 @@ class CUDAAgent : public AgentInterface {
      * @param stream CUDA stream to be used for async CUDA operations
      * @note Scatter is required for initialising submodel vars
      */
-    void setPopulationData(const AgentVector& population, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t& stream);
+    void setPopulationData(const AgentVector& population, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Copies population data the device buffers held by this object
      * To the hosts object (overwriting any existing agent data)
@@ -118,7 +118,7 @@ class CUDAAgent : public AgentInterface {
      * @param stream CUDA stream to be used for async CUDA operations
      * @see CUDAFatAgent::processDeath(unsigned int, const std::string &, unsigned int)
      */
-    void processDeath(const AgentFunctionData& func, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void processDeath(const AgentFunctionData& func, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param _src The source state
@@ -128,7 +128,7 @@ class CUDAAgent : public AgentInterface {
      * @param stream CUDA stream to be used for async CUDA operations
      * @see CUDAFatAgent::transitionState(unsigned int, const std::string &, const std::string &, unsigned int)
      */
-    void transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Scatters agents based on their output of the agent function condition
      * Agents which failed the condition are scattered to the front and marked as disabled
@@ -141,7 +141,7 @@ class CUDAAgent : public AgentInterface {
      * @note Named state must not already contain disabled agents
      * @note The disabled agents are re-enabled using clearFunctionCondition(const std::string &)
      */
-    void processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Scatters agents from the provided device buffer, this is used for host agent creation
      * The device buffer must be packed according to the param offsets
@@ -153,7 +153,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void scatterHostCreation(const std::string &state_name, unsigned int newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void scatterHostCreation(const std::string &state_name, unsigned int newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param state_name The state agents are scattered into
@@ -190,7 +190,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void scatterNew(const AgentFunctionData& func, unsigned int newSize, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void scatterNew(const AgentFunctionData& func, unsigned int newSize, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Reenables all disabled agents within the named state
      * @param state The named state to enable all agents within
@@ -240,7 +240,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initUnmappedVars(CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
+    void initUnmappedVars(CUDAScatter& scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Initialises any agent variables within the CUDAFatAgentStateList of state which are not present in the agent-state's CUDAAgentStateList
      * @param state Affected state
@@ -250,7 +250,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initExcludedVars(const std::string& state, unsigned int count, unsigned int offset, CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
+    void initExcludedVars(const std::string& state, unsigned int count, unsigned int offset, CUDAScatter& scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Resets the number of agents in every statelist to 0
      */

--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -69,7 +69,7 @@ class CUDAAgent : public AgentInterface {
      * @note TODO: This could be improved by iterating the variable list within the state_list, rather than individually looking up vars (the two lists should have all the same vars)
      * @note This should probably be addressed when curve is updated to not use individual memcpys
      */
-    void mapRuntimeVariables(const AgentFunctionData& func, const unsigned int &instance_id) const;
+    void mapRuntimeVariables(const AgentFunctionData& func, unsigned int instance_id) const;
     /**
      * Copies population data from the provided host object
      * To the device buffers held by this object (overwriting any existing agent data)
@@ -81,7 +81,7 @@ class CUDAAgent : public AgentInterface {
      * @param stream CUDA stream to be used for async CUDA operations
      * @note Scatter is required for initialising submodel vars
      */
-    void setPopulationData(const AgentVector& population, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t& stream);
+    void setPopulationData(const AgentVector& population, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t& stream);
     /**
      * Copies population data the device buffers held by this object
      * To the hosts object (overwriting any existing agent data)
@@ -116,9 +116,9 @@ class CUDAAgent : public AgentInterface {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
-     * @see CUDAFatAgent::processDeath(const unsigned int &, const std::string &, const unsigned int &)
+     * @see CUDAFatAgent::processDeath(unsigned int, const std::string &, unsigned int)
      */
-    void processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void processDeath(const AgentFunctionData& func, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param _src The source state
@@ -126,9 +126,9 @@ class CUDAAgent : public AgentInterface {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
-     * @see CUDAFatAgent::transitionState(const unsigned int &, const std::string &, const std::string &, const unsigned int &)
+     * @see CUDAFatAgent::transitionState(unsigned int, const std::string &, const std::string &, unsigned int)
      */
-    void transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Scatters agents based on their output of the agent function condition
      * Agents which failed the condition are scattered to the front and marked as disabled
@@ -137,11 +137,11 @@ class CUDAAgent : public AgentInterface {
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
-     * @see CUDAFatAgent::processFunctionCondition(const unsigned int &, const unsigned int &)
+     * @see CUDAFatAgent::processFunctionCondition(unsigned int, unsigned int)
      * @note Named state must not already contain disabled agents
      * @note The disabled agents are re-enabled using clearFunctionCondition(const std::string &)
      */
-    void processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Scatters agents from the provided device buffer, this is used for host agent creation
      * The device buffer must be packed according to the param offsets
@@ -153,7 +153,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void scatterHostCreation(const std::string &state_name, const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void scatterHostCreation(const std::string &state_name, unsigned int newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param state_name The state agents are scattered into
@@ -183,14 +183,14 @@ class CUDAAgent : public AgentInterface {
     void releaseNewBuffer(const AgentFunctionData& func);
     /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
-     * The device buffer must be packed in the same format as mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)
+     * The device buffer must be packed in the same format as mapNewRuntimeVariables(const AgentFunctionData&, unsigned int, unsigned int)
      * @param func The agent function being processed
      * @param newSize The maximum number of new agents (this will be the size of the agent state executing func)
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void scatterNew(const AgentFunctionData& func, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void scatterNew(const AgentFunctionData& func, unsigned int newSize, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Reenables all disabled agents within the named state
      * @param state The named state to enable all agents within
@@ -240,7 +240,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initUnmappedVars(CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream);
+    void initUnmappedVars(CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
     /**
      * Initialises any agent variables within the CUDAFatAgentStateList of state which are not present in the agent-state's CUDAAgentStateList
      * @param state Affected state
@@ -250,7 +250,7 @@ class CUDAAgent : public AgentInterface {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initExcludedVars(const std::string& state, const unsigned int& count, const unsigned int& offset, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream);
+    void initExcludedVars(const std::string& state, unsigned int count, unsigned int offset, CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
     /**
      * Resets the number of agents in every statelist to 0
      */
@@ -275,7 +275,7 @@ class CUDAAgent : public AgentInterface {
      * @param newSize Number of active agents
      * @throw exception::InvalidMemoryCapacity If the new number of disabled + active agents would exceed currently allocated buffer capacity
      */
-    void setStateAgentCount(const std::string& state, const unsigned int &newSize);
+    void setStateAgentCount(const std::string& state, unsigned int newSize);
     /**
      * Returns a list of variable buffers attached to bound agents, not available in this agent
      * @param state The state affected state

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -31,7 +31,7 @@ class CUDAAgentStateList {
     CUDAAgentStateList(
         const std::shared_ptr<CUDAFatAgentStateList> &fat_list,
         CUDAAgent& cuda_agent,
-        const unsigned int &_fat_index,
+        unsigned int _fat_index,
         const AgentData& description,
         bool _isSubStateList = false);
     /**
@@ -46,7 +46,7 @@ class CUDAAgentStateList {
     CUDAAgentStateList(
         const std::shared_ptr<CUDAFatAgentStateList> &fat_list,
         CUDAAgent& cuda_agent,
-        const unsigned int &_fat_index,
+        unsigned int _fat_index,
         const AgentData& description,
         bool _isSubStateList,
         const SubAgentData::Mapping &mapping);
@@ -56,7 +56,7 @@ class CUDAAgentStateList {
      * @param minimumSize The minimum number of agents that must be representable
      * @param retainData If true existing buffer data is retained
      * @param stream The stream used to perform memcpys if data is retained
-     * @see CUDAFatAgentStateList::resize(const unsigned int &, const bool &)
+     * @see CUDAFatAgentStateList::resize(unsigned int, bool)
      */
     void resize(unsigned int minimumSize, bool retainData, cudaStream_t stream);
     /**
@@ -105,7 +105,7 @@ class CUDAAgentStateList {
     void scatterSort_async(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Scatters agents from the currently assigned device agent birth buffer (see member variable newBuffs)
-     * The device buffer must be packed in the same format as CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData&, const unsigned int &, const unsigned int &)
+     * The device buffer must be packed in the same format as CUDAAgent::mapNewRuntimeVariables(const AgentFunctionData&, unsigned int, unsigned int)
      * @param d_newBuff The buffer holding the new agent data
      * @param newSize The maximum number of new agents (this will be the size of the agent state executing func)
      * @param scatter Scatter instance and scan arrays to be used
@@ -124,7 +124,7 @@ class CUDAAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void initUnmappedVars(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Initialises any agent variables within the CUDAFatAgentStateList which are not present in this CUDAAgentStateList
      * @param count Number of variables to init
@@ -133,7 +133,7 @@ class CUDAAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initExcludedVars(const unsigned int& count, const unsigned int& offset, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream);
+    void initExcludedVars(unsigned int count, unsigned int offset, CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
     /**
      * Returns the statelist to an empty state
      * This resets the size to 0.
@@ -144,7 +144,7 @@ class CUDAAgentStateList {
      * @param newSize Number of active agents
      * @throw exception::InvalidMemoryCapacity If the new number of disabled + active agents would exceed currently allocated buffer capacity
      */
-    void setAgentCount(const unsigned int& newSize);
+    void setAgentCount(unsigned int newSize);
     /**
      * Returns a list of variable buffers attached to bound agents, not available in this agent
      * @note This access is only intended for DeviceAgentVector's correctly handling of subagents

--- a/include/flamegpu/gpu/CUDAAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAAgentStateList.h
@@ -124,7 +124,7 @@ class CUDAAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initUnmappedVars(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void initUnmappedVars(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Initialises any agent variables within the CUDAFatAgentStateList which are not present in this CUDAAgentStateList
      * @param count Number of variables to init
@@ -133,7 +133,7 @@ class CUDAAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initExcludedVars(unsigned int count, unsigned int offset, CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
+    void initExcludedVars(unsigned int count, unsigned int offset, CUDAScatter& scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Returns the statelist to an empty state
      * This resets the size to 0.

--- a/include/flamegpu/gpu/CUDAFatAgent.h
+++ b/include/flamegpu/gpu/CUDAFatAgent.h
@@ -95,7 +95,7 @@ class CUDAFatAgent {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void processDeath(unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void processDeath(unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
@@ -115,7 +115,7 @@ class CUDAFatAgent {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void processFunctionCondition(unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void processFunctionCondition(unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Marks the specified number of agents within the specified statelist as disabled
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
@@ -131,10 +131,10 @@ class CUDAFatAgent {
      * @note It is assumed that when splitting the buffer into variables, each variable's sub-buffer will be 64 bit aligned
      * @note New buffers are shared between all states and mapped/unmapped agents
      */
-    void *allocNewBuffer(const size_t &total_agent_size, unsigned int new_agents, const size_t &varCount);
+    void *allocNewBuffer(size_t total_agent_size, unsigned int new_agents, size_t varCount);
     /**
      * Marks the named buffer as free
-     * @param buff The buffer to free, this must be a pointer returned by allocNewBuffer(const size_t &, unsigned int, const size_t &)
+     * @param buff The buffer to free, this must be a pointer returned by allocNewBuffer(size_t, unsigned int, size_t)
      */
     void freeNewBuffer(void *buff);
     /**

--- a/include/flamegpu/gpu/CUDAFatAgent.h
+++ b/include/flamegpu/gpu/CUDAFatAgent.h
@@ -33,7 +33,7 @@ class CUDAFatAgent {
         /**
          * Index assigned to the agent when it is added to the CUDAFatAgent
          * @note An index is used as two mapped agents from different models may share the same name
-         * @see CUDAFatAgent::addSubAgent(const AgentData &, const unsigned int &, const std::shared_ptr<SubAgentData> &)
+         * @see CUDAFatAgent::addSubAgent(const AgentData &, unsigned int, const std::shared_ptr<SubAgentData> &)
          */
         const unsigned int agent;
         /**
@@ -78,14 +78,14 @@ class CUDAFatAgent {
      */
     void addSubAgent(
       const AgentData &description,
-      const unsigned int &master_fat_index,
+      unsigned int master_fat_index,
       const std::shared_ptr<SubAgentData> &mapping);
     /**
      * This function builds and returns the state_map required by the named CUDAAgent
      * @param fat_index The index of the CUDAAgent within this CUDAFatAgent
      * @return a statemap suitable for the named agent
      */
-    std::unordered_map<std::string, std::shared_ptr<CUDAFatAgentStateList>> getStateMap(const unsigned int &fat_index);
+    std::unordered_map<std::string, std::shared_ptr<CUDAFatAgentStateList>> getStateMap(unsigned int fat_index);
     /**
      * Scatters all active agents within the named state to remove agents with death flag set
      * This updates the alive agent count
@@ -95,7 +95,7 @@ class CUDAFatAgent {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void processDeath(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void processDeath(unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Transitions all active agents from the source state to the destination state
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
@@ -115,14 +115,14 @@ class CUDAFatAgent {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void processFunctionCondition(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void processFunctionCondition(unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Marks the specified number of agents within the specified statelist as disabled
      * @param agent_fat_id The index of the CUDAAgent within this CUDAFatAgent
      * @param state_name The name of the state attached to the named fat agent index
      * @param numberOfDisabled The number of agents to be marked as disabled
      */
-    void setConditionState(const unsigned int &agent_fat_id, const std::string &state_name, const unsigned int numberOfDisabled);
+    void setConditionState(unsigned int agent_fat_id, const std::string &state_name, unsigned int numberOfDisabled);
     /**
      * Returns a device pointer of atleast type_size x new_agents bytes available
      * @param total_agent_size Total number of bytes required to fit all variables in the agent
@@ -131,10 +131,10 @@ class CUDAFatAgent {
      * @note It is assumed that when splitting the buffer into variables, each variable's sub-buffer will be 64 bit aligned
      * @note New buffers are shared between all states and mapped/unmapped agents
      */
-    void *allocNewBuffer(const size_t &total_agent_size, const unsigned int &new_agents, const size_t &varCount);
+    void *allocNewBuffer(const size_t &total_agent_size, unsigned int new_agents, const size_t &varCount);
     /**
      * Marks the named buffer as free
-     * @param buff The buffer to free, this must be a pointer returned by allocNewBuffer(const size_t &, const unsigned int &, const size_t &)
+     * @param buff The buffer to free, this must be a pointer returned by allocNewBuffer(const size_t &, unsigned int, const size_t &)
      */
     void freeNewBuffer(void *buff);
     /**

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -160,15 +160,15 @@ class CUDAFatAgentStateList {
      */
     void addSubAgentVariables(
       const AgentData &description,
-      const unsigned int &master_fat_index,
-      const unsigned int &sub_fat_index,
+      unsigned int master_fat_index,
+      unsigned int sub_fat_index,
       const std::shared_ptr<SubAgentData> &mapping);
     /**
      * Returns the VariableBuffer for the corresponding agent variable
      * @param fat_index Fat index of the corresponding agent
      * @param name Name of the variable within the corresponding agent
      */
-    std::shared_ptr<VariableBuffer> getVariableBuffer(const unsigned int &fat_index, const std::string &name);
+    std::shared_ptr<VariableBuffer> getVariableBuffer(unsigned int fat_index, const std::string &name);
     /**
      * Resize all variable buffers
      * @param minSize The minimum number of agents that must be representable
@@ -193,7 +193,7 @@ class CUDAFatAgentStateList {
      * @param newCount New number of alive (and active agents)
      * @param resetDisabled If true, the disableAgents count will be set to 0, else it will be added to newCount for the internal true alive count
      */
-    void setAgentCount(const unsigned int &newCount, const bool &resetDisabled = false);
+    void setAgentCount(unsigned int newCount, bool resetDisabled = false);
     /**
      * Scatters all living agents (including disabled, according to the provided stream's death flag)
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
@@ -201,7 +201,7 @@ class CUDAFatAgentStateList {
      * @param stream CUDA stream to be used for async CUDA operations
      * @return The number of agents that are still alive (this includes temporarily disabled agents due to agent function condition)
      */
-    unsigned int scatterDeath(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    unsigned int scatterDeath(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Scatters all living agents which failed the agent function condition into the swap buffer (there should be no disabled at this time)
      * This does not swap buffers or update disabledAgent)
@@ -209,9 +209,9 @@ class CUDAFatAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      * @return The number of agents that were scattered (the number of agents which failed the condition)
-     * @see scatterAgentFunctionConditionTrue(const unsigned int &, const unsigned int &)
+     * @see scatterAgentFunctionConditionTrue(unsigned int, unsigned int)
      */
-    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Scatters all living agents which passed the agent function condition into the swap buffer (there should be no disabled at this time)
      * Also swaps the buffers and sets the number of disabled agents
@@ -220,10 +220,10 @@ class CUDAFatAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      * @return The number of agents that were scattered (the number of agents which passed the condition)
-     * @see scatterAgentFunctionConditionFalse(const unsigned int &)
-     * @see setConditionState(const unsigned int &)
+     * @see scatterAgentFunctionConditionFalse(unsigned int)
+     * @see setConditionState(unsigned int)
      */
-    unsigned int scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    unsigned int scatterAgentFunctionConditionTrue(unsigned int conditionFailCount, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
@@ -236,7 +236,7 @@ class CUDAFatAgentStateList {
      * Updates member var disabledAgents and data_condition for every item inside variables_unique
      * @param numberOfDisabled The new number of disabled agents (this can increase of decrease)
      */
-    void setDisabledAgents(const unsigned int &numberOfDisabled);
+    void setDisabledAgents(unsigned int numberOfDisabled);
     /**
      * Resets the value of all variables not present in exclusionSet to their defaults
      *
@@ -248,7 +248,7 @@ class CUDAFatAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     /**
      * Returns the collection of unique variable buffers held by this CUDAFatAgentStateList
      */

--- a/include/flamegpu/gpu/CUDAFatAgentStateList.h
+++ b/include/flamegpu/gpu/CUDAFatAgentStateList.h
@@ -75,7 +75,7 @@ struct VariableBuffer {
      * @note The memory pointed to by this pointer is allocated and free'd by the instance
      */
     const void *const default_value;
-    VariableBuffer(const std::type_index &_type, const size_t &_type_size, const void * const _default_value, const size_t &_elements = 1, void *_data = nullptr, void *_data_swap = nullptr)
+    VariableBuffer(const std::type_index &_type, const size_t _type_size, const void * const _default_value, const size_t _elements = 1, void *_data = nullptr, void *_data_swap = nullptr)
         : data(_data)
         , data_condition(_data)
         , data_swap(_data_swap)
@@ -201,7 +201,7 @@ class CUDAFatAgentStateList {
      * @param stream CUDA stream to be used for async CUDA operations
      * @return The number of agents that are still alive (this includes temporarily disabled agents due to agent function condition)
      */
-    unsigned int scatterDeath(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    unsigned int scatterDeath(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Scatters all living agents which failed the agent function condition into the swap buffer (there should be no disabled at this time)
      * This does not swap buffers or update disabledAgent)
@@ -211,7 +211,7 @@ class CUDAFatAgentStateList {
      * @return The number of agents that were scattered (the number of agents which failed the condition)
      * @see scatterAgentFunctionConditionTrue(unsigned int, unsigned int)
      */
-    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    unsigned int scatterAgentFunctionConditionFalse(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Scatters all living agents which passed the agent function condition into the swap buffer (there should be no disabled at this time)
      * Also swaps the buffers and sets the number of disabled agents
@@ -223,7 +223,7 @@ class CUDAFatAgentStateList {
      * @see scatterAgentFunctionConditionFalse(unsigned int)
      * @see setConditionState(unsigned int)
      */
-    unsigned int scatterAgentFunctionConditionTrue(unsigned int conditionFailCount, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    unsigned int scatterAgentFunctionConditionTrue(unsigned int conditionFailCount, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Sorts all agent variables according to the positions stored inside Message Output scan buffer
      * @param scatter Scatter instance and scan arrays to be used (CUDASimulation::singletons->scatter)
@@ -248,7 +248,7 @@ class CUDAFatAgentStateList {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Returns the collection of unique variable buffers held by this CUDAFatAgentStateList
      */

--- a/include/flamegpu/gpu/CUDAMacroEnvironment.h
+++ b/include/flamegpu/gpu/CUDAMacroEnvironment.h
@@ -42,7 +42,7 @@ class CUDAMacroEnvironment {
          * @param _type_size The size of the base type (e.g. sizeof(float))
          * @param _elements Number of elements in each dimension
          */
-        MacroEnvProp(const std::type_index& _type, const size_t &_type_size, const std::array<unsigned int, 4> &_elements)
+        MacroEnvProp(const std::type_index& _type, const size_t _type_size, const std::array<unsigned int, 4> &_elements)
             : type(_type)
             , type_size(_type_size)
             , elements(_elements)

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -122,7 +122,7 @@ class CUDAMessage {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream);
     const void *getMetaDataDevicePtr() const;
 
  protected:

--- a/include/flamegpu/gpu/CUDAMessage.h
+++ b/include/flamegpu/gpu/CUDAMessage.h
@@ -58,7 +58,7 @@ class CUDAMessage {
      * @note This should be used cautiously
      * @note Required by array message types
      */
-    void setMessageCount(const unsigned int &_message_count);
+    void setMessageCount(unsigned int _message_count);
     /**
      * Initialise the CUDAMessagelist
      * This allocates and initialises any CUDA data structures for reading the messagelist, and sets them asthough the messagelist were empty.
@@ -92,7 +92,7 @@ class CUDAMessage {
      * @param stream The CUDAStream to use for CUDA operations
      * @note swap() or scatter() should be called after the agent function has written messages
      */
-    void mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &writeLen, cudaStream_t stream) const;
+    void mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, unsigned int writeLen, cudaStream_t stream) const;
     void *getReadPtr(const std::string &var_name);
     const CUDAMessageMap &getReadList() { return message_list->getReadList(); }
     const CUDAMessageMap &getWriteList() { return message_list->getWriteList(); }
@@ -122,7 +122,7 @@ class CUDAMessage {
      * @param streamId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
      * @param stream CUDA stream to be used for async CUDA operations
      */
-    void buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream);
+    void buildIndex(CUDAScatter &scatter, unsigned int streamId, const cudaStream_t &stream);
     const void *getMetaDataDevicePtr() const;
 
  protected:

--- a/include/flamegpu/gpu/CUDAScanCompaction.h
+++ b/include/flamegpu/gpu/CUDAScanCompaction.h
@@ -56,7 +56,7 @@ struct CUDAScanCompactionConfig {
      * Resize the two scan buffers inside d_ptrs
      * @param count The number of items required to fit in the resized buffers
      */
-    void resize_scan_flag(const unsigned int& count);
+    void resize_scan_flag(unsigned int count);
     /**
      * Reset all data inside the two scan buffers to 0
      * @param stream The CUDA stream used to execute the memset
@@ -104,7 +104,7 @@ class CUDAScanCompaction {
      * @param type The type of the scan flag buffer to be resized
      * @param streamId The stream index of the scan flag buffer to be resized
      */
-    void resize(const unsigned int& newCount, const Type& type, const unsigned int& streamId);
+    void resize(unsigned int newCount, const Type& type, unsigned int streamId);
     /**
      * Reset all scan flags in the buffer for the specified stream and type to zero
      * @param type The type of the scan flag buffer to be zerod
@@ -119,14 +119,14 @@ class CUDAScanCompaction {
      * @param streamId The stream index of the scan flag buffer to return
      * @see Config() for the non-const variant.
      */
-    const CUDAScanCompactionConfig &getConfig(const Type& type, const unsigned int& streamId);
+    const CUDAScanCompactionConfig &getConfig(const Type& type, unsigned int streamId);
     /**
      * Returns a reference to the scan flag config structure for the specified stream and type
      * @param type The type of the scan flag buffer to return
      * @param streamId The stream index of the scan flag buffer to return
      * @see getConfig() for the const variant.
      */
-    CUDAScanCompactionConfig &Config(const Type& type, const unsigned int& streamId);
+    CUDAScanCompactionConfig &Config(const Type& type, unsigned int streamId);
 
  private:
     /**

--- a/include/flamegpu/gpu/CUDAScatter.cuh
+++ b/include/flamegpu/gpu/CUDAScatter.cuh
@@ -129,7 +129,7 @@ class CUDAScatter {
         const std::vector<ScatterData> &scatterData,
         unsigned int itemCount,
         unsigned int out_index_offset = 0,
-        const bool invert_scan_flag = false,
+        bool invert_scan_flag = false,
         unsigned int scatter_all_count = 0);
     /**
      * Scatters agents from SoA to SoA according to d_position flag as input_source, all variables are scattered

--- a/include/flamegpu/gpu/CUDAScatter.cuh
+++ b/include/flamegpu/gpu/CUDAScatter.cuh
@@ -106,7 +106,7 @@ class CUDAScatter {
         const std::map<std::string, void*> &out,
         unsigned int itemCount,
         unsigned int out_index_offset = 0,
-        const bool invert_scan_flag = false,
+        bool invert_scan_flag = false,
         unsigned int scatter_all_count = 0);
     /**
      * Scatters agents from SoA to SoA according to d_position flag

--- a/include/flamegpu/gpu/CUDAScatter.cuh
+++ b/include/flamegpu/gpu/CUDAScatter.cuh
@@ -99,7 +99,7 @@ class CUDAScatter {
      */
      unsigned int scatter(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const Type &messageOrAgent,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
@@ -124,7 +124,7 @@ class CUDAScatter {
      */
     unsigned int scatter(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const Type &messageOrAgent,
         const std::vector<ScatterData> &scatterData,
         unsigned int itemCount,
@@ -164,7 +164,7 @@ class CUDAScatter {
      */
     unsigned int scatterCount(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const Type &messageOrAgent,
         unsigned int itemCount,
         unsigned int scatter_all_count = 0);
@@ -180,7 +180,7 @@ class CUDAScatter {
      */
     unsigned int scatterAll(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const std::vector<ScatterData> &scatterData,
         unsigned int itemCount,
         unsigned int out_index_offset = 0);
@@ -196,7 +196,7 @@ class CUDAScatter {
      */
     unsigned int scatterAll(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,
@@ -218,7 +218,7 @@ class CUDAScatter {
      */
     void pbm_reorder(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,
@@ -238,9 +238,9 @@ class CUDAScatter {
      */
     void scatterNewAgents(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const std::vector<ScatterData> &scatterData,
-        const size_t &totalAgentSize,
+        size_t totalAgentSize,
         unsigned int inCount,
         unsigned int out_index_offset);
     /**
@@ -292,7 +292,7 @@ class CUDAScatter {
      */
     void arrayMessageReorder(
         unsigned int streamResourceId,
-        const cudaStream_t &stream,
+        cudaStream_t stream,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,

--- a/include/flamegpu/gpu/CUDAScatter.cuh
+++ b/include/flamegpu/gpu/CUDAScatter.cuh
@@ -41,7 +41,7 @@ class CUDAScatter {
          __device__ InversionIterator operator++ (int a) { p += a;  return *this; }
          __device__ InversionIterator operator++ () { p++;  return *this; }
          __device__ unsigned int operator *() { return invert(*p); }
-         __device__ InversionIterator operator+(const int &b) const { return InversionIterator(p + b); }
+         __device__ InversionIterator operator+(const int b) const { return InversionIterator(p + b); }
          __device__ unsigned int operator[](int b) const { return  invert(p[b]); }
       private:
          __device__ unsigned int invert(unsigned int c) const { return c == 0 ? 1 : 0; }
@@ -71,7 +71,7 @@ class CUDAScatter {
         unsigned int data_len;
         StreamData();
         ~StreamData();
-        void resize(const unsigned int &newLen);
+        void resize(unsigned int newLen);
     };
     std::array<StreamData, CUDAScanCompaction::MAX_STREAMS> streamResources;
     std::array<detail::CubTemporaryMemory, CUDAScanCompaction::MAX_STREAMS> cubTemps;
@@ -98,16 +98,16 @@ class CUDAScatter {
      * @note This is deprecated, unclear if still used
      */
      unsigned int scatter(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const Type &messageOrAgent,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,
-        const unsigned int &itemCount,
-        const unsigned int &out_index_offset = 0,
-        const bool &invert_scan_flag = false,
-        const unsigned int &scatter_all_count = 0);
+        unsigned int itemCount,
+        unsigned int out_index_offset = 0,
+        const bool invert_scan_flag = false,
+        unsigned int scatter_all_count = 0);
     /**
      * Scatters agents from SoA to SoA according to d_position flag
      * Used for device agent creation and agent death
@@ -123,14 +123,14 @@ class CUDAScatter {
      * @param scatter_all_count The number of agents at the start of in to be copied, ones after this use scanflag
      */
     unsigned int scatter(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const Type &messageOrAgent,
         const std::vector<ScatterData> &scatterData,
-        const unsigned int &itemCount,
-        const unsigned int &out_index_offset = 0,
-        const bool &invert_scan_flag = false,
-        const unsigned int &scatter_all_count = 0);
+        unsigned int itemCount,
+        unsigned int out_index_offset = 0,
+        const bool invert_scan_flag = false,
+        unsigned int scatter_all_count = 0);
     /**
      * Scatters agents from SoA to SoA according to d_position flag as input_source, all variables are scattered
      * Used for Host function sort agent
@@ -163,11 +163,11 @@ class CUDAScatter {
      * @param scatter_all_count The number offset into the array where the scan began
      */
     unsigned int scatterCount(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const Type &messageOrAgent,
-        const unsigned int &itemCount,
-        const unsigned int &scatter_all_count = 0);
+        unsigned int itemCount,
+        unsigned int scatter_all_count = 0);
     /**
      * Scatters a contigous block from SoA to SoA
      * CUDAScanCompaction::scan_flag/position are not used
@@ -179,11 +179,11 @@ class CUDAScatter {
      * @note If calling scatter() with itemCount == scatter_all_count works the same
      */
     unsigned int scatterAll(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const std::vector<ScatterData> &scatterData,
-        const unsigned int &itemCount,
-        const unsigned int &out_index_offset = 0);
+        unsigned int itemCount,
+        unsigned int out_index_offset = 0);
     /**
      * Convenience wrapper to scatterAll()
      * @param streamResourceId The stream index to use for accessing stream specific resources such as scan compaction arrays and buffers
@@ -195,13 +195,13 @@ class CUDAScatter {
      * @param out_index_offset The offset to be applied to the output index (e.g. if out already contains data)
      */
     unsigned int scatterAll(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,
-        const unsigned int &itemCount,
-        const unsigned int &out_index_offset);
+        unsigned int itemCount,
+        unsigned int out_index_offset);
     /**
      * Used for reordering messages from SoA to SoA
      * Position information is taken using PBM data, rather than d_position
@@ -217,12 +217,12 @@ class CUDAScatter {
      * @param d_pbm This is the PBM, it identifies at which index a bin's storage begins
      */
     void pbm_reorder(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,
-        const unsigned int &itemCount,
+        unsigned int itemCount,
         const unsigned int *d_bin_index,
         const unsigned int *d_bin_sub_index,
         const unsigned int *d_pbm);
@@ -237,12 +237,12 @@ class CUDAScatter {
      * @param out_index_offset The offset to be applied to the ouput index (e.g. if out already contains data)
      */
     void scatterNewAgents(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const std::vector<ScatterData> &scatterData,
         const size_t &totalAgentSize,
-        const unsigned int &inCount,
-        const unsigned int &out_index_offset);
+        unsigned int inCount,
+        unsigned int out_index_offset);
     /**
      * Broadcasts a single value for each variable to a contiguous block in SoA
      * Used prior to device agent creation
@@ -291,13 +291,13 @@ class CUDAScatter {
      * @param d_write_flag Device pointer to array for tracking how many messages output to each bin, caller responsibiltiy to ensure it is array_length or longer
      */
     void arrayMessageReorder(
-        const unsigned int &streamResourceId,
+        unsigned int streamResourceId,
         const cudaStream_t &stream,
         const VariableMap &vars,
         const std::map<std::string, void*> &in,
         const std::map<std::string, void*> &out,
-        const unsigned int &itemCount,
-        const unsigned int &array_length,
+        unsigned int itemCount,
+        unsigned int array_length,
         unsigned int *d_write_flag = nullptr);
 
  private:

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -571,7 +571,7 @@ class CUDASimulation : public Simulation {
      * @param streamId Stream index to perform scatter on
      * @note called at the end of step() and after all init/hostLayer functions and exit conditions have finished
      */
-    void processHostAgentCreation(const unsigned int &streamId);
+    void processHostAgentCreation(unsigned int streamId);
 
  public:
     typedef std::vector<NewAgentStorage> AgentDataBuffer;

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -174,7 +174,7 @@ class CUDASimulation : public Simulation {
      * @throws exception::ReadOnlyEnvProperty If the named environment property is marked as read-only
      */
     template<typename T>
-    void setEnvironmentProperty(const std::string &property_name, const T& value);
+    void setEnvironmentProperty(const std::string &property_name, T value);
     /**
      * Update the current value of the named environment property array
      * @param property_name Name of the environment property to be updated
@@ -196,7 +196,7 @@ class CUDASimulation : public Simulation {
      * @throws exception::ReadOnlyEnvProperty If the named environment property is marked as read-only
      */
     template<typename T, EnvironmentManager::size_type N = 0>
-    void setEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type &index, const T& value);
+    void setEnvironmentProperty(const std::string& property_name, EnvironmentManager::size_type index, T value);
 #ifdef SWIG
     /**
      * Update the current value of the named environment property array
@@ -235,7 +235,7 @@ class CUDASimulation : public Simulation {
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      */
     template<typename T, EnvironmentManager::size_type N = 0>
-    T getEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type& index);
+    T getEnvironmentProperty(const std::string& property_name, EnvironmentManager::size_type index);
 #ifdef SWIG
     /**
      * Return the current value of the named environment property array
@@ -372,7 +372,7 @@ class CUDASimulation : public Simulation {
      * Reinitalises random generation for this model and all submodels
      * @param seed New random seed (this updates stored seed in config)
      */
-    void reseed(const uint64_t &seed);
+    void reseed(uint64_t seed);
     /**
      * Number of times step() has been called since sim was last reset/init
      */
@@ -435,7 +435,7 @@ class CUDASimulation : public Simulation {
      * If true, add the current simulation state to the step log
      * @param step_time_seconds Duration of the step to be logged in seconds
      */
-    void processStepLog(const double &step_time_seconds);
+    void processStepLog(const double step_time_seconds);
     /**
      * Replace the current exit log with the current simulation state
      */
@@ -629,7 +629,7 @@ class CUDASimulation : public Simulation {
 };
 
 template<typename T>
-void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const T& value) {
+void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const T value) {
     if (!property_name.empty() && property_name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in CUDASimulation::setEnvironmentProperty().");
@@ -649,7 +649,7 @@ void CUDASimulation::setEnvironmentProperty(const std::string& property_name, co
     singletons->environment->setProperty<T, N>(property_name, value);
 }
 template<typename T, EnvironmentManager::size_type N>
-void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type& index, const T& value) {
+void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type index, const T value) {
     if (!singletonsInitialised)
         initialiseSingletons();
     singletons->environment->setProperty<T, N>(property_name, index, value);
@@ -667,7 +667,7 @@ std::array<T, N> CUDASimulation::getEnvironmentProperty(const std::string& prope
     return singletons->environment->getProperty<T, N>(property_name);
 }
 template<typename T, EnvironmentManager::size_type N>
-T CUDASimulation::getEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type& index) {
+T CUDASimulation::getEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type index) {
     if (!singletonsInitialised)
         initialiseSingletons();
     return singletons->environment->getProperty<T, N>(property_name, index);

--- a/include/flamegpu/io/JSONLogger.h
+++ b/include/flamegpu/io/JSONLogger.h
@@ -129,7 +129,7 @@ class JSONLogger : public Logger{
      * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
      */
     template<typename T>
-    void writeAny(T &writer, const util::Any &value, const unsigned int &elements = 1) const;
+    void writeAny(T &writer, const util::Any &value, unsigned int elements = 1) const;
 
     std::string out_path;
     bool prettyPrint;

--- a/include/flamegpu/io/JSONStateWriter.h
+++ b/include/flamegpu/io/JSONStateWriter.h
@@ -30,7 +30,7 @@ class JSONStateWriter : public StateWriter {
         const std::string &model_name,
         const std::shared_ptr<EnvironmentManager>& env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
-        const unsigned int &iterations,
+        unsigned int iterations,
         const std::string &output_file,
         const Simulation *sim_instance);
     /**

--- a/include/flamegpu/io/StateWriter.h
+++ b/include/flamegpu/io/StateWriter.h
@@ -35,7 +35,7 @@ class StateWriter {
     StateWriter(const std::string &_model_name,
         const std::shared_ptr<EnvironmentManager>& _env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &_model_state,
-        const unsigned int &_iterations,
+        const unsigned int _iterations,
         const std::string &output_file,
         const Simulation *_sim_instance)
     : model_state(_model_state)

--- a/include/flamegpu/io/StateWriterFactory.h
+++ b/include/flamegpu/io/StateWriterFactory.h
@@ -41,7 +41,7 @@ class StateWriterFactory {
         const std::string& model_name,
         const std::shared_ptr<EnvironmentManager>& env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& model_state,
-        const unsigned int& iterations,
+        const unsigned int iterations,
         const std::string& output_file,
         const Simulation* sim_instance) {
         const std::string extension = std::filesystem::path(output_file).extension().string();

--- a/include/flamegpu/io/XMLLogger.h
+++ b/include/flamegpu/io/XMLLogger.h
@@ -113,7 +113,7 @@ class XMLLogger : public Logger{
      * @tparam T Instance of rapidjson::Writer or subclass (e.g. rapidjson::PrettyWriter)
      * @note Templated as can't forward declare rapidjson::Writer<rapidjson::StringBuffer>
      */
-    void writeAny(tinyxml2::XMLElement *element, const util::Any &value, const unsigned int &elements = 1) const;
+    void writeAny(tinyxml2::XMLElement *element, const util::Any &value, unsigned int elements = 1) const;
 
     std::string out_path;
     bool prettyPrint;

--- a/include/flamegpu/io/XMLStateWriter.h
+++ b/include/flamegpu/io/XMLStateWriter.h
@@ -30,7 +30,7 @@ class XMLStateWriter : public StateWriter {
         const std::string &model_name,
         const std::shared_ptr<EnvironmentManager>& env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
-        const unsigned int &iterations,
+        unsigned int iterations,
         const std::string &output_file,
         const Simulation *sim_instance);
     /**

--- a/include/flamegpu/model/AgentDescription.h
+++ b/include/flamegpu/model/AgentDescription.h
@@ -128,7 +128,7 @@ class AgentDescription {
      * @throws exception::InvalidAgentVar If a variable already exists within the agent with the same name
      */
     template<typename T>
-    void newVariable(const std::string& variable_name, const T& default_value = {});
+    void newVariable(const std::string& variable_name, T default_value = {});
 #else
     /**
      * Adds a new variable to the agent
@@ -141,7 +141,7 @@ class AgentDescription {
      * Hence, easiest to require python users to init GLM types as arrays
      */
     template<typename T>
-    void newVariable(const std::string& variable_name, const T& default_value = 0);
+    void newVariable(const std::string& variable_name, T default_value = 0);
     /**
      * Adds a new variable array to the agent
      * @param variable_name Name of the variable array
@@ -328,7 +328,7 @@ void AgentDescription::newVariable(const std::string &variable_name, const std::
         agent->name.c_str(), variable_name.c_str());
 }
 template <typename T>
-void AgentDescription::newVariable(const std::string &variable_name, const T &default_value) {
+void AgentDescription::newVariable(const std::string &variable_name, const T default_value) {
     newVariable<T, 1>(variable_name, { default_value });
 }
 #ifdef SWIG

--- a/include/flamegpu/model/AgentFunctionDescription.h
+++ b/include/flamegpu/model/AgentFunctionDescription.h
@@ -122,7 +122,7 @@ class AgentFunctionDescription : public DependencyNode {
      * @throws exception::InvalidMessageName If a message with the same name is not found within the model's hierarchy
      * @throws exception::InvalidMessageName If the same message is already bound to the message input of this agent function
      * @see AgentFunctionDescription::setMessageOutput(MessageDescription &)
-     * @see AgentFunctionDescription::setMessageOutputOptional(const bool &) To configure whether all agents must output messages
+     * @see AgentFunctionDescription::setMessageOutputOptional(bool) To configure whether all agents must output messages
      */
     void setMessageOutput(const std::string &message_name);
     /**
@@ -133,7 +133,7 @@ class AgentFunctionDescription : public DependencyNode {
      * @throws exception::InvalidMessageName If a message with the same name is not found within the model's hierarchy
      * @throws exception::InvalidMessageName If the same message is already bound to the message input of this agent function
      * @see AgentFunctionDescription::setMessageInput(const std::string &)
-     * @see AgentFunctionDescription::setMessageOutputOptional(const bool &) To configure whether all agents must output messages
+     * @see AgentFunctionDescription::setMessageOutputOptional(bool) To configure whether all agents must output messages
      */
     void setMessageOutput(MessageBruteForce::Description &message);
     /**
@@ -143,7 +143,7 @@ class AgentFunctionDescription : public DependencyNode {
      * @param output_is_optional True if not all agents executing this function will output messages
      * @note Defaults to false
      */
-    void setMessageOutputOptional(const bool &output_is_optional);
+    void setMessageOutputOptional(bool output_is_optional);
     /**
      * Sets the agent type that can be output during this agent function
      * This is optional, and only one type of agent can be output per agent function
@@ -173,7 +173,7 @@ class AgentFunctionDescription : public DependencyNode {
      * @see AgentFunctionDescription::getAllowAgentDeath()
      * @note Defaults to false
      */
-    void setAllowAgentDeath(const bool &has_death);
+    void setAllowAgentDeath(bool has_death);
     /**
      * Sets the function condition for the agent function
      * This is an FLAMEGPU_AGENT_FUNCTION_CONDITION which returns a boolean value (true or false)
@@ -219,13 +219,13 @@ class AgentFunctionDescription : public DependencyNode {
     /**
      * @return A mutable reference to the message output optional configuration flag
      * @see AgentFunctionDescription::getAgentOutputOptional()
-     * @see AgentFunctionDescription::setAgentOutputOptional(const bool &)
+     * @see AgentFunctionDescription::setAgentOutputOptional(bool)
      */
     bool &MessageOutputOptional();
     /**
      * @return A mutable reference to the allow agent death configuration flag
      * @see AgentFunctionDescription::getAllowAgentDeath()
-     * @see AgentFunctionDescription::setAllowAgentDeath(const bool &)
+     * @see AgentFunctionDescription::setAllowAgentDeath(bool)
      */
     bool &AllowAgentDeath();
 

--- a/include/flamegpu/model/EnvironmentDescription.h
+++ b/include/flamegpu/model/EnvironmentDescription.h
@@ -260,7 +260,7 @@ class EnvironmentDescription {
      * @return Returns the previous value of the environment property array element which has been set
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws std::out_of_range
-     * @see set(const std::string &, const T &value)
+     * @see set(const std::string &, T value)
      */
     template<typename T>
     T setProperty(const std::string &name, EnvironmentManager::size_type index, T value);

--- a/include/flamegpu/model/EnvironmentDescription.h
+++ b/include/flamegpu/model/EnvironmentDescription.h
@@ -53,7 +53,7 @@ class EnvironmentDescription {
          * @param _is_const Is the property constant
          * @param _data The data to initially fill the property with
          */
-        PropData(const bool &_is_const, const util::Any &_data)
+        PropData(bool _is_const, const util::Any &_data)
             : isConst(_is_const)
             , data(_data) { }
         bool isConst;

--- a/include/flamegpu/model/SubModelDescription.h
+++ b/include/flamegpu/model/SubModelDescription.h
@@ -96,7 +96,7 @@ class SubModelDescription : public DependencyNode {
      * Set the maximum number of steps per execution of the submodel
      * If 0 (default), unlimited however an exit condition is required
      */
-    void setMaxSteps(const unsigned int &max_steps);
+    void setMaxSteps(unsigned int max_steps);
     /**
      * Return the current value of max steps, defaults to 0
      * This is the maximum number of steps per call of the submodel

--- a/include/flamegpu/model/Variable.h
+++ b/include/flamegpu/model/Variable.h
@@ -66,7 +66,7 @@ struct Variable {
       * @tparam T The type of the variable, it's size and std::type_index are derived from this
       */
     template<typename T>
-    explicit Variable(const unsigned int &N, const std::vector<T> &_default_value)
+    explicit Variable(const unsigned int N, const std::vector<T> &_default_value)
         : type(typeid(T))
         , type_size(sizeof(T))
         , elements(N)

--- a/include/flamegpu/pop/AgentInstance.h
+++ b/include/flamegpu/pop/AgentInstance.h
@@ -65,11 +65,11 @@ class AgentInstance {
      * Setters
      */
     template <typename T>
-    void setVariable(const std::string& variable_name, const T& value);
+    void setVariable(const std::string& variable_name, T value);
     template <typename T, unsigned int N>
     void setVariable(const std::string& variable_name, const std::array<T, N>& value);
     template <typename T, unsigned int N = 0>
-    void setVariable(const std::string& variable_name, unsigned int index, const T& value);
+    void setVariable(const std::string& variable_name, unsigned int index, T value);
 #ifdef SWIG
     template <typename T>
     void setVariableArray(const std::string& variable_name, const std::vector<T>& value);
@@ -187,7 +187,7 @@ std::vector<T> AgentInstance::getVariableArray(const std::string& variable_name)
 }
 #endif
 template <typename T>
-void AgentInstance::setVariable(const std::string& variable_name, const T& value) {
+void AgentInstance::setVariable(const std::string& variable_name, T value) {
     const auto v_it = _data.find(variable_name);
     if (v_it == _data.end()) {
         THROW exception::InvalidAgentVar("Variable with name '%s' was not found in agent, "
@@ -232,7 +232,7 @@ void AgentInstance::setVariable(const std::string& variable_name, const std::arr
     memcpy(static_cast<T*>(v_buff.ptr), value.data(), sizeof(T) * N);
 }
 template <typename T, unsigned int N>
-void AgentInstance::setVariable(const std::string& variable_name, const unsigned int index, const T& value) {
+void AgentInstance::setVariable(const std::string& variable_name, const unsigned int index, T value) {
     const auto v_it = _data.find(variable_name);
     if (v_it == _data.end()) {
         THROW exception::InvalidAgentVar("Variable with name '%s' was not found in agent, "

--- a/include/flamegpu/pop/AgentInstance.h
+++ b/include/flamegpu/pop/AgentInstance.h
@@ -55,7 +55,7 @@ class AgentInstance {
     template <typename T, unsigned int N>
     std::array<T, N> getVariable(const std::string& variable_name) const;
     template <typename T, unsigned int N = 0>
-    T getVariable(const std::string& variable_name, const unsigned int& index) const;
+    T getVariable(const std::string& variable_name, unsigned int index) const;
 #ifdef SWIG
     template <typename T>
     std::vector<T> getVariableArray(const std::string& variable_name) const;
@@ -69,7 +69,7 @@ class AgentInstance {
     template <typename T, unsigned int N>
     void setVariable(const std::string& variable_name, const std::array<T, N>& value);
     template <typename T, unsigned int N = 0>
-    void setVariable(const std::string& variable_name, const unsigned int& index, const T& value);
+    void setVariable(const std::string& variable_name, unsigned int index, const T& value);
 #ifdef SWIG
     template <typename T>
     void setVariableArray(const std::string& variable_name, const std::vector<T>& value);
@@ -128,7 +128,7 @@ std::array<T, N> AgentInstance::getVariable(const std::string& variable_name) co
     return rtn;
 }
 template <typename T, unsigned int N>
-T AgentInstance::getVariable(const std::string& variable_name, const unsigned int& index) const {
+T AgentInstance::getVariable(const std::string& variable_name, const unsigned int index) const {
     const auto v_it = _data.find(variable_name);
     if (v_it == _data.end()) {
         THROW exception::InvalidAgentVar("Variable with name '%s' was not found in agent, "
@@ -232,7 +232,7 @@ void AgentInstance::setVariable(const std::string& variable_name, const std::arr
     memcpy(static_cast<T*>(v_buff.ptr), value.data(), sizeof(T) * N);
 }
 template <typename T, unsigned int N>
-void AgentInstance::setVariable(const std::string& variable_name, const unsigned int& index, const T& value) {
+void AgentInstance::setVariable(const std::string& variable_name, const unsigned int index, const T& value) {
     const auto v_it = _data.find(variable_name);
     if (v_it == _data.end()) {
         THROW exception::InvalidAgentVar("Variable with name '%s' was not found in agent, "

--- a/include/flamegpu/pop/AgentVector_Agent.h
+++ b/include/flamegpu/pop/AgentVector_Agent.h
@@ -81,11 +81,11 @@ class AgentVector_Agent : public AgentVector_CAgent {
 
  public:
     template <typename T>
-    void setVariable(const std::string &variable_name, const T &value);
+    void setVariable(const std::string &variable_name, T value);
     template <typename T, unsigned int N>
     void setVariable(const std::string &variable_name, const std::array<T, N> &value);
     template <typename T, unsigned int N = 0>
-    void setVariable(const std::string &variable_name, unsigned int index, const T &value);
+    void setVariable(const std::string &variable_name, unsigned int index, T value);
 #ifdef SWIG
     template <typename T>
     void setVariableArray(const std::string &variable_name, const std::vector<T> &value);
@@ -132,7 +132,7 @@ class AgentVector_Agent : public AgentVector_CAgent {
 };
 
 template <typename T>
-void AgentVector_Agent::setVariable(const std::string &variable_name, const T &value) {
+void AgentVector_Agent::setVariable(const std::string &variable_name, const T value) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Agent variable names that begin with '_' are reserved for internal usage and cannot be changed directly, "
             "in AgentVector::Agent::setVariable().");
@@ -206,7 +206,7 @@ void AgentVector_Agent::setVariable(const std::string &variable_name, const std:
     _parent->_changed(variable_name, index);
 }
 template <typename T, unsigned int N>
-void AgentVector_Agent::setVariable(const std::string &variable_name, const unsigned int array_index, const T &value) {
+void AgentVector_Agent::setVariable(const std::string &variable_name, const unsigned int array_index, const T value) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Agent variable names that begin with '_' are reserved for internal usage and cannot be changed directly, "
             "in AgentVector::Agent::setVariable().");

--- a/include/flamegpu/pop/AgentVector_Agent.h
+++ b/include/flamegpu/pop/AgentVector_Agent.h
@@ -38,7 +38,7 @@ class AgentVector_CAgent {
     template <typename T, unsigned int N>
     std::array<T, N> getVariable(const std::string& variable_name) const;
     template <typename T, unsigned int N = 0>
-    T getVariable(const std::string& variable_name, const unsigned int& index) const;
+    T getVariable(const std::string& variable_name, unsigned int index) const;
 #ifdef SWIG
     template <typename T>
     std::vector<T> getVariableArray(const std::string& variable_name) const;
@@ -85,7 +85,7 @@ class AgentVector_Agent : public AgentVector_CAgent {
     template <typename T, unsigned int N>
     void setVariable(const std::string &variable_name, const std::array<T, N> &value);
     template <typename T, unsigned int N = 0>
-    void setVariable(const std::string &variable_name, const unsigned int &index, const T &value);
+    void setVariable(const std::string &variable_name, unsigned int index, const T &value);
 #ifdef SWIG
     template <typename T>
     void setVariableArray(const std::string &variable_name, const std::vector<T> &value);
@@ -206,7 +206,7 @@ void AgentVector_Agent::setVariable(const std::string &variable_name, const std:
     _parent->_changed(variable_name, index);
 }
 template <typename T, unsigned int N>
-void AgentVector_Agent::setVariable(const std::string &variable_name, const unsigned int &array_index, const T &value) {
+void AgentVector_Agent::setVariable(const std::string &variable_name, const unsigned int array_index, const T &value) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Agent variable names that begin with '_' are reserved for internal usage and cannot be changed directly, "
             "in AgentVector::Agent::setVariable().");
@@ -349,7 +349,7 @@ std::array<T, N> AgentVector_CAgent::getVariable(const std::string &variable_nam
     return rtn;
 }
 template <typename T, unsigned int N>
-T AgentVector_CAgent::getVariable(const std::string &variable_name, const unsigned int &array_index) const {
+T AgentVector_CAgent::getVariable(const std::string &variable_name, const unsigned int array_index) const {
     const auto data = _data.lock();
     if (!data) {
         THROW exception::ExpiredWeakPtr("The AgentVector which owns this AgentVector::Agent has been deallocated, "

--- a/include/flamegpu/pop/DeviceAgentVector_impl.h
+++ b/include/flamegpu/pop/DeviceAgentVector_impl.h
@@ -45,7 +45,7 @@ class DeviceAgentVector_impl : protected AgentVector {
      */
     DeviceAgentVector_impl(CUDAAgent& _cuda_agent, const std::string& cuda_agent_state,
         const VarOffsetStruct& _agentOffsets, std::vector<NewAgentStorage>& _newAgentData,
-        CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream);
+        CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
     /**
      * Copy operations are disabled
      */
@@ -351,7 +351,7 @@ class DeviceAgentVector_impl : protected AgentVector {
      * @param new_capacity New buffer capacity
      * @param init If true, new memory is init
      */
-    void resizeUnboundBuffers(const unsigned int& new_capacity, bool init);
+    void resizeUnboundBuffers(unsigned int new_capacity, bool init);
     CUDAAgent& cuda_agent;
     std::string cuda_agent_state;
 
@@ -360,7 +360,7 @@ class DeviceAgentVector_impl : protected AgentVector {
     std::vector<NewAgentStorage>& newAgentData;
 
     CUDAScatter& scatter;
-    const unsigned int& streamId;
+    const unsigned int streamId;
     const cudaStream_t& stream;
 };
 

--- a/include/flamegpu/pop/DeviceAgentVector_impl.h
+++ b/include/flamegpu/pop/DeviceAgentVector_impl.h
@@ -45,7 +45,7 @@ class DeviceAgentVector_impl : protected AgentVector {
      */
     DeviceAgentVector_impl(CUDAAgent& _cuda_agent, const std::string& cuda_agent_state,
         const VarOffsetStruct& _agentOffsets, std::vector<NewAgentStorage>& _newAgentData,
-        CUDAScatter& scatter, unsigned int streamId, const cudaStream_t& stream);
+        CUDAScatter& scatter, unsigned int streamId, cudaStream_t stream);
     /**
      * Copy operations are disabled
      */
@@ -361,7 +361,7 @@ class DeviceAgentVector_impl : protected AgentVector {
 
     CUDAScatter& scatter;
     const unsigned int streamId;
-    const cudaStream_t& stream;
+    const cudaStream_t stream;
 };
 
 }  // namespace flamegpu

--- a/include/flamegpu/runtime/DeviceAPI.cuh
+++ b/include/flamegpu/runtime/DeviceAPI.cuh
@@ -295,7 +295,7 @@ class DeviceAPI {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M>
-    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, const T &value);
+    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, T value);
     /**
      * Returns the agent's unique identifier
      */
@@ -427,7 +427,7 @@ __device__ void DeviceAPI<MessageIn, MessageOut>::setVariable(const char(&variab
 }
 template<typename MessageIn, typename MessageOut>
 template<typename T, unsigned int N, unsigned int M>
-__device__ void DeviceAPI<MessageIn, MessageOut>::setVariable(const char(&variable_name)[M], const unsigned int array_index, const T &value) {
+__device__ void DeviceAPI<MessageIn, MessageOut>::setVariable(const char(&variable_name)[M], const unsigned int array_index, const T value) {
     if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS
         DTHROW("Variable names starting with '_' are reserved for internal use, with '%s', in DeviceAPI::setVariable().\n", variable_name);

--- a/include/flamegpu/runtime/DeviceAPI.cuh
+++ b/include/flamegpu/runtime/DeviceAPI.cuh
@@ -79,7 +79,7 @@ class ReadOnlyDeviceAPI {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M> __device__
-    T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
+    T getVariable(const char(&variable_name)[M], unsigned int index) const;
     /**
      * Returns the agent's unique identifier
      */
@@ -201,7 +201,7 @@ class DeviceAPI {
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
         template<typename T, unsigned int N, unsigned int M>
-        __device__ void setVariable(const char(&variable_name)[M], const unsigned int &index, T value) const;
+        __device__ void setVariable(const char(&variable_name)[M], unsigned int index, T value) const;
         /**
          * Return the ID of the agent to be created
          * @note Calling AgentOut::setVariable() or AgentOut::getID() will trigger agent output
@@ -270,7 +270,7 @@ class DeviceAPI {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M> __device__
-    T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
+    T getVariable(const char(&variable_name)[M], unsigned int index) const;
     /**
      * Sets a variable within the currently executing agent
      * @param variable_name The name of the variable
@@ -295,7 +295,7 @@ class DeviceAPI {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M>
-    __device__ void setVariable(const char(&variable_name)[M], const unsigned int &index, const T &value);
+    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, const T &value);
     /**
      * Returns the agent's unique identifier
      */
@@ -373,7 +373,7 @@ __device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[N]) const
     return value;
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[M], const unsigned int &array_index) const {
+__device__ T ReadOnlyDeviceAPI::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
     const unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
@@ -400,7 +400,7 @@ __device__ T DeviceAPI<MessageIn, MessageOut>::getVariable(const char(&variable_
 
 template<typename MessageIn, typename MessageOut>
 template<typename T, unsigned int N, unsigned int M>
-__device__ T DeviceAPI<MessageIn, MessageOut>::getVariable(const char(&variable_name)[M], const unsigned int &array_index) const {
+__device__ T DeviceAPI<MessageIn, MessageOut>::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
     const unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
@@ -427,7 +427,7 @@ __device__ void DeviceAPI<MessageIn, MessageOut>::setVariable(const char(&variab
 }
 template<typename MessageIn, typename MessageOut>
 template<typename T, unsigned int N, unsigned int M>
-__device__ void DeviceAPI<MessageIn, MessageOut>::setVariable(const char(&variable_name)[M], const unsigned int &array_index, const T &value) {
+__device__ void DeviceAPI<MessageIn, MessageOut>::setVariable(const char(&variable_name)[M], const unsigned int array_index, const T &value) {
     if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS
         DTHROW("Variable names starting with '_' are reserved for internal use, with '%s', in DeviceAPI::setVariable().\n", variable_name);
@@ -467,7 +467,7 @@ __device__ void DeviceAPI<MessageIn, MessageOut>::AgentOut::setVariable(const ch
 }
 template<typename MessageIn, typename MessageOut>
 template<typename T, unsigned int N, unsigned int M>
-__device__ void DeviceAPI<MessageIn, MessageOut>::AgentOut::setVariable(const char(&variable_name)[M], const unsigned int &array_index, T value) const {
+__device__ void DeviceAPI<MessageIn, MessageOut>::AgentOut::setVariable(const char(&variable_name)[M], const unsigned int array_index, T value) const {
     if (nextID) {
         if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS

--- a/include/flamegpu/runtime/HostAPI.h
+++ b/include/flamegpu/runtime/HostAPI.h
@@ -55,7 +55,7 @@ class HostAPI {
           AgentDataMap &agentData,
           const std::shared_ptr<EnvironmentManager> &env,
           CUDAMacroEnvironment &macro_env,
-          const unsigned int &streamId,
+          unsigned int streamId,
          cudaStream_t stream);
     /**
      * Frees held device memory
@@ -82,7 +82,7 @@ class HostAPI {
 
  private:
     template<typename T>
-    void resizeOutputSpace(const unsigned int &items = 1);
+    void resizeOutputSpace(unsigned int items = 1);
     CUDASimulation &agentModel;
     void *d_output_space;
     size_t d_output_space_size;
@@ -112,7 +112,7 @@ class HostAPI {
 };
 
 template<typename T>
-void HostAPI::resizeOutputSpace(const unsigned int &items) {
+void HostAPI::resizeOutputSpace(const unsigned int items) {
     if (sizeof(T) * items > d_output_space_size) {
         if (d_output_space_size) {
             gpuErrchk(cudaFree(d_output_space));

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -131,7 +131,7 @@ struct NewAgentStorage {
             free(data);
     }
     template<typename T>
-    void setVariable(const std::string &var_name, const T &val) {
+    void setVariable(const std::string &var_name, const T val) {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW exception::InvalidAgentVar("Variable '%s' not found, "
@@ -153,7 +153,7 @@ struct NewAgentStorage {
         memcpy(data + var->second.offset, &val, var->second.len);
     }
     template<typename T, unsigned int N = 0>
-    void setVariable(const std::string &var_name, const unsigned int index, const T &val) {
+    void setVariable(const std::string &var_name, const unsigned int index, const T val) {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW exception::InvalidAgentVar("Variable '%s' not found, "
@@ -380,7 +380,7 @@ class HostNewAgentAPI {
      * Updates a variable within the new agent
      */
     template<typename T>
-    void setVariable(const std::string &var_name, const T &val) {
+    void setVariable(const std::string &var_name, const T val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW exception::ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
                 "in HostNewAgentAPI::setVariable().");
@@ -388,7 +388,7 @@ class HostNewAgentAPI {
         s->setVariable<T>(var_name, val);
     }
     template<typename T, unsigned int N = 0>
-    void setVariable(const std::string &var_name, const unsigned int index, const T &val) {
+    void setVariable(const std::string &var_name, const unsigned int index, const T val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW exception::ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
                 "in HostNewAgentAPI::setVariable().");

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -153,7 +153,7 @@ struct NewAgentStorage {
         memcpy(data + var->second.offset, &val, var->second.len);
     }
     template<typename T, unsigned int N = 0>
-    void setVariable(const std::string &var_name, const unsigned int &index, const T &val) {
+    void setVariable(const std::string &var_name, const unsigned int index, const T &val) {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW exception::InvalidAgentVar("Variable '%s' not found, "
@@ -256,7 +256,7 @@ struct NewAgentStorage {
         return *reinterpret_cast<T*>(data + var->second.offset);
     }
     template<typename T, unsigned int N = 0>
-    T getVariable(const std::string &var_name, const unsigned int &index) {
+    T getVariable(const std::string &var_name, const unsigned int index) {
         const auto &var = offsets.vars.find(var_name);
         if (var == offsets.vars.end()) {
             THROW exception::InvalidAgentVar("Variable '%s' not found, "
@@ -388,7 +388,7 @@ class HostNewAgentAPI {
         s->setVariable<T>(var_name, val);
     }
     template<typename T, unsigned int N = 0>
-    void setVariable(const std::string &var_name, const unsigned int &index, const T &val) {
+    void setVariable(const std::string &var_name, const unsigned int index, const T &val) {
         if (!var_name.empty() && var_name[0] == '_') {
             THROW exception::ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
                 "in HostNewAgentAPI::setVariable().");
@@ -422,7 +422,7 @@ class HostNewAgentAPI {
         return s->getVariable<T>(var_name);
     }
     template<typename T, unsigned int N = 0>
-    T getVariable(const std::string &var_name, const unsigned int &index) {
+    T getVariable(const std::string &var_name, const unsigned int index) {
         return s->getVariable<T, N>(var_name, index);
     }
 #ifndef SWIG

--- a/include/flamegpu/runtime/HostNewAgentAPI.h
+++ b/include/flamegpu/runtime/HostNewAgentAPI.h
@@ -28,7 +28,7 @@ struct VarOffsetStruct {
          * @param _len Length of the variables data within the buffer
          * @param _type Type of the variable's base type (does not account for whether it's an array)
          */
-        OffsetLen(const ptrdiff_t &_offset, const size_t &_len, const std::type_index _type)
+        OffsetLen(const ptrdiff_t &_offset, const size_t _len, const std::type_index _type)
             : offset(_offset)
             , len(_len)
             , type(_type) { }

--- a/include/flamegpu/runtime/messaging/MessageArray/MessageArrayDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray/MessageArrayDevice.cuh
@@ -39,7 +39,7 @@ class MessageArray::In {
         * index is always init to 0
         * @note See member variable documentation for their purposes
         */
-        __device__ Message(const MessageArray::In &parent, const size_type &_index) : _parent(parent), index(_index) {}
+        __device__ Message(const MessageArray::In &parent, const size_type _index) : _parent(parent), index(_index) {}
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null message which always returns the message at index 0
@@ -243,7 +243,7 @@ class MessageArray::In {
          * @param x Search origin x coord
          * @param _radius Search radius
          */
-        inline __device__ WrapFilter(const size_type &_length, const size_type &x, const size_type &_radius);
+        inline __device__ WrapFilter(const size_type _length, const size_type x, const size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -443,7 +443,7 @@ class MessageArray::In {
          * @param _radius Search radius
          */
 
-        inline __device__ Filter(const size_type& _length, const size_type& x, const size_type& _radius);
+        inline __device__ Filter(size_type _length, size_type x, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -506,7 +506,7 @@ class MessageArray::In {
      * @note radius of 0 is unsupported
      * @note The location x must be within the bounds of the message list
      */
-    inline __device__ WrapFilter wrap(const size_type &x, const size_type &radius = 1) const {
+    inline __device__ WrapFilter wrap(const size_type x, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("Invalid radius %u for accessing array messagelist of length %u\n", radius, length);
@@ -539,7 +539,7 @@ class MessageArray::In {
      * @note radius of 0 is unsupported
      * @note The location x must be within the bounds of the message list
      */
-    inline __device__ Filter operator() (const size_type &x, const size_type &radius = 1) const {
+    inline __device__ Filter operator() (const size_type x, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("Invalid radius %u for accessing array messagelist of length %u\n", radius, length);
@@ -558,7 +558,7 @@ class MessageArray::In {
     __device__ size_type size(void) const {
         return length;
     }
-    __device__ Message at(const size_type &index) const {
+    __device__ Message at(const size_type index) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (index >= length) {
             DTHROW("Index is out of bounds for Array messagelist (%u >= %u).\n", index, length);
@@ -597,7 +597,7 @@ class MessageArray::Out {
     /**
      * Sets the array index to store the message in
      */
-    __device__ inline void setIndex(const size_type &id) const;
+    __device__ inline void setIndex(const size_type id) const;
     /**
      * Sets the specified variable for this agents message
      * @param variable_name Name of the variable
@@ -747,7 +747,7 @@ __device__ void MessageArray::Out::setVariable(const char(&variable_name)[M], co
 /**
 * Sets the array index to store the message in
 */
-__device__ void MessageArray::Out::setIndex(const size_type &id) const {
+__device__ void MessageArray::Out::setIndex(const size_type id) const {
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 
 #if !defined(SEATBELTS) || SEATBELTS
@@ -762,7 +762,7 @@ __device__ void MessageArray::Out::setIndex(const size_type &id) const {
     // Set scan flag incase the message is optional
     this->scan_flag[index] = 1;
 }
-__device__ MessageArray::In::WrapFilter::WrapFilter(const size_type &_length, const size_type &x, const size_type &_radius)
+__device__ MessageArray::In::WrapFilter::WrapFilter(const size_type _length, const size_type x, const size_type _radius)
     : radius(_radius)
     , length(_length) {
     loc = x;
@@ -788,7 +788,7 @@ __device__ MessageArray::In::WrapFilter::Message& MessageArray::In::WrapFilter::
     index_1d = (this->_parent.loc + relative_cell + this->_parent.length) % this->_parent.length;
     return *this;
 }
-__device__ MessageArray::In::Filter::Filter(const size_type &_length, const size_type &x, const size_type &_radius)
+__device__ MessageArray::In::Filter::Filter(const size_type _length, const size_type x, const size_type _radius)
     : length(_length) {
     loc = x;
     min_cell = static_cast<int>(x) - static_cast<int>(_radius) < 0 ? -static_cast<int>(x) : -static_cast<int>(_radius);

--- a/include/flamegpu/runtime/messaging/MessageArray/MessageArrayDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray/MessageArrayDevice.cuh
@@ -83,7 +83,7 @@ class MessageArray::In {
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
         template<typename T, MessageNone::size_type N, unsigned int M>
-        __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+        __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
     /**
      * This class is created when a search origin is provided to MessageArray::In::operator()(size_type, size_type, size_type = 1)
@@ -124,7 +124,7 @@ class MessageArray::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const WrapFilter&parent, const int &relative_x)
+            __device__ Message(const WrapFilter&parent, const int relative_x)
                 : _parent(parent) {
                 relative_cell = relative_x;
             }
@@ -182,7 +182,7 @@ class MessageArray::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M> __device__
-            T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
+            T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::WrapFilter::Message objects
@@ -199,7 +199,7 @@ class MessageArray::In {
              * This iterator is constructed by MessageArray::In::WrapFilter::begin()(size_type, size_type)
              * @see MessageArray::In::wrap(size_type, size_type)
              */
-            __device__ iterator(const WrapFilter&parent, const int &relative_x)
+            __device__ iterator(const WrapFilter&parent, const int relative_x)
                 : _message(parent, relative_x) {
                 // Increment to find first message
                 ++_message;
@@ -324,7 +324,7 @@ class MessageArray::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter& parent, const int& relative_x)
+            __device__ Message(const Filter& parent, const int relative_x)
                 : _parent(parent) {
                 relative_cell = relative_x;
             }
@@ -381,7 +381,7 @@ class MessageArray::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
@@ -398,7 +398,7 @@ class MessageArray::In {
              * This iterator is constructed by MessageArray::In::Filter::begin()(size_type, size_type)
              * @see MessageArray::In::Operator()(size_type, size_type)
              */
-            __device__ iterator(const Filter& parent, const int& relative_x)
+            __device__ iterator(const Filter& parent, const int relative_x)
                 : _message(parent, relative_x) {
                 // Increment to find first message
                 ++_message;
@@ -621,7 +621,7 @@ class MessageArray::Out {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M>
-    __device__ void setVariable(const char(&variable_name)[M], const unsigned int& index, T value) const;
+    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, T value) const;
 
  protected:
     /**
@@ -647,7 +647,7 @@ __device__ T MessageArray::In::Message::getVariable(const char(&variable_name)[N
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray::In::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -673,7 +673,7 @@ __device__ T MessageArray::In::WrapFilter::Message::getVariable(const char(&vari
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -699,7 +699,7 @@ __device__ T MessageArray::In::Filter::Message::getVariable(const char(&variable
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -729,7 +729,7 @@ __device__ void MessageArray::Out::setVariable(const char(&variable_name)[N], T 
     // setIndex() sets the optional message scan flag
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ void MessageArray::Out::setVariable(const char(&variable_name)[M], const unsigned int& array_index, T value) const {
+__device__ void MessageArray::Out::setVariable(const char(&variable_name)[M], const unsigned int array_index, T value) const {
     if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS
         DTHROW("Variable names starting with '_' are reserved for internal use, with '%s', in MessageArray::Out::setVariable().\n", variable_name);

--- a/include/flamegpu/runtime/messaging/MessageArray/MessageArrayHost.h
+++ b/include/flamegpu/runtime/messaging/MessageArray/MessageArrayHost.h
@@ -145,7 +145,7 @@ class MessageArray::Description : public MessageBruteForce::Description {
     Description& operator=(Description &&other_message) noexcept = delete;
 
  public:
-    void setLength(const size_type &len);
+    void setLength(const size_type len);
 
     size_type getLength() const;
 };

--- a/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DDevice.cuh
@@ -79,7 +79,7 @@ class MessageArray2D::In {
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
         template<typename T, MessageNone::size_type N, unsigned int M>
-        __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+        __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
 
     /**
@@ -122,7 +122,7 @@ class MessageArray2D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const WrapFilter&parent, const int &relative_x, const int &relative_y)
+            __device__ Message(const WrapFilter&parent, const int relative_x, const int relative_y)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -196,7 +196,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::WrapFilter::Message objects
@@ -213,7 +213,7 @@ class MessageArray2D::In {
              * This iterator is constructed by MessageArray2D::In::WrapFilter::begin()(size_type, size_type, size_type)
              * @see MessageArray2D::In::wrap(size_type, size_type, size_type)
              */
-            __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y)
+            __device__ iterator(const WrapFilter&parent, const int relative_x, const int relative_y)
                 : _message(parent, relative_x, relative_y) {
                 // Increment to find first message
                 ++_message;
@@ -339,7 +339,7 @@ class MessageArray2D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter &parent, const int &relative_x, const int &relative_y)
+            __device__ Message(const Filter &parent, const int relative_x, const int relative_y)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -411,7 +411,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
@@ -428,7 +428,7 @@ class MessageArray2D::In {
              * This iterator is constructed by MessageArray2D::In::Filter::begin()(size_type, size_type, size_type)
              * @see MessageArray2D::In::Operator()(size_type, size_type, size_type)
              */
-            __device__ iterator(const Filter &parent, const int &relative_x, const int &relative_y)
+            __device__ iterator(const Filter &parent, const int relative_x, const int relative_y)
                 : _message(parent, relative_x, relative_y) {
                 // Increment to find first message
                 ++_message;
@@ -555,7 +555,7 @@ class MessageArray2D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const VonNeumannWrapFilter&parent, const int &relative_x, const int &relative_y)
+            __device__ Message(const VonNeumannWrapFilter&parent, const int relative_x, const int relative_y)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -629,7 +629,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::WrapFilter::Message objects
@@ -646,7 +646,7 @@ class MessageArray2D::In {
              * This iterator is constructed by MessageArray2D::In::WrapFilter::begin()(size_type, size_type, size_type)
              * @see MessageArray2D::In::wrap(size_type, size_type, size_type)
              */
-            __device__ iterator(const VonNeumannWrapFilter&parent, const int &relative_x, const int &relative_y)
+            __device__ iterator(const VonNeumannWrapFilter&parent, const int relative_x, const int relative_y)
                 : _message(parent, relative_x, relative_y) {
                 // Increment to find first message
                 ++_message;
@@ -772,7 +772,7 @@ class MessageArray2D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const VonNeumannFilter &parent, const int &relative_x, const int &relative_y)
+            __device__ Message(const VonNeumannFilter &parent, const int relative_x, const int relative_y)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -844,7 +844,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
@@ -861,7 +861,7 @@ class MessageArray2D::In {
              * This iterator is constructed by MessageArray2D::In::Filter::begin()(size_type, size_type, size_type)
              * @see MessageArray2D::In::Operator()(size_type, size_type, size_type)
              */
-            __device__ iterator(const VonNeumannFilter&parent, const int &relative_x, const int &relative_y)
+            __device__ iterator(const VonNeumannFilter&parent, const int relative_x, const int relative_y)
                 : _message(parent, relative_x, relative_y) {
                 // Increment to find first message
                 ++_message;
@@ -1169,7 +1169,7 @@ class MessageArray2D::Out {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M>
-    __device__ void setVariable(const char(&variable_name)[M], const unsigned int& index, T value) const;
+    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, T value) const;
 
  protected:
     /**
@@ -1197,7 +1197,7 @@ __device__ T MessageArray2D::In::Message::getVariable(const char(&variable_name)
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray2D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray2D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (index >= this->_parent.metadata->length) {
@@ -1222,7 +1222,7 @@ __device__ T MessageArray2D::In::WrapFilter::Message::getVariable(const char(&va
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray2D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray2D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (index_1d >= this->_parent.metadata->length) {
@@ -1247,7 +1247,7 @@ __device__ T MessageArray2D::In::Filter::Message::getVariable(const char(&variab
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray2D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray2D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (index_1d >= this->_parent.metadata->length) {
@@ -1272,7 +1272,7 @@ __device__ T MessageArray2D::In::VonNeumannWrapFilter::Message::getVariable(cons
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray2D::In::VonNeumannWrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray2D::In::VonNeumannWrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (index_1d >= this->_parent.metadata->length) {
@@ -1297,7 +1297,7 @@ __device__ T MessageArray2D::In::VonNeumannFilter::Message::getVariable(const ch
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray2D::In::VonNeumannFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray2D::In::VonNeumannFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (index_1d >= this->_parent.metadata->length) {
@@ -1326,7 +1326,7 @@ __device__ void MessageArray2D::Out::setVariable(const char(&variable_name)[N], 
     // setIndex() sets the optional message scan flag
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ void MessageArray2D::Out::setVariable(const char(&variable_name)[M], const unsigned int& array_index, T value) const {
+__device__ void MessageArray2D::Out::setVariable(const char(&variable_name)[M], const unsigned int array_index, T value) const {
     if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS
         DTHROW("Variable names starting with '_' are reserved for internal use, with '%s', in MessageArray2D::Out::setVariable().\n", variable_name);

--- a/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DDevice.cuh
@@ -35,7 +35,7 @@ class MessageArray2D::In {
          * index is always init to 0
          * @note See member variable documentation for their purposes
          */
-        __device__ Message(const MessageArray2D::In &parent, const size_type &_index) : _parent(parent), index(_index) {}
+        __device__ Message(const MessageArray2D::In &parent, const size_type _index) : _parent(parent), index(_index) {}
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null message which always returns the message at index 0
@@ -258,7 +258,7 @@ class MessageArray2D::In {
          * @param y Search origin y coord
          * @param _radius Search radius
          */
-        inline __device__ WrapFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &_radius);
+        inline __device__ WrapFilter(const MetaData *_metadata, size_type x, size_type y, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -473,7 +473,7 @@ class MessageArray2D::In {
          * @param y Search origin y coord
          * @param _radius Search radius
          */
-        inline __device__ Filter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &_radius);
+        inline __device__ Filter(const MetaData *_metadata, size_type x, size_type y, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -691,7 +691,7 @@ class MessageArray2D::In {
          * @param y Search origin y coord
          * @param _radius Search radius
          */
-        inline __device__ VonNeumannWrapFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &_radius);
+        inline __device__ VonNeumannWrapFilter(const MetaData *_metadata, size_type x, size_type y, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -906,7 +906,7 @@ class MessageArray2D::In {
          * @param y Search origin y coord
          * @param _radius Search radius
          */
-        inline __device__ VonNeumannFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &_radius);
+        inline __device__ VonNeumannFilter(const MetaData *_metadata, size_type x, size_type y, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -974,7 +974,7 @@ class MessageArray2D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y] must be within the bounds of the message list
      */
-    inline __device__ WrapFilter wrap(const size_type & x, const size_type & y, const size_type & radius = 1) const {
+    inline __device__ WrapFilter wrap(const size_type x, const size_type y, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
@@ -1009,7 +1009,7 @@ class MessageArray2D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y] must be within the bounds of the message list
      */
-    inline __device__ Filter operator() (const size_type &x, const size_type &y, const size_type &radius = 1) const {
+    inline __device__ Filter operator() (const size_type x, const size_type y, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
@@ -1038,7 +1038,7 @@ class MessageArray2D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y] must be within the bounds of the message list
      */
-    inline __device__ VonNeumannWrapFilter vn_wrap(const size_type & x, const size_type & y, const size_type & radius = 1) const {
+    inline __device__ VonNeumannWrapFilter vn_wrap(const size_type x, const size_type y, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
@@ -1073,7 +1073,7 @@ class MessageArray2D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y] must be within the bounds of the message list
      */
-    inline __device__ VonNeumannFilter vn(const size_type &x, const size_type &y, const size_type &radius = 1) const {
+    inline __device__ VonNeumannFilter vn(const size_type x, const size_type y, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array2D message lists.\n", radius);
@@ -1106,7 +1106,7 @@ class MessageArray2D::In {
     __device__ size_type size(void) const {
         return metadata->length;
     }
-    __device__ Message at(const size_type &x, const size_type &y) const {
+    __device__ Message at(const size_type x, const size_type y) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (x >= metadata->dimensions[0] || y >= metadata->dimensions[1]) {
             DTHROW("Index is out of bounds for Array2D messagelist ([%u, %u] >= [%u, %u]).\n", x, y, metadata->dimensions[0], metadata->dimensions[1]);
@@ -1145,7 +1145,7 @@ class MessageArray2D::Out {
     /**
      * Sets the array index to store the message in
      */
-    inline __device__ void setIndex(const size_type &x, const size_type &y) const;
+    inline __device__ void setIndex(const size_type x, const size_type y) const;
     /**
      * Sets the specified variable for this agents message
      * @param variable_name Name of the variable
@@ -1345,7 +1345,7 @@ __device__ void MessageArray2D::Out::setVariable(const char(&variable_name)[M], 
 /**
  * Sets the array index to store the message in
  */
-__device__ void MessageArray2D::Out::setIndex(const size_type &x, const size_type &y) const {
+__device__ void MessageArray2D::Out::setIndex(const size_type x, const size_type y) const {
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
     size_type index_1d =
         y * metadata->dimensions[0] +
@@ -1363,7 +1363,7 @@ __device__ void MessageArray2D::Out::setIndex(const size_type &x, const size_typ
     this->scan_flag[index] = 1;
 }
 // Moore Wrap
-__device__ MessageArray2D::In::WrapFilter::WrapFilter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& _radius)
+__device__ MessageArray2D::In::WrapFilter::WrapFilter(const MetaData* _metadata, const size_type x, const size_type y, const size_type _radius)
     : radius(_radius)
     , metadata(_metadata) {
     loc[0] = x;
@@ -1401,7 +1401,7 @@ __device__ MessageArray2D::In::WrapFilter::Message& MessageArray2D::In::WrapFilt
     return *this;
 }
 // Moore
-__device__ MessageArray2D::In::Filter::Filter(const MetaData *_metadata,  const size_type &x, const size_type &y, const size_type &_radius)
+__device__ MessageArray2D::In::Filter::Filter(const MetaData *_metadata,  const size_type x, const size_type y, const size_type _radius)
     : metadata(_metadata) {
     loc[0] = x;
     loc[1] = y;
@@ -1447,7 +1447,7 @@ __device__ MessageArray2D::In::Filter::Message& MessageArray2D::In::Filter::Mess
     return *this;
 }
 // Von Neumann Wrap
-__device__ MessageArray2D::In::VonNeumannWrapFilter::VonNeumannWrapFilter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& _radius)
+__device__ MessageArray2D::In::VonNeumannWrapFilter::VonNeumannWrapFilter(const MetaData* _metadata, const size_type x, const size_type y, const size_type _radius)
     : radius(static_cast<int>(_radius))
     , metadata(_metadata) {
     loc[0] = x;
@@ -1492,7 +1492,7 @@ __device__ MessageArray2D::In::VonNeumannWrapFilter::Message& MessageArray2D::In
     return *this;
 }
 // Von Neumann
-__device__ MessageArray2D::In::VonNeumannFilter::VonNeumannFilter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& _radius)
+__device__ MessageArray2D::In::VonNeumannFilter::VonNeumannFilter(const MetaData* _metadata, const size_type x, const size_type y, const size_type _radius)
     : radius(static_cast<int>(_radius))
     , metadata(_metadata) {
     loc[0] = x;

--- a/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DHost.h
@@ -146,7 +146,7 @@ class MessageArray2D::Description : public MessageBruteForce::Description {
      Description& operator=(Description &&other_message) noexcept = delete;
 
  public:
-     void setDimensions(const size_type &len_x, const size_type &len_y);
+     void setDimensions(size_type len_x, size_type len_y);
      void setDimensions(const std::array<size_type, 2> &dims);
 
     std::array<size_type, 2> getDimensions() const;

--- a/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
@@ -85,7 +85,7 @@ class MessageArray3D::In {
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
         template<typename T, MessageNone::size_type N, unsigned int M>
-        __device__ T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
+        __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
     /**
      * This class is created when a search origin is provided to MessageArray2D::wrap()(size_type, size_type, size_type = 1)
@@ -127,7 +127,7 @@ class MessageArray3D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ Message(const WrapFilter&parent, const int relative_x, const int relative_y, const int relative_z)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -217,7 +217,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::WrapFilter::Message objects
@@ -234,7 +234,7 @@ class MessageArray3D::In {
              * This iterator is constructed by MessageArray3D::In::WrapFilter::begin()(size_type, size_type, size_type, size_type)
              * @see MessageArray3D::In::wrap(size_type, size_type, size_type, size_type)
              */
-            __device__ iterator(const WrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ iterator(const WrapFilter&parent, const int relative_x, const int relative_y, const int relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
                 // Increment to find first message
                 ++_message;
@@ -360,7 +360,7 @@ class MessageArray3D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const Filter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+            __device__ Message(const Filter& parent, const int relative_x, const int relative_y, const int relative_z)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -447,7 +447,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
@@ -464,7 +464,7 @@ class MessageArray3D::In {
              * This iterator is constructed by MessageArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
              * @see MessageArray3D::In::Operator()(size_type, size_type, size_type, size_type)
              */
-            __device__ iterator(const Filter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+            __device__ iterator(const Filter& parent, const int relative_x, const int relative_y, const int relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
                 // Increment to find first message
                 ++_message;
@@ -591,7 +591,7 @@ class MessageArray3D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const VonNeumannWrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ Message(const VonNeumannWrapFilter&parent, const int relative_x, const int relative_y, const int relative_z)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -681,7 +681,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::WrapFilter::Message objects
@@ -698,7 +698,7 @@ class MessageArray3D::In {
              * This iterator is constructed by MessageArray3D::In::WrapFilter::begin()(size_type, size_type, size_type, size_type)
              * @see MessageArray3D::In::wrap(size_type, size_type, size_type, size_type)
              */
-            __device__ iterator(const VonNeumannWrapFilter&parent, const int &relative_x, const int &relative_y, const int &relative_z)
+            __device__ iterator(const VonNeumannWrapFilter&parent, const int relative_x, const int relative_y, const int relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
                 // Increment to find first message
                 ++_message;
@@ -824,7 +824,7 @@ class MessageArray3D::In {
              * Constructs a message and directly initialises all of it's member variables
              * @note See member variable documentation for their purposes
              */
-            __device__ Message(const VonNeumannFilter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+            __device__ Message(const VonNeumannFilter& parent, const int relative_x, const int relative_y, const int relative_z)
                 : _parent(parent) {
                 relative_cell[0] = relative_x;
                 relative_cell[1] = relative_y;
@@ -911,7 +911,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M>
-            __device__ T getVariable(const char(&variable_name)[M], const unsigned int& index) const;
+            __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
          * Stock iterator for iterating MessageSpatial3D::In::Filter::Message objects
@@ -928,7 +928,7 @@ class MessageArray3D::In {
              * This iterator is constructed by MessageArray3D::In::Filter::begin()(size_type, size_type, size_type, size_type)
              * @see MessageArray3D::In::Operator()(size_type, size_type, size_type, size_type)
              */
-            __device__ iterator(const VonNeumannFilter& parent, const int& relative_x, const int& relative_y, const int& relative_z)
+            __device__ iterator(const VonNeumannFilter& parent, const int relative_x, const int relative_y, const int relative_z)
                 : _message(parent, relative_x, relative_y, relative_z) {
                 // Increment to find first message
                 ++_message;
@@ -1260,7 +1260,7 @@ class MessageArray3D::Out {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M>
-    __device__ void setVariable(const char(&variable_name)[M], const unsigned int& index, T value) const;
+    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, T value) const;
 
  protected:
     /**
@@ -1286,7 +1286,7 @@ __device__ T MessageArray3D::In::Message::getVariable(const char(&variable_name)
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray3D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray3D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1312,7 +1312,7 @@ __device__ T MessageArray3D::In::WrapFilter::Message::getVariable(const char(&va
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1338,7 +1338,7 @@ __device__ T MessageArray3D::In::Filter::Message::getVariable(const char(&variab
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1364,7 +1364,7 @@ __device__ T MessageArray3D::In::VonNeumannWrapFilter::Message::getVariable(cons
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray3D::In::VonNeumannWrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray3D::In::VonNeumannWrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1390,7 +1390,7 @@ __device__ T MessageArray3D::In::VonNeumannFilter::Message::getVariable(const ch
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageArray3D::In::VonNeumannFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageArray3D::In::VonNeumannFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1420,7 +1420,7 @@ __device__ void MessageArray3D::Out::setVariable(const char(&variable_name)[N], 
     // setIndex() sets the optional message scan flag
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ void MessageArray3D::Out::setVariable(const char(&variable_name)[M], const unsigned int& array_index, T value) const {
+__device__ void MessageArray3D::Out::setVariable(const char(&variable_name)[M], const unsigned int array_index, T value) const {
     if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS
         DTHROW("Variable names starting with '_' are reserved for internal use, with '%s', in MessageArray3D::Out::setVariable().\n", variable_name);

--- a/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
@@ -41,7 +41,7 @@ class MessageArray3D::In {
          * index is always init to 0
          * @note See member variable documentation for their purposes
          */
-        __device__ Message(const MessageArray3D::In &parent, const size_type &_index) : _parent(parent), index(_index) {}
+        __device__ Message(const MessageArray3D::In &parent, const size_type _index) : _parent(parent), index(_index) {}
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null message which always returns the message at index 0
@@ -280,7 +280,7 @@ class MessageArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ WrapFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
+        inline __device__ WrapFilter(const MetaData *_metadata, size_type x, size_type y, size_type z, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -510,7 +510,7 @@ class MessageArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ Filter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius);
+        inline __device__ Filter(const MetaData* _metadata, const size_type x, const size_type y, const size_type z, const size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -744,7 +744,7 @@ class MessageArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ VonNeumannWrapFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius);
+        inline __device__ VonNeumannWrapFilter(const MetaData *_metadata, size_type x, size_type y, size_type z, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -974,7 +974,7 @@ class MessageArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ VonNeumannFilter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius);
+        inline __device__ VonNeumannFilter(const MetaData* _metadata, size_type& x, size_type& y, size_type& z, size_type& _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages
@@ -1043,7 +1043,7 @@ class MessageArray3D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y, z] must be within the bounds of the message list
      */
-    inline __device__ WrapFilter wrap(const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
+    inline __device__ WrapFilter wrap(const size_type x, const size_type y, const size_type z, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
@@ -1084,7 +1084,7 @@ class MessageArray3D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y, z] must be within the bounds of the message list
      */
-    inline __device__ Filter operator()(const size_type& x, const size_type& y, const size_type& z, const size_type& radius = 1) const {
+    inline __device__ Filter operator()(const size_type x, const size_type y, const size_type z, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
@@ -1115,7 +1115,7 @@ class MessageArray3D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y, z] must be within the bounds of the message list
      */
-    inline __device__ VonNeumannWrapFilter vn_wrap(const size_type &x, const size_type &y, const size_type &z, const size_type &radius = 1) const {
+    inline __device__ VonNeumannWrapFilter vn_wrap(const size_type x, const size_type y, const size_type z, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
@@ -1156,7 +1156,7 @@ class MessageArray3D::In {
      * @note radius of 0 is unsupported
      * @note The location [x, y, z] must be within the bounds of the message list
      */
-    inline __device__ VonNeumannFilter vn(const size_type& x, const size_type& y, const size_type& z, const size_type& radius = 1) const {
+    inline __device__ VonNeumannFilter vn(const size_type x, const size_type y, const size_type z, const size_type radius = 1) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (radius == 0) {
             DTHROW("%u is not a valid radius for accessing Array3D message lists.\n", radius);
@@ -1196,7 +1196,7 @@ class MessageArray3D::In {
     __device__ size_type size(void) const {
         return metadata->length;
     }
-    __device__ Message at(const size_type &x, const size_type &y, const size_type &z) const {
+    __device__ Message at(const size_type x, const size_type y, const size_type z) const {
 #if !defined(SEATBELTS) || SEATBELTS
         if (x >= metadata->dimensions[0] || y >= metadata->dimensions[1] || z >= metadata->dimensions[2]) {
             DTHROW("Index is out of bounds for Array3D messagelist ([%u, %u, %u] >= [%u, %u, %u]).\n", x, y, z, metadata->dimensions[0], metadata->dimensions[1], metadata->dimensions[2]);
@@ -1236,7 +1236,7 @@ class MessageArray3D::Out {
     /**
      * Sets the array index to store the message in
      */
-    inline __device__ void setIndex(const size_type &x, const size_type &y, const size_type &z) const;
+    inline __device__ void setIndex(size_type x, size_type y, size_type z) const;
     /**
      * Sets the specified variable for this agents message
      * @param variable_name Name of the variable
@@ -1438,7 +1438,7 @@ __device__ void MessageArray3D::Out::setVariable(const char(&variable_name)[M], 
 /**
 * Sets the array index to store the message in
 */
-__device__ inline void MessageArray3D::Out::setIndex(const size_type &x, const size_type &y, const size_type &z) const {
+__device__ inline void MessageArray3D::Out::setIndex(const size_type x, const size_type y, const size_type z) const {
     unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
     size_type index_1d =
         z * metadata->dimensions[0] * metadata->dimensions[1] +
@@ -1460,7 +1460,7 @@ __device__ inline void MessageArray3D::Out::setIndex(const size_type &x, const s
     this->scan_flag[index] = 1;
 }
 // Moore Wrap
-__device__ inline MessageArray3D::In::WrapFilter::WrapFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
+__device__ inline MessageArray3D::In::WrapFilter::WrapFilter(const MetaData *_metadata, const size_type x, const size_type y, const size_type z, const size_type _radius)
     : radius(_radius)
     , metadata(_metadata) {
     loc[0] = x;
@@ -1507,7 +1507,7 @@ __device__ inline MessageArray3D::In::WrapFilter::Message& MessageArray3D::In::W
     return *this;
 }
 // Moore
-__device__ inline MessageArray3D::In::Filter::Filter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius)
+__device__ inline MessageArray3D::In::Filter::Filter(const MetaData* _metadata, const size_type x, const size_type y, const size_type z, const size_type _radius)
     : metadata(_metadata) {
     loc[0] = x;
     loc[1] = y;
@@ -1570,7 +1570,7 @@ __device__ inline MessageArray3D::In::Filter::Message& MessageArray3D::In::Filte
     return *this;
 }
 // Von Neumann Wrap
-__device__ inline MessageArray3D::In::VonNeumannWrapFilter::VonNeumannWrapFilter(const MetaData *_metadata, const size_type &x, const size_type &y, const size_type &z, const size_type &_radius)
+__device__ inline MessageArray3D::In::VonNeumannWrapFilter::VonNeumannWrapFilter(const MetaData *_metadata, const size_type x, const size_type y, const size_type z, const size_type _radius)
     : radius(static_cast<int>(_radius))
     , metadata(_metadata) {
     loc[0] = x;
@@ -1624,7 +1624,7 @@ __device__ inline MessageArray3D::In::VonNeumannWrapFilter::Message& MessageArra
     return *this;
 }
 // Von Neumann
-__device__ inline MessageArray3D::In::VonNeumannFilter::VonNeumannFilter(const MetaData* _metadata, const size_type& x, const size_type& y, const size_type& z, const size_type& _radius)
+__device__ inline MessageArray3D::In::VonNeumannFilter::VonNeumannFilter(const MetaData* _metadata, const size_type x, const size_type y, const size_type z, const size_type _radius)
     : radius(static_cast<int>(_radius))
     , metadata(_metadata) {
     loc[0] = x;

--- a/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
@@ -974,7 +974,7 @@ class MessageArray3D::In {
          * @param z Search origin z coord
          * @param _radius Search radius
          */
-        inline __device__ VonNeumannFilter(const MetaData* _metadata, size_type& x, size_type& y, size_type& z, size_type& _radius);
+        inline __device__ VonNeumannFilter(const MetaData* _metadata, size_type x, size_type y, size_type z, size_type _radius);
 #if !defined(SEATBELTS) || SEATBELTS
         /**
          * A null filter which always returns 0 messages

--- a/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DHost.h
@@ -146,7 +146,7 @@ class MessageArray3D::Description : public MessageBruteForce::Description {
      Description& operator=(Description &&other_message) noexcept = delete;
 
  public:
-    void setDimensions(const size_type &len_x, const size_type &len_y, const size_type &len_Z);
+    void setDimensions(size_type len_x, size_type len_y, size_type len_Z);
     void setDimensions(const std::array<size_type, 3> &dims);
 
     std::array<size_type, 3> getDimensions() const;

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh
@@ -125,7 +125,7 @@ class MessageBruteForce::In {
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
         template<typename T, MessageNone::size_type N, unsigned int M> __device__
-        T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
+        T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
 
     /**
@@ -210,7 +210,7 @@ class MessageBruteForce::Out {
      * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N, unsigned int M>
-    __device__ void setVariable(const char(&variable_name)[M], const unsigned int& index, T value) const;
+    __device__ void setVariable(const char(&variable_name)[M], unsigned int index, T value) const;
 
  protected:
     /**
@@ -237,7 +237,7 @@ __device__ T MessageBruteForce::In::Message::getVariable(const char(&variable_na
     return value;
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageBruteForce::In::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageBruteForce::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
     const unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;
 #if !defined(SEATBELTS) || SEATBELTS
@@ -275,7 +275,7 @@ __device__ void MessageBruteForce::Out::setVariable(const char(&variable_name)[N
     this->scan_flag[index] = 1;
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ void MessageBruteForce::Out::setVariable(const char(&variable_name)[M], const unsigned int& array_index, T value) const {
+__device__ void MessageBruteForce::Out::setVariable(const char(&variable_name)[M], const unsigned int array_index, T value) const {
     if (variable_name[0] == '_') {
 #if !defined(SEATBELTS) || SEATBELTS
         DTHROW("Variable names starting with '_' are reserved for internal use, with '%s', in MessageBruteForce::Out::setVariable().\n", variable_name);

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
@@ -232,7 +232,7 @@ class MessageBruteForce::Description {
      * @throws exception::InvalidMessageVar If length is <= 0
      */
     template<typename T>
-    void newVariableArray(const std::string& variable_name, const size_type& length);
+    void newVariableArray(const std::string& variable_name, size_type length);
 #endif
     /**
      * @return The message's name
@@ -301,7 +301,7 @@ void MessageBruteForce::Description::newVariable(const std::string& variable_nam
 }
 #ifdef SWIG
 template<typename T>
-void MessageBruteForce::Description::newVariableArray(const std::string& variable_name, const size_type& length) {
+void MessageBruteForce::Description::newVariableArray(const std::string& variable_name, const size_type length) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Message variable names cannot begin with '_', this is reserved for internal usage, "
             "in MessageDescription::newVariable().");

--- a/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketDevice.cuh
@@ -89,7 +89,7 @@ class MessageBucket::In {
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
             template<typename T, MessageNone::size_type N, unsigned int M> __device__
-            T getVariable(const char(&variable_name)[M], const unsigned int &index) const;
+            T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
         * Stock iterator for iterating MessageBucket::In::Filter::Message objects
@@ -330,7 +330,7 @@ __device__ T MessageBucket::In::Filter::Message::getVariable(const char(&variabl
     return value;
 }
 template<typename T, MessageNone::size_type N, unsigned int M> __device__
-T MessageBucket::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int& array_index) const {
+T MessageBucket::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
     if (cell_index >= _parent.bucket_end) {

--- a/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketHost.h
@@ -72,7 +72,7 @@ class MessageBucket::CUDAModelHandler : public MessageSpecialisationHandler {
     * @param newSize The new number of agents to represent
     * @note This only scales upwards, it will never reduce the size
     */
-    void resizeKeysVals(const unsigned int &newSize);
+    void resizeKeysVals(unsigned int newSize);
     /**
     * upperBound-lowerBound
     */

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h
@@ -73,7 +73,7 @@ class MessageSpatial2D::CUDAModelHandler : public MessageSpecialisationHandler {
      * @param newSize The new number of agents to represent
      * @note This only scales upwards, it will never reduce the size
      */
-    void resizeKeysVals(const unsigned int &newSize);
+    void resizeKeysVals(unsigned int newSize);
     /**
      * Number of bins, arrays are +1 this length
      */

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h
@@ -184,13 +184,13 @@ class MessageSpatial2D::Description : public MessageBruteForce::Description {
     Description& operator=(Description &&other_message) noexcept = delete;
 
  public:
-    void setRadius(const float &r);
-    void setMinX(const float &x);
-    void setMinY(const float &y);
-    void setMin(const float &x, const float &y);
-    void setMaxX(const float &x);
-    void setMaxY(const float &y);
-    void setMax(const float &x, const float &y);
+    void setRadius(float r);
+    void setMinX(float x);
+    void setMinY(float y);
+    void setMin(float x, float y);
+    void setMaxX(float x);
+    void setMaxY(float y);
+    void setMax(float x, float y);
 
     float getRadius() const;
     float getMinX() const;

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
@@ -74,7 +74,7 @@ class MessageSpatial3D::CUDAModelHandler : public MessageSpecialisationHandler {
      * @param newSize The new number of agents to represent
      * @note This only scales upwards, it will never reduce the size
      */
-    void resizeKeysVals(const unsigned int &newSize);
+    void resizeKeysVals(unsigned int newSize);
     /**
      * Number of bins, arrays are +1 this length
      */

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h
@@ -182,15 +182,15 @@ class MessageSpatial3D::Description : public MessageBruteForce::Description {
     Description& operator=(Description &&other_message) noexcept = delete;
 
  public:
-    void setRadius(const float &r);
-    void setMinX(const float &x);
-    void setMinY(const float &y);
-    void setMinZ(const float &z);
-    void setMin(const float &x, const float &y, const float &z);
-    void setMaxX(const float &x);
-    void setMaxY(const float &y);
-    void setMaxZ(const float &z);
-    void setMax(const float &x, const float &y, const float &z);
+    void setRadius(float r);
+    void setMinX(float x);
+    void setMinY(float y);
+    void setMinZ(float z);
+    void setMin(float x, float y, float z);
+    void setMaxX(float x);
+    void setMaxY(float y);
+    void setMaxZ(float z);
+    void setMax(float x, float y, float z);
 
     float getRadius() const;
     float getMinX() const;

--- a/include/flamegpu/runtime/utility/AgentRandom.cuh
+++ b/include/flamegpu/runtime/utility/AgentRandom.cuh
@@ -41,7 +41,7 @@ class AgentRandom {
      * @note Available as float or double
      */
     template<typename T>
-    __forceinline__ __device__ T logNormal(const T& mean, const T& stddev) const;
+    __forceinline__ __device__ T logNormal(T mean, T stddev) const;
     /**
      * Returns an integer uniformly distributed in the inclusive range [min, max]
      * or
@@ -50,7 +50,7 @@ class AgentRandom {
      * @note Available as signed and unsigned: char, short, int, long long, float, double
      */
     template<typename T>
-    __forceinline__ __device__ T uniform(const T& min, const T& max) const;
+    __forceinline__ __device__ T uniform(T min, T max) const;
 
  private:
     /**
@@ -91,19 +91,19 @@ __forceinline__ __device__ double AgentRandom::normal() const {
  * Log Normal floating point
  */
 template<>
-__forceinline__ __device__ float AgentRandom::logNormal(const float& mean, const float& stddev) const {
+__forceinline__ __device__ float AgentRandom::logNormal(const float mean, const float stddev) const {
     return curand_log_normal(d_random_state, mean, stddev);
 }
 template<>
-__forceinline__ __device__ double AgentRandom::logNormal(const double& mean, const double& stddev) const {
+__forceinline__ __device__ double AgentRandom::logNormal(const double mean, const double stddev) const {
     return curand_log_normal_double(d_random_state, mean, stddev);
 }
 /**
 * Uniform Range
 */
 template<typename T>
-__forceinline__ __device__ T AgentRandom::uniform(const T& min, const T& max) const {
-    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for AgentRandom::uniform(const T& lowerBound, const T& max)");
+__forceinline__ __device__ T AgentRandom::uniform(T min, T max) const {
+    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for AgentRandom::uniform(T lowerBound, T max)");
 #if !defined(SEATBELTS) || SEATBELTS
     if (min > max) {
         DTHROW("Invalid arguments passed to AgentRandom::uniform(), %lld > %lld\n", static_cast<int64_t>(min), static_cast<int64_t>(max));
@@ -121,7 +121,7 @@ __forceinline__ __device__ int64_t AgentRandom::uniform(const int64_t& min, cons
     return static_cast<int64_t>(min + (max - min) * uniform<double>());
 }
 template<>
-__forceinline__ __device__ uint64_t AgentRandom::uniform(const uint64_t& min, const uint64_t& max) const {
+__forceinline__ __device__ uint64_t AgentRandom::uniform(const uint64_t min, const uint64_t max) const {
 #if !defined(SEATBELTS) || SEATBELTS
     if (min > max) {
         DTHROW("Invalid arguments passed to AgentRandom::uniform(), %lld > %lld\n", static_cast<int64_t>(min), static_cast<int64_t>(max));
@@ -130,7 +130,7 @@ __forceinline__ __device__ uint64_t AgentRandom::uniform(const uint64_t& min, co
     return static_cast<uint64_t>(min + (max - min) * uniform<double>());
 }
 template<>
-__forceinline__ __device__ float AgentRandom::uniform(const float& min, const float& max) const {
+__forceinline__ __device__ float AgentRandom::uniform(const float min, const float max) const {
 #if !defined(SEATBELTS) || SEATBELTS
     if (min > max) {
         DTHROW("Invalid arguments passed to AgentRandom::uniform(), %f > %f\n", min, max);
@@ -139,7 +139,7 @@ __forceinline__ __device__ float AgentRandom::uniform(const float& min, const fl
     return min + (max - min) * uniform<float>();
 }
 template<>
-__forceinline__ __device__ double AgentRandom::uniform(const double& min, const double& max) const {
+__forceinline__ __device__ double AgentRandom::uniform(const double min, const double max) const {
 #if !defined(SEATBELTS) || SEATBELTS
     if (min > max) {
         DTHROW("Invalid arguments passed to AgentRandom::uniform(), %f > %f\n", min, max);

--- a/include/flamegpu/runtime/utility/AgentRandom.cuh
+++ b/include/flamegpu/runtime/utility/AgentRandom.cuh
@@ -112,7 +112,7 @@ __forceinline__ __device__ T AgentRandom::uniform(T min, T max) const {
     return static_cast<T>(min + (max - min) * uniform<float>());
 }
 template<>
-__forceinline__ __device__ int64_t AgentRandom::uniform(const int64_t& min, const int64_t& max) const {
+__forceinline__ __device__ int64_t AgentRandom::uniform(const int64_t min, const int64_t max) const {
 #if !defined(SEATBELTS) || SEATBELTS
     if (min > max) {
         DTHROW("Invalid arguments passed to AgentRandom::uniform(), %lld > %lld\n", static_cast<int64_t>(min), static_cast<int64_t>(max));

--- a/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/DeviceEnvironment.cuh
@@ -48,7 +48,7 @@ class ReadOnlyDeviceEnvironment {
      * @throws exception::DeviceError If N does not match the length of the environment property array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
      */
     template<typename T, unsigned int N = 0, unsigned int M>
-    __device__ __forceinline__ T getProperty(const char(&name)[M], const unsigned int&index) const;
+    __device__ __forceinline__ T getProperty(const char(&name)[M], unsigned int index) const;
     /**
      * Returns a read-only accessor to the named macro property
      * @param name name used for accessing the property, this value should be a string literal e.g. "foobar"
@@ -92,7 +92,7 @@ __device__ __forceinline__ T ReadOnlyDeviceEnvironment::getProperty(const char(&
     return detail::curve::DeviceCurve::getEnvironmentProperty<T>(name);
 }
 template<typename T, unsigned int N, unsigned int M>
-__device__ __forceinline__ T ReadOnlyDeviceEnvironment::getProperty(const char(&name)[M], const unsigned int &index) const {
+__device__ __forceinline__ T ReadOnlyDeviceEnvironment::getProperty(const char(&name)[M], const unsigned int index) const {
     return detail::curve::DeviceCurve::getEnvironmentArrayProperty<T, N>(name,  index);
 }
 

--- a/include/flamegpu/runtime/utility/DeviceMacroProperty.cuh
+++ b/include/flamegpu/runtime/utility/DeviceMacroProperty.cuh
@@ -113,7 +113,7 @@ class DeviceMacroProperty : public ReadOnlyDeviceMacroProperty<T, I, J, K, W> {
      * Note, taking value of the returned object will fail, due to the risk of atomic conflicts
      * @note Only suitable where T is type int32_t, uint32_t, uint64_t, float, double
      */
-    __device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& operator +=(const T& val);
+    __device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& operator +=(T val);
     /**
      * atomic subtraction
      * @param val The 2nd operand
@@ -121,19 +121,19 @@ class DeviceMacroProperty : public ReadOnlyDeviceMacroProperty<T, I, J, K, W> {
      * Note, taking value of the returned object will fail, due to the risk of atomic conflicts
      * @note Only suitable where T is type int32_t or uint32_t
      */
-    __device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& operator -=(const T& val);
+    __device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& operator -=(T val);
     /**
      * atomic add
      * @param val The 2nd operand
      * @return (this + val)
      */
-    __device__ __forceinline__ T operator+(const T& val) const;
+    __device__ __forceinline__ T operator+(T val) const;
     /**
      * atomic subtraction
      * @param val The 2nd operand
      * @return (this - val)
      */
-    __device__ __forceinline__ T operator-(const T& val) const;
+    __device__ __forceinline__ T operator-(T val) const;
     /**
      * atomic pre-increment
      * @return the value after the increment operation is performed
@@ -280,7 +280,7 @@ __device__ __forceinline__ ReadOnlyDeviceMacroProperty<T, I, J, K, W>::operator 
     return *this->ptr;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
-__device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& DeviceMacroProperty<T, I, J, K, W>::operator+=(const T& val) {
+__device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& DeviceMacroProperty<T, I, J, K, W>::operator+=(const T val) {
     static_assert(std::is_same<T, int32_t>::value ||
         std::is_same<T, uint32_t>::value ||
         std::is_same<T, uint64_t>::value ||
@@ -299,7 +299,7 @@ __device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& DeviceMacroProper
     return *this;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
-__device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& DeviceMacroProperty<T, I, J, K, W>::operator-=(const T& val) {
+__device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& DeviceMacroProperty<T, I, J, K, W>::operator-=(const T val) {
     static_assert(std::is_same<T, uint32_t>::value || std::is_same<T, int32_t>::value, "atomic subtract only supports the types int32_t/uint32_t.");
 #if !defined(SEATBELTS) || SEATBELTS
     if (I != 1 || J != 1 || K != 1 || W != 1) {
@@ -314,7 +314,7 @@ __device__ __forceinline__ DeviceMacroProperty<T, I, J, K, W>& DeviceMacroProper
     return *this;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
-__device__ __forceinline__ T DeviceMacroProperty<T, I, J, K, W>::operator+(const T& val) const {
+__device__ __forceinline__ T DeviceMacroProperty<T, I, J, K, W>::operator+(const T val) const {
 #if !defined(SEATBELTS) || SEATBELTS
     if (I != 1 || J != 1 || K != 1 || W != 1) {
         DTHROW("Indexing error, property has more dimensions.\n");
@@ -327,7 +327,7 @@ __device__ __forceinline__ T DeviceMacroProperty<T, I, J, K, W>::operator+(const
     return *this->ptr + val;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
-__device__ __forceinline__ T DeviceMacroProperty<T, I, J, K, W>::operator-(const T& val) const {
+__device__ __forceinline__ T DeviceMacroProperty<T, I, J, K, W>::operator-(const T val) const {
 #if !defined(SEATBELTS) || SEATBELTS
     if (I != 1 || J != 1 || K != 1 || W != 1) {
         DTHROW("Indexing error, property has more dimensions.\n");

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -56,7 +56,7 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
          * @param _elements How many elements does the stored data contain (1 if not array)
          * @param _type Type of property (from typeid())
          */
-        EnvProp(const ptrdiff_t& _offset, const size_t& _length, const bool& _isConst, const size_type& _elements, const std::type_index& _type)
+        EnvProp(const ptrdiff_t& _offset, const size_t& _length, const bool _isConst, const size_type& _elements, const std::type_index& _type)
             : offset(_offset),
             length(_length),
             isConst(_isConst),
@@ -98,7 +98,7 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
         * @param _elements How many elements does the stored data contain (1 if not array)
         * @param _type Type of property (from typeid())
         */
-        DefragProp(void *_data, const size_t &_length, const bool &_isConst, const size_type &_elements, const std::type_index &_type)
+        DefragProp(void *_data, const size_t &_length, bool _isConst, const size_type &_elements, const std::type_index &_type)
             : data(_data),
             length(_length),
             isConst(_isConst),

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -56,7 +56,7 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
          * @param _elements How many elements does the stored data contain (1 if not array)
          * @param _type Type of property (from typeid())
          */
-        EnvProp(const ptrdiff_t& _offset, const size_t& _length, const bool _isConst, const size_type& _elements, const std::type_index& _type)
+        EnvProp(const ptrdiff_t& _offset, const size_t& _length, const bool _isConst, const size_type _elements, const std::type_index& _type)
             : offset(_offset),
             length(_length),
             isConst(_isConst),
@@ -98,7 +98,7 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
         * @param _elements How many elements does the stored data contain (1 if not array)
         * @param _type Type of property (from typeid())
         */
-        DefragProp(void *_data, const size_t &_length, bool _isConst, const size_type &_elements, const std::type_index &_type)
+        DefragProp(void *_data, const size_t &_length, bool _isConst, const size_type _elements, const std::type_index &_type)
             : data(_data),
             length(_length),
             isConst(_isConst),

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -56,7 +56,7 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
          * @param _elements How many elements does the stored data contain (1 if not array)
          * @param _type Type of property (from typeid())
          */
-        EnvProp(const ptrdiff_t& _offset, const size_t& _length, const bool _isConst, const size_type _elements, const std::type_index& _type)
+        EnvProp(const ptrdiff_t& _offset, const size_t _length, const bool _isConst, const size_type _elements, const std::type_index& _type)
             : offset(_offset),
             length(_length),
             isConst(_isConst),
@@ -98,7 +98,7 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
         * @param _elements How many elements does the stored data contain (1 if not array)
         * @param _type Type of property (from typeid())
         */
-        DefragProp(void *_data, const size_t &_length, bool _isConst, const size_type _elements, const std::type_index &_type)
+        DefragProp(void *_data, const size_t _length, bool _isConst, const size_type _elements, const std::type_index &_type)
             : data(_data),
             length(_length),
             isConst(_isConst),
@@ -116,8 +116,8 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
      * Transparent operators for DefragMap
      * This allows them to be secondarily ordered based on name if size is equal
      */
-    friend bool operator<(const std::pair<size_t, std::string>& fk, const size_t& lk) { return fk.first < lk; }
-    friend bool operator<(const size_t& lk, const std::pair<size_t, std::string>& fk) { return lk < fk.first; }
+    friend bool operator<(const std::pair<size_t, std::string>& fk, const size_t lk) { return fk.first < lk; }
+    friend bool operator<(const size_t lk, const std::pair<size_t, std::string>& fk) { return lk < fk.first; }
     friend bool operator<(const std::pair<size_t, std::string>& fk1, const std::pair<size_t, std::string>& fk2) {
         if (fk1.first == fk2.first) {
             // If size is equal, order by name

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -80,7 +80,7 @@ class HostEnvironment {
      * @see get(const std::string &)
      */
     template<typename T, EnvironmentManager::size_type N = 0>
-    T getProperty(const std::string &name, const EnvironmentManager::size_type &index) const;
+    T getProperty(const std::string &name, EnvironmentManager::size_type index) const;
 #ifdef SWIG
     /**
      * Gets an environment property array
@@ -101,7 +101,7 @@ class HostEnvironment {
      * @throws exception::ReadOnlyEnvProperty If the named property is marked as const
      */
     template<typename T>
-    T setProperty(const std::string &name, const T &value) const;
+    T setProperty(const std::string &name, T value) const;
     /**
      * Sets an environment property array
      * @param name name used for accessing the property array
@@ -127,7 +127,7 @@ class HostEnvironment {
      * @see get(const std::string &)
      */
     template<typename T, EnvironmentManager::size_type N = 0>
-    T setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) const;
+    T setProperty(const std::string &name, EnvironmentManager::size_type index, T value) const;
 #ifdef SWIG
     /**
      * Sets an environment property array
@@ -161,7 +161,7 @@ class HostEnvironment {
  * Setters
  */
 template<typename T>
-T HostEnvironment::setProperty(const std::string &name, const T &value) const {
+T HostEnvironment::setProperty(const std::string &name, const T value) const {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in HostEnvironment::set().");
@@ -177,7 +177,7 @@ std::array<T, N> HostEnvironment::setProperty(const std::string &name, const std
     return env_mgr->setProperty<T, N>(name, value);
 }
 template<typename T, EnvironmentManager::size_type N>
-T HostEnvironment::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) const {
+T HostEnvironment::setProperty(const std::string &name, EnvironmentManager::size_type index, const T value) const {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in HostEnvironment::set().");
@@ -207,7 +207,7 @@ std::array<T, N> HostEnvironment::getProperty(const std::string &name) const  {
     return env_mgr->getProperty<T, N>(name);
 }
 template<typename T, EnvironmentManager::size_type N>
-T HostEnvironment::getProperty(const std::string &name, const EnvironmentManager::size_type &index) const  {
+T HostEnvironment::getProperty(const std::string &name, const EnvironmentManager::size_type index) const  {
     return env_mgr->getProperty<T, N>(name, index);
 }
 #ifdef SWIG

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -36,7 +36,7 @@ class HostEnvironment {
     /**
      * Constructor, to be called by HostAPI
      */
-    explicit HostEnvironment(const unsigned int &instance_id, const std::shared_ptr<EnvironmentManager> &env, CUDAMacroEnvironment &_macro_env);
+    explicit HostEnvironment(unsigned int instance_id, const std::shared_ptr<EnvironmentManager> &env, CUDAMacroEnvironment &_macro_env);
     /**
      * Provides access to EnvironmentManager singleton
      */

--- a/include/flamegpu/runtime/utility/HostMacroProperty.cuh
+++ b/include/flamegpu/runtime/utility/HostMacroProperty.cuh
@@ -112,7 +112,7 @@ class HostMacroProperty {
      * @param val New value of the element
      * @throws exception::InvalidOperation If template arguments I, J, K , W are not all 1. Which denotes the macro property has more dimensions remaining to be indexed. 
      */
-    HostMacroProperty<T, I, J, K, W>& operator=(const T &val);
+    HostMacroProperty<T, I, J, K, W>& operator=(T val);
     /**
      * Zero's the selected area of the array
      */
@@ -132,30 +132,30 @@ class HostMacroProperty {
      * Arithmetic operators
      */
     template<typename T2>
-    auto operator+(const T2& b) const;
+    auto operator+(T2 b) const;
     template<typename T2>
-    auto operator-(const T2& b) const;
+    auto operator-(T2 b) const;
     template<typename T2>
-    auto operator*(const T2& b) const;
+    auto operator*(T2 b) const;
     template<typename T2>
-    auto operator/(const T2& b) const;
+    auto operator/(T2 b) const;
     template<typename T2>
-    auto operator%(const T2& b) const;
+    auto operator%(T2 b) const;
 #endif
     /**
      * Assignment operators
      */
-    // HostMacroProperty<T, I, J, K, W>& operator=(const T& b);  // Defined above
+    // HostMacroProperty<T, I, J, K, W>& operator=(T b);  // Defined above
     template<typename T2>
-    HostMacroProperty<T, I, J, K, W>& operator+=(const T2& b);
+    HostMacroProperty<T, I, J, K, W>& operator+=(T2 b);
     template<typename T2>
-    HostMacroProperty<T, I, J, K, W>& operator-=(const T2& b);
+    HostMacroProperty<T, I, J, K, W>& operator-=(T2 b);
     template<typename T2>
-    HostMacroProperty<T, I, J, K, W>& operator*=(const T2& b);
+    HostMacroProperty<T, I, J, K, W>& operator*=(T2 b);
     template<typename T2>
-    HostMacroProperty<T, I, J, K, W>& operator/=(const T2& b);
+    HostMacroProperty<T, I, J, K, W>& operator/=(T2 b);
     template<typename T2>
-    HostMacroProperty<T, I, J, K, W>& operator%=(const T2& b);
+    HostMacroProperty<T, I, J, K, W>& operator%=(T2 b);
 
  private:
     /**
@@ -210,7 +210,7 @@ class HostMacroProperty_swig {
      * @throws exception::OutOfBoundsException If i >= I.
      * @throws exception::InvalidOperation If the macro property has no dimensions remaining to be indexed.
      */
-    void __setitem__(unsigned int i,  const T &val);
+    void __setitem__(unsigned int i,  T val);
     /**
      * Explicit set method, as we lack operator= in python
      */
@@ -221,12 +221,12 @@ class HostMacroProperty_swig {
     double __float__();
     bool __bool__();
 
-    bool __eq__(const T& other) const;
-    bool __ne__(const T &other) const;
-    bool __lt__(const T& other) const;
-    bool __le__(const T& other) const;
-    bool __gt__(const T& other) const;
-    bool __ge__(const T& other) const;
+    bool __eq__(T other) const;
+    bool __ne__(T other) const;
+    bool __lt__(T other) const;
+    bool __le__(T other) const;
+    bool __gt__(T other) const;
+    bool __ge__(T other) const;
 
     /**
      * Required for iterable
@@ -345,64 +345,64 @@ T HostMacroProperty<T, I, J, K, W>::operator--(int) {
 #ifndef SWIG
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-auto HostMacroProperty<T, I, J, K, W>::operator+(const T2& b) const {
+auto HostMacroProperty<T, I, J, K, W>::operator+(const T2 b) const {
     return _get() + b;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-auto HostMacroProperty<T, I, J, K, W>::operator-(const T2& b) const {
+auto HostMacroProperty<T, I, J, K, W>::operator-(const T2 b) const {
     return _get() - b;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-auto HostMacroProperty<T, I, J, K, W>::operator*(const T2& b) const {
+auto HostMacroProperty<T, I, J, K, W>::operator*(const T2 b) const {
     return _get() * b;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-auto HostMacroProperty<T, I, J, K, W>::operator/(const T2& b) const {
+auto HostMacroProperty<T, I, J, K, W>::operator/(const T2 b) const {
     return _get() / b;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-auto HostMacroProperty<T, I, J, K, W>::operator%(const T2& b) const {
+auto HostMacroProperty<T, I, J, K, W>::operator%(const T2 b) const {
     return _get() % b;
 }
 #endif
 
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator+=(const T2& b) {
+HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator+=(const T2 b) {
     _get() += b;
     return *this;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator-=(const T2& b) {
+HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator-=(const T2 b) {
     _get() -= b;
     return *this;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator*=(const T2& b) {
+HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator*=(const T2 b) {
     _get() *= b;
     return *this;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator/=(const T2& b) {
+HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator/=(const T2 b) {
     _get() /= b;
     return *this;
 }
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 template<typename T2>
-HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator%=(const T2& b) {
+HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator%=(const T2 b) {
     _get() %= b;
     return *this;
 }
 
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
-HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator=(const T& val) {
+HostMacroProperty<T, I, J, K, W>& HostMacroProperty<T, I, J, K, W>::operator=(const T val) {
     if (I != 1 || J != 1 || K != 1 || W != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -458,7 +458,7 @@ void HostMacroProperty_swig<T>::set(T val) {
     metadata->has_changed = true;
 }
 template<typename T>
-void HostMacroProperty_swig<T>::__setitem__(unsigned int i, const T& val) {
+void HostMacroProperty_swig<T>::__setitem__(unsigned int i, const T val) {
     if (dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     } else if (i >= dimensions[0]) {
@@ -502,7 +502,7 @@ bool HostMacroProperty_swig<T>::__bool__() {
     return static_cast<bool>(reinterpret_cast<T*>(metadata->h_base_ptr)[offset]);
 }
 template<typename T>
-bool HostMacroProperty_swig<T>::__eq__(const T& other) const {
+bool HostMacroProperty_swig<T>::__eq__(const T other) const {
     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -510,7 +510,7 @@ bool HostMacroProperty_swig<T>::__eq__(const T& other) const {
     return reinterpret_cast<T*>(metadata->h_base_ptr)[offset] == other;
 }
 template<typename T>
-bool HostMacroProperty_swig<T>::__ne__(const T& other) const {
+bool HostMacroProperty_swig<T>::__ne__(const T other) const {
     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -518,7 +518,7 @@ bool HostMacroProperty_swig<T>::__ne__(const T& other) const {
     return reinterpret_cast<T*>(metadata->h_base_ptr)[offset] != other;
 }
 template<typename T>
-bool HostMacroProperty_swig<T>::__lt__(const T& other) const {
+bool HostMacroProperty_swig<T>::__lt__(const T other) const {
     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -526,7 +526,7 @@ bool HostMacroProperty_swig<T>::__lt__(const T& other) const {
     return reinterpret_cast<T*>(metadata->h_base_ptr)[offset] < other;
 }
 template<typename T>
-bool HostMacroProperty_swig<T>::__le__(const T& other) const {
+bool HostMacroProperty_swig<T>::__le__(const T other) const {
     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -534,7 +534,7 @@ bool HostMacroProperty_swig<T>::__le__(const T& other) const {
     return reinterpret_cast<T*>(metadata->h_base_ptr)[offset] <= other;
 }
 template<typename T>
-bool HostMacroProperty_swig<T>::__gt__(const T& other) const {
+bool HostMacroProperty_swig<T>::__gt__(const T other) const {
     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -542,7 +542,7 @@ bool HostMacroProperty_swig<T>::__gt__(const T& other) const {
     return reinterpret_cast<T*>(metadata->h_base_ptr)[offset] > other;
 }
 template<typename T>
-bool HostMacroProperty_swig<T>::__ge__(const T& other) const {
+bool HostMacroProperty_swig<T>::__ge__(const T other) const {
     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
     }
@@ -550,7 +550,7 @@ bool HostMacroProperty_swig<T>::__ge__(const T& other) const {
     return reinterpret_cast<T*>(metadata->h_base_ptr)[offset] >= other;
 }
 // template<typename T>
-// T HostMacroProperty_swig<T>::__mod__(const T& other) {
+// T HostMacroProperty_swig<T>::__mod__(const T other) {
 //     if (dimensions[0] != 1 || dimensions[1] != 1 || dimensions[2] != 1 || dimensions[3] != 1) {
 //         THROW exception::InvalidOperation("Indexing error, property has more dimensions.\n");
 //     }

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -38,7 +38,7 @@ class HostRandom {
     * @note Available as float or double
     */
     template<typename T>
-    inline T logNormal(const T mean, const T stddev) const;
+    inline T logNormal(T mean, T stddev) const;
     /**
      * Returns an integer uniformly distributed in the inclusive range [min, max]
      * or

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -38,7 +38,7 @@ class HostRandom {
     * @note Available as float or double
     */
     template<typename T>
-    inline T logNormal(const T& mean, const T& stddev) const;
+    inline T logNormal(const T mean, const T stddev) const;
     /**
      * Returns an integer uniformly distributed in the inclusive range [min, max]
      * or
@@ -47,12 +47,12 @@ class HostRandom {
      * @note Available as signed and unsigned: char, short, int, long long
      */
     template<typename T>
-    inline T uniform(const T& min, const T& max) const;
+    inline T uniform(T min, T max) const;
     /**
      * Change the seed used for random generation
      * @param seed New random seed
      */
-    void setSeed(const uint64_t &seed);
+    void setSeed(uint64_t seed);
     /**
      * Returns the last value used to seed random generation
      */
@@ -80,15 +80,15 @@ inline T HostRandom::normal() const {
 }
 
 template<typename T>
-inline T HostRandom::logNormal(const T& mean, const T& stddev) const {
-    static_assert(util::detail::StaticAssert::_Is_RealType<T>::value, "Invalid template argument for HostRandom::logNormal(const T& mean, const T& stddev)");
+inline T HostRandom::logNormal(const T mean, const T stddev) const {
+    static_assert(util::detail::StaticAssert::_Is_RealType<T>::value, "Invalid template argument for HostRandom::logNormal(T mean, T stddev)");
     std::lognormal_distribution<T> dist(mean, stddev);
     return rng.getDistribution<T>(dist);
 }
 
 template<typename T>
-inline T HostRandom::uniform(const T& min, const T& max) const {
-    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for HostRandom::uniform(const T& lowerBound, const T& max)");
+inline T HostRandom::uniform(const T min, const T max) const {
+    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for HostRandom::uniform(T lowerBound, T max)");
     std::uniform_int_distribution<T> dist(min, max);
     return rng.getDistribution<T>(dist);
 }
@@ -109,17 +109,17 @@ inline unsigned char HostRandom::uniform(const unsigned char min, const unsigned
 }
 
 template<>
-inline signed char HostRandom::uniform(const signed char& min, const signed char& max) const {
+inline signed char HostRandom::uniform(const signed char min, const signed char max) const {
     std::uniform_int_distribution<int16_t> dist(min, max);
     return static_cast<signed char>(rng.getDistribution<int16_t>(dist));
 }
 template<>
-inline float HostRandom::uniform(const float& min, const float& max) const {
+inline float HostRandom::uniform(const float min, const float max) const {
     std::uniform_real_distribution<float> dist(min, max);
     return rng.getDistribution<float>(dist);
 }
 template<>
-inline double HostRandom::uniform(const double& min, const double& max) const {
+inline double HostRandom::uniform(const double min, const double max) const {
     std::uniform_real_distribution<double> dist(min, max);
     return rng.getDistribution<double>(dist);
 }

--- a/include/flamegpu/runtime/utility/HostRandom.cuh
+++ b/include/flamegpu/runtime/utility/HostRandom.cuh
@@ -97,13 +97,13 @@ inline T HostRandom::uniform(const T& min, const T& max) const {
  * Special cases, std::random doesn't support char, emulate behaviour
  */
 template<>
-inline char HostRandom::uniform(const char& min, const char& max) const {
+inline char HostRandom::uniform(const char min, const char max) const {
     std::uniform_int_distribution<int16_t> dist(min, max);
     return static_cast<char>(rng.getDistribution<int16_t>(dist));
 }
 
 template<>
-inline unsigned char HostRandom::uniform(const unsigned char& min, const unsigned char& max) const {
+inline unsigned char HostRandom::uniform(const unsigned char min, const unsigned char max) const {
     std::uniform_int_distribution<uint16_t> dist(min, max);
     return static_cast<unsigned char>(rng.getDistribution<uint16_t>(dist));
 }

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -120,7 +120,7 @@ class RandomManager {
      * If shrinking, 'deallocated' curand states are backed up to host until next required,
      *  this prevents them being reinitialised with the same seed.
      */
-    void resizeDeviceArray(const size_type &_length, cudaStream_t stream);
+    void resizeDeviceArray(size_type _length, cudaStream_t stream);
     /**
      * Host copy of 'deallocated' curand states
      * When the device array shrinks in size, shrunk away curand states are stored here

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -53,7 +53,7 @@ class RandomManager {
      * Reseeds all owned random generators
      * @note Can be called multiple times to reseed, doing so releases existing memory allocations
      */
-    void reseed(const uint64_t &seed);
+    void reseed(uint64_t seed);
     /**
      * Resizes random array according to the rules:
      *   while(length<_length)

--- a/include/flamegpu/sim/LogFrame.h
+++ b/include/flamegpu/sim/LogFrame.h
@@ -34,7 +34,7 @@ struct LogFrame {
      */
     LogFrame(const std::map<std::string, util::Any> &_environment,
     const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>> &_agents,
-    const unsigned int &_step_count);
+    unsigned int _step_count);
     /**
      * Returns the step count of the log
      * 0 is the state prior to the first step
@@ -92,7 +92,7 @@ struct StepLogFrame : public LogFrame {
      */
     StepLogFrame(const std::map<std::string, util::Any>&& _environment,
         const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>>&& _agents,
-        const unsigned int& _step_count);
+        unsigned int _step_count);
 
     /**
      * Return the execution time of the associated step, in seconds
@@ -123,7 +123,7 @@ struct ExitLogFrame : public LogFrame {
      */
     ExitLogFrame(const std::map<std::string, util::Any>&& _environment,
         const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>>&& _agents,
-        const unsigned int& _step_count);
+        unsigned int _step_count);
 
     /**
      * Return the runtime compilation time, in seconds
@@ -267,7 +267,7 @@ struct AgentLogFrame {
      * @param data Map of reduction data
      * @param count Population size (alive agents)
      */
-    explicit AgentLogFrame(const std::map<LoggingConfig::NameReductionFn, util::Any> &data, const unsigned int &count);
+    explicit AgentLogFrame(const std::map<LoggingConfig::NameReductionFn, util::Any> &data, unsigned int count);
     /**
      * Return the number of alive agents in the population
      * @return The population size
@@ -335,7 +335,7 @@ struct AgentLogFrame {
     /**
      * Population size of the related agent state
      */
-    const unsigned int &count;
+    const unsigned int count;
 };
 
 template<typename T>

--- a/include/flamegpu/sim/LoggingConfig.h
+++ b/include/flamegpu/sim/LoggingConfig.h
@@ -181,7 +181,7 @@ class StepLoggingConfig : public LoggingConfig {
      * How many steps between each log collection, defaults to 1, so a log is collected every step
      * A value of 0 disables step log collection
      */
-    void setFrequency(const unsigned int &steps);
+    void setFrequency(unsigned int steps);
 
  private:
     /**

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -53,7 +53,7 @@ class RunPlan {
      * A steps value of 0 requires the ModelDescription to have atleast 1 exit condition
      * @param steps The number of steps to execute, 0 is unlimited but requires an exit condition
      */
-    void setSteps(const unsigned int &steps);
+    void setSteps(unsigned int steps);
     /**
      * Set the sub directory within the output directory for outputs of this run
      * If left empty, output will not goto subdirectories
@@ -173,10 +173,10 @@ class RunPlan {
      */
     RunPlanVector operator+(const RunPlan& rhs) const;
     RunPlanVector operator+(const RunPlanVector& rhs) const;
-    RunPlanVector operator*(const unsigned int& rhs) const;
+    RunPlanVector operator*(unsigned int rhs) const;
 
  private:
-    explicit RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, const bool &allow_0);
+    explicit RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, bool allow_0);
     uint64_t random_seed;
     unsigned int steps;
     std::string output_subdirectory;

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -47,7 +47,7 @@ class RunPlan {
      * Set the random seed passed to this run of the simulation
      * @param random_seed Seed for random generation during execution
      */
-    void setRandomSimulationSeed(const uint64_t &random_seed);
+    void setRandomSimulationSeed(uint64_t random_seed);
     /**
      * Set the number of steps for this instance of the simulation
      * A steps value of 0 requires the ModelDescription to have atleast 1 exit condition
@@ -69,7 +69,7 @@ class RunPlan {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      */
     template<typename T>
-    void setProperty(const std::string &name, const T&value);
+    void setProperty(const std::string &name, T value);
     /**
      * Set the environment property override for this run of the model
      * This version should be used for array properties
@@ -95,7 +95,7 @@ class RunPlan {
      * @throws exception::OutOfBoundsException If index is not in range of the length of the property array
      */
     template<typename T, EnvironmentManager::size_type N = 0>
-    void setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value);
+    void setProperty(const std::string &name, EnvironmentManager::size_type index, T value);
 #ifdef SWIG
     /**
      * Set the environment property override for this run of the model
@@ -155,7 +155,7 @@ class RunPlan {
      * @throws exception::OutOfBoundsException If index is not in range of the length of the property array
      */
     template<typename T, EnvironmentManager::size_type N = 0>
-    T getProperty(const std::string &name, const EnvironmentManager::size_type &index) const;
+    T getProperty(const std::string &name, EnvironmentManager::size_type index) const;
 #ifdef SWIG
     /**
      * Gets the currently configured environment property array value
@@ -193,7 +193,7 @@ class RunPlan {
 };
 
 template<typename T>
-void RunPlan::setProperty(const std::string &name, const T&value) {
+void RunPlan::setProperty(const std::string &name, T value) {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {
@@ -239,7 +239,7 @@ void RunPlan::setProperty(const std::string &name, const std::array<T, N> &value
     property_overrides.emplace(name, util::Any(value.data(), sizeof(T) * N, typeid(typename type_decode<T>::type_t), type_decode<T>::len_t * N));
 }
 template<typename T, EnvironmentManager::size_type N>
-void RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+void RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type index, T value) {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {
@@ -358,7 +358,7 @@ std::array<T, N> RunPlan::getProperty(const std::string &name) const {
     return rtn;
 }
 template<typename T, EnvironmentManager::size_type N>
-T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index) const {
+T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type index) const {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -219,7 +219,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
-    void setPropertyLogNormalRandom(const std::string &name, const T mean, const T stddev);
+    void setPropertyLogNormalRandom(const std::string &name, T mean, T stddev);
     /**
      * Array property element equivalent of setPropertyLogNormalRandom()
      * Sweep named environment property over a log normal random distribution

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -206,7 +206,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setPropertyNormalRandom(const std::string &name, T mean, T stddev)
      */
     template<typename T>
-    void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev);
+    void setPropertyNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev);
     /**
      * Sweep named environment property over a log normal random distribution
      * Only floating point types are supported

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -589,22 +589,22 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<double>(name, index, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const char &min, const char &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const char min, const char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const char &min, const char &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const char min, const char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<char>(name, index, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const unsigned char &min, const unsigned char &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const unsigned char min, const unsigned char max) {
     std::uniform_int_distribution<uint16_t> dist(min, max);
     setPropertyRandom<unsigned char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const unsigned char &min, const unsigned char &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const unsigned char min, const unsigned char max) {
     std::uniform_int_distribution<uint16_t> dist(min, max);
     setPropertyRandom<unsigned char>(name, index, dist);
 }

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -39,13 +39,13 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @param step The value added to the previous seed to calculate the next seed
      * @note A step of 0, will give the exact same seed to all RunPlans
      */
-    void setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int &step = 0);
+    void setRandomSimulationSeed(const uint64_t &initial_seed, unsigned int step = 0);
     /**
      * Set the steps of each RunPlan currently within this vector
      * @param steps The number of steps to be executed
      * @note If 0 is provided, the model must have an exit condition
      */
-    void setSteps(const unsigned int &steps);
+    void setSteps(unsigned int steps);
     /**
      * Set the the sub directory within the output directory for outputs of runplans in this vector
      * @param subdir The name of the subdirectory
@@ -287,11 +287,11 @@ class RunPlanVector : private std::vector<RunPlan>  {
     RunPlanVector operator+(const RunPlanVector& rhs) const;
     RunPlanVector& operator+=(const RunPlan& rhs);
     RunPlanVector& operator+=(const RunPlanVector& rhs);
-    RunPlanVector& operator*=(const unsigned int& rhs);
-    RunPlanVector operator*(const unsigned int& rhs) const;
+    RunPlanVector& operator*=(unsigned int rhs);
+    RunPlanVector operator*(unsigned int rhs) const;
 
  private:
-    RunPlanVector(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, const bool &allow_0_steps);
+    RunPlanVector(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &environment, bool allow_0_steps);
     /**
      * Seed used for the current `rand` instance, which is only valid for elements generated since the last call to setRandomPropertySeed
      */

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -236,7 +236,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setPropertyNormalRandom(const std::string &name, T mean, T stddev)
      */
     template<typename T>
-    void setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev);
+    void setPropertyLogNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev);
     /**
      * Use a random distribution to generate parameters for the named environment property
      * @param name The name of the environment property to set

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -263,7 +263,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T, typename rand_dist>
-    void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type index, rand_dist &distribution);
+    void setPropertyRandom(const std::string &name, EnvironmentManager::size_type index, rand_dist &distribution);
 
     /**
      * Expose inherited std::vector methods/classes

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -39,7 +39,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @param step The value added to the previous seed to calculate the next seed
      * @note A step of 0, will give the exact same seed to all RunPlans
      */
-    void setRandomSimulationSeed(const uint64_t &initial_seed, unsigned int step = 0);
+    void setRandomSimulationSeed(uint64_t initial_seed, unsigned int step = 0);
     /**
      * Set the steps of each RunPlan currently within this vector
      * @param steps The number of steps to be executed
@@ -61,7 +61,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length > 1
      */
     template<typename T>
-    void setProperty(const std::string &name, const T &value);
+    void setProperty(const std::string &name, const T value);
     /**
      * Set named environment property array to a specific value
      * This version should be used for array properties
@@ -83,10 +83,10 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is not in range of the length of the property array
-     * @see setProperty(const std::string &name, const T &value)
+     * @see setProperty(const std::string &name, T value)
      */
     template<typename T>
-    void setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value);
+    void setProperty(const std::string &name, const EnvironmentManager::size_type index, const T value);
 #ifdef SWIG
     /**
      * Set named environment property array to a specific value
@@ -114,7 +114,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
-    void setPropertyUniformDistribution(const std::string &name, const T &min, const T &max);
+    void setPropertyUniformDistribution(const std::string &name, const T min, const T max);
     /**
      * Array property element equivalent of setPropertyUniformDistribution()
      * Sweep element of named environment property array over an inclusive uniform distribution
@@ -129,16 +129,16 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
-     * @see setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
+     * @see setPropertyUniformDistribution(const std::string &name, T min, T max)
      */
     template<typename T>
-    void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max);
+    void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max);
     /**
      * Seed the internal random generator used for random property distributions
      * This will only affect subsequent calls to setPropertyRandom()
      * @param seed The random seed to be used
      */
-    void setRandomPropertySeed(const uint64_t &seed);
+    void setRandomPropertySeed(uint64_t seed);
     /**
      * Get the seed used for the internal random generator used for random property distributions
      * This will only valid for calls to setPropertyRandom() since the last call toSetRandomPropertySeed
@@ -158,7 +158,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
-    void setPropertyUniformRandom(const std::string &name, const T &min, const T &max);
+    void setPropertyUniformRandom(const std::string &name, const T min, const T max);
     /**
      * Array property element equivalent of setPropertyUniformRandom()
      * Sweep named environment property over a uniform random distribution
@@ -173,10 +173,10 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
-     * @see setPropertyUniformRandom(const std::string &name, const T &min, const T &max)
+     * @see setPropertyUniformRandom(const std::string &name, T min, T max)
      */
     template<typename T>
-    void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max);
+    void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max);
     /**
      * Sweep named environment property over a normal random distribution
      * Only floating point types are supported
@@ -189,7 +189,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
-    void setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev);
+    void setPropertyNormalRandom(const std::string &name, const T mean, const T stddev);
     /**
      * Array property element equivalent of setPropertyNormalRandom()
      * Sweep named environment property over a normal random distribution
@@ -203,10 +203,10 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
-     * @see setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
+     * @see setPropertyNormalRandom(const std::string &name, T mean, T stddev)
      */
     template<typename T>
-    void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev);
+    void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev);
     /**
      * Sweep named environment property over a log normal random distribution
      * Only floating point types are supported
@@ -219,7 +219,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T>
-    void setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev);
+    void setPropertyLogNormalRandom(const std::string &name, const T mean, const T stddev);
     /**
      * Array property element equivalent of setPropertyLogNormalRandom()
      * Sweep named environment property over a log normal random distribution
@@ -233,10 +233,10 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is greater than or equal to the length of the environment property array
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
-     * @see setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)
+     * @see setPropertyNormalRandom(const std::string &name, T mean, T stddev)
      */
     template<typename T>
-    void setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev);
+    void setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev);
     /**
      * Use a random distribution to generate parameters for the named environment property
      * @param name The name of the environment property to set
@@ -263,7 +263,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T, typename rand_dist>
-    void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution);
+    void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type index, rand_dist &distribution);
 
     /**
      * Expose inherited std::vector methods/classes
@@ -306,7 +306,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
 };
 
 template<typename T>
-void RunPlanVector::setProperty(const std::string &name, const T &value) {
+void RunPlanVector::setProperty(const std::string &name, const T value) {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {
@@ -352,7 +352,7 @@ void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> 
     }
 }
 template<typename T>
-void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type index, const T value) {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {
@@ -401,7 +401,7 @@ void RunPlanVector::setPropertyArray(const std::string &name, const std::vector<
 #endif
 
 template<typename T>
-void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max) {
+void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T min, const T max) {
     // Validation
     if (this->size() < 2) {
         THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
@@ -434,7 +434,7 @@ void RunPlanVector::setPropertyUniformDistribution(const std::string &name, cons
     }
 }
 template<typename T>
-void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max) {
+void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max) {
     // Validation
     if (this->size() < 2) {
         THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
@@ -495,7 +495,7 @@ void RunPlanVector::setPropertyRandom(const std::string &name, rand_dist &distri
     }
 }
 template<typename T, typename rand_dist>
-void RunPlanVector::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution) {
+void RunPlanVector::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type index, rand_dist &distribution) {
     // Validation
     if (this->size() < 2) {
         THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
@@ -525,41 +525,41 @@ void RunPlanVector::setPropertyRandom(const std::string &name, const Environment
  * Convenience random implementations
  */
 template<typename T>
-void RunPlanVector::setPropertyUniformRandom(const std::string &name, const T &min, const T &max) {
-    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for RunPlanVector::setPropertyUniformRandom(const std::string &name, const T &min, const T&max)");
+void RunPlanVector::setPropertyUniformRandom(const std::string &name, const T min, const T max) {
+    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for RunPlanVector::setPropertyUniformRandom(const std::string &name, T min, T max)");
     std::uniform_int_distribution<T> dist(min, max);
     setPropertyRandom<T>(name, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max) {
-    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T&max)");
+void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max) {
+    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for RunPlanVector::setPropertyUniformRandom(const std::string &name, EnvironmentManager::size_type index, T min, T max)");
     std::uniform_int_distribution<T> dist(min, max);
     setPropertyRandom<T>(name, index, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev) {
-    static_assert(util::detail::StaticAssert::_Is_RealType<T>::value, "Invalid template argument for RunPlanVector::setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev)");
+void RunPlanVector::setPropertyNormalRandom(const std::string &name, const T mean, const T stddev) {
+    static_assert(util::detail::StaticAssert::_Is_RealType<T>::value, "Invalid template argument for RunPlanVector::setPropertyNormalRandom(const std::string &name, T mean, T stddev)");
     std::normal_distribution<T> dist(mean, stddev);
     setPropertyRandom<T>(name, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) {
+void RunPlanVector::setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev) {
     static_assert(util::detail::StaticAssert::_Is_RealType<T>::value,
-        "Invalid template argument for RunPlanVector::setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev)");
+        "Invalid template argument for RunPlanVector::setPropertyNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev)");
     std::normal_distribution<T> dist(mean, stddev);
     setPropertyRandom<T>(name, index, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev) {
+void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T mean, const T stddev) {
     static_assert(util::detail::StaticAssert::_Is_RealType<T>::value,
-    "Invalid template argument for RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev)");
+    "Invalid template argument for RunPlanVector::setPropertyLogNormalRandom(const std::string &name, T mean, T stddev)");
     std::lognormal_distribution<T> dist(mean, stddev);
     setPropertyRandom<T>(name, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) {
+void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev) {
     static_assert(util::detail::StaticAssert::_Is_RealType<T>::value,
-    "Invalid template argument for RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev)");
+    "Invalid template argument for RunPlanVector::setPropertyLogNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev)");
     std::lognormal_distribution<T> dist(mean, stddev);
     setPropertyRandom<T>(name, index, dist);
 }
@@ -569,22 +569,22 @@ void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const En
  * char != signed char (or unsigned char)
  */
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const float &min, const float &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const float min, const float max) {
     std::uniform_real_distribution<float> dist(min, max);
     setPropertyRandom<float>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const float &min, const float &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const float min, const float max) {
     std::uniform_real_distribution<float> dist(min, max);
     setPropertyRandom<float>(name, index, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const double &min, const double &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const double min, const double max) {
     std::uniform_real_distribution<double> dist(min, max);
     setPropertyRandom<double>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const double &min, const double &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const double min, const double max) {
     std::uniform_real_distribution<double> dist(min, max);
     setPropertyRandom<double>(name, index, dist);
 }
@@ -594,7 +594,7 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const char min, const char max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const char min, const char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<char>(name, index, dist);
 }
@@ -604,17 +604,17 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<unsigned char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const unsigned char min, const unsigned char max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const unsigned char min, const unsigned char max) {
     std::uniform_int_distribution<uint16_t> dist(min, max);
     setPropertyRandom<unsigned char>(name, index, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const signed char &min, const signed char &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const signed char min, const signed char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<signed char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const signed char &min, const signed char &max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const signed char min, const signed char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<signed char>(name, index, dist);
 }

--- a/include/flamegpu/util/Any.h
+++ b/include/flamegpu/util/Any.h
@@ -24,7 +24,7 @@ struct Any {
         memcpy(ptr, _ptr, length);
     }
     template<typename T>
-    explicit Any(const T&other)
+    explicit Any(const T other)
         : ptr(malloc(sizeof(T)))
         , length(sizeof(T))
         , type(typeid(T))

--- a/include/flamegpu/util/Any.h
+++ b/include/flamegpu/util/Any.h
@@ -16,7 +16,7 @@ struct Any {
      * @param _elements How many elements does the property have (1 if it's not an array)
      * @note Copies the data
      */
-    Any(const void *_ptr, const size_t &_length, const std::type_index &_type, const unsigned int &_elements)
+    Any(const void *_ptr, const size_t &_length, const std::type_index &_type, const unsigned int _elements)
         : ptr(malloc(_length))
         , length(_length)
         , type(_type)

--- a/include/flamegpu/util/Any.h
+++ b/include/flamegpu/util/Any.h
@@ -16,7 +16,7 @@ struct Any {
      * @param _elements How many elements does the property have (1 if it's not an array)
      * @note Copies the data
      */
-    Any(const void *_ptr, const size_t &_length, const std::type_index &_type, const unsigned int _elements)
+    Any(const void *_ptr, const size_t _length, const std::type_index &_type, const unsigned int _elements)
         : ptr(malloc(_length))
         , length(_length)
         , type(_type)

--- a/src/flamegpu/exception/FLAMEGPUDeviceException.cu
+++ b/src/flamegpu/exception/FLAMEGPUDeviceException.cu
@@ -17,7 +17,7 @@ DeviceExceptionManager::~DeviceExceptionManager() {
         gpuErrchk(cudaFree(i));
     }
 }
-DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int &streamId, const cudaStream_t &stream) {
+DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int streamId, const cudaStream_t &stream) {
     if (streamId >= CUDAScanCompaction::MAX_STREAMS) {
         THROW exception::OutOfBoundsException("Stream id %u is out of bounds, %u >= %u, "
         "in FLAMEGPUDeviceException::getDevicePtr()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);
@@ -34,7 +34,7 @@ DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int &
     memset(&hd_buffer[streamId], 0, sizeof(DeviceExceptionBuffer));
     return d_buffer[streamId];
 }
-void DeviceExceptionManager::checkError(const std::string &function, const unsigned int &streamId, const cudaStream_t &stream) {
+void DeviceExceptionManager::checkError(const std::string &function, const unsigned int streamId, const cudaStream_t &stream) {
     if (streamId >= CUDAScanCompaction::MAX_STREAMS) {
         THROW exception::OutOfBoundsException("Stream id %u is out of bounds, %u >= %u, "
         "in FLAMEGPUDeviceException::checkError()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);

--- a/src/flamegpu/exception/FLAMEGPUDeviceException.cu
+++ b/src/flamegpu/exception/FLAMEGPUDeviceException.cu
@@ -17,7 +17,7 @@ DeviceExceptionManager::~DeviceExceptionManager() {
         gpuErrchk(cudaFree(i));
     }
 }
-DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int streamId, const cudaStream_t &stream) {
+DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int streamId, const cudaStream_t stream) {
     if (streamId >= CUDAScanCompaction::MAX_STREAMS) {
         THROW exception::OutOfBoundsException("Stream id %u is out of bounds, %u >= %u, "
         "in FLAMEGPUDeviceException::getDevicePtr()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);
@@ -34,7 +34,7 @@ DeviceExceptionBuffer *DeviceExceptionManager::getDevicePtr(const unsigned int s
     memset(&hd_buffer[streamId], 0, sizeof(DeviceExceptionBuffer));
     return d_buffer[streamId];
 }
-void DeviceExceptionManager::checkError(const std::string &function, const unsigned int streamId, const cudaStream_t &stream) {
+void DeviceExceptionManager::checkError(const std::string &function, const unsigned int streamId, const cudaStream_t stream) {
     if (streamId >= CUDAScanCompaction::MAX_STREAMS) {
         THROW exception::OutOfBoundsException("Stream id %u is out of bounds, %u >= %u, "
         "in FLAMEGPUDeviceException::checkError()\n", streamId, streamId, CUDAScanCompaction::MAX_STREAMS);

--- a/src/flamegpu/exception/FLAMEGPUException.cpp
+++ b/src/flamegpu/exception/FLAMEGPUException.cpp
@@ -25,7 +25,7 @@ const char * FLAMEGPUException::what() const noexcept {
     return err_message.c_str();
 }
 
-void FLAMEGPUException::setLocation(const char *_file, const unsigned int &_line) {
+void FLAMEGPUException::setLocation(const char *_file, const unsigned int _line) {
     file = _file;
     line = _line;
 }

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -113,7 +113,7 @@ void CUDAAgent::mapRuntimeVariables(const AgentFunctionData& func, const unsigne
     }
 }
 
-void CUDAAgent::setPopulationData(const AgentVector& population, const std::string& state_name, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t& stream) {
+void CUDAAgent::setPopulationData(const AgentVector& population, const std::string& state_name, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t stream) {
     // Validate agent state
     auto our_state = state_map.find(state_name);
     if (our_state == state_map.end()) {
@@ -288,25 +288,25 @@ void *CUDAAgent::getStateVariablePtr(const std::string &state_name, const std::s
     }
     return sm->second->getVariablePointer(variable_name);
 }
-void CUDAAgent::processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgent::processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // Optionally process agent death
     if (func.has_agent_death) {
         // Agent death operates on all mapped vars, so handled by fat agent
         fat_agent->processDeath(fat_index, func.initial_state, scatter, streamId, stream);
     }
 }
-void CUDAAgent::transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgent::transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // All mapped vars need to transition too, so handled by fat agent
     fat_agent->transitionState(fat_index, _src, _dest, scatter, streamId, stream);
 }
-void CUDAAgent::processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgent::processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // Optionally process function condition
     if ((func.condition) || (!func.rtc_func_condition_name.empty())) {
         // Agent function condition operates on all mapped vars, so handled by fat agent
         fat_agent->processFunctionCondition(fat_index, func.initial_state, scatter, streamId, stream);
     }
 }
-void CUDAAgent::scatterHostCreation(const std::string &state_name, const unsigned int newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgent::scatterHostCreation(const std::string &state_name, const unsigned int newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     auto sm = state_map.find(state_name);
     if (sm == state_map.end()) {
         THROW exception::InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
@@ -407,7 +407,7 @@ void CUDAAgent::releaseNewBuffer(const AgentFunctionData& func) {
     }
 }
 
-void CUDAAgent::scatterNew(const AgentFunctionData& func, const unsigned int newSize, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgent::scatterNew(const AgentFunctionData& func, const unsigned int newSize, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // Confirm agent output is set
     if (auto oa = func.agent_output.lock()) {
         auto sm = state_map.find(func.agent_output_state);
@@ -630,12 +630,12 @@ const CUDAAgent::CUDARTCFuncMap& CUDAAgent::getRTCFunctions() const {
     return rtc_func_map;
 }
 
-void CUDAAgent::initUnmappedVars(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgent::initUnmappedVars(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     for (auto &s : state_map) {
         s.second->initUnmappedVars(scatter, streamId, stream);
     }
 }
-void CUDAAgent::initExcludedVars(const std::string &state, const unsigned int count, const unsigned int offset, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t& stream) {
+void CUDAAgent::initExcludedVars(const std::string &state, const unsigned int count, const unsigned int offset, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t stream) {
     // check the cuda agent state map to find the correct state list
     const auto& sm = state_map.find(state);
 

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -75,7 +75,7 @@ CUDAAgent::CUDAAgent(
     }
 }
 
-void CUDAAgent::mapRuntimeVariables(const AgentFunctionData& func, const unsigned int &instance_id) const {
+void CUDAAgent::mapRuntimeVariables(const AgentFunctionData& func, const unsigned int instance_id) const {
     // check the cuda agent state map to find the correct state list for functions starting state
     auto sm = state_map.find(func.initial_state);
 
@@ -113,7 +113,7 @@ void CUDAAgent::mapRuntimeVariables(const AgentFunctionData& func, const unsigne
     }
 }
 
-void CUDAAgent::setPopulationData(const AgentVector& population, const std::string& state_name, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream) {
+void CUDAAgent::setPopulationData(const AgentVector& population, const std::string& state_name, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t& stream) {
     // Validate agent state
     auto our_state = state_map.find(state_name);
     if (our_state == state_map.end()) {
@@ -263,7 +263,7 @@ void CUDAAgent::resizeState(const std::string& state, const unsigned int minimum
     sm->second->resize(minimumSize, retainData, stream);
 }
 
-void CUDAAgent::setStateAgentCount(const std::string& state, const unsigned int& newSize) {
+void CUDAAgent::setStateAgentCount(const std::string& state, const unsigned int newSize) {
     // check the cuda agent state map to find the correct state list
     const auto& sm = state_map.find(state);
 
@@ -288,25 +288,25 @@ void *CUDAAgent::getStateVariablePtr(const std::string &state_name, const std::s
     }
     return sm->second->getVariablePointer(variable_name);
 }
-void CUDAAgent::processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgent::processDeath(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // Optionally process agent death
     if (func.has_agent_death) {
         // Agent death operates on all mapped vars, so handled by fat agent
         fat_agent->processDeath(fat_index, func.initial_state, scatter, streamId, stream);
     }
 }
-void CUDAAgent::transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgent::transitionState(const std::string &_src, const std::string &_dest, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // All mapped vars need to transition too, so handled by fat agent
     fat_agent->transitionState(fat_index, _src, _dest, scatter, streamId, stream);
 }
-void CUDAAgent::processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgent::processFunctionCondition(const AgentFunctionData& func, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // Optionally process function condition
     if ((func.condition) || (!func.rtc_func_condition_name.empty())) {
         // Agent function condition operates on all mapped vars, so handled by fat agent
         fat_agent->processFunctionCondition(fat_index, func.initial_state, scatter, streamId, stream);
     }
 }
-void CUDAAgent::scatterHostCreation(const std::string &state_name, const unsigned int &newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgent::scatterHostCreation(const std::string &state_name, const unsigned int newSize, char *const d_inBuff, const VarOffsetStruct &offsets, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     auto sm = state_map.find(state_name);
     if (sm == state_map.end()) {
         THROW exception::InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
@@ -407,7 +407,7 @@ void CUDAAgent::releaseNewBuffer(const AgentFunctionData& func) {
     }
 }
 
-void CUDAAgent::scatterNew(const AgentFunctionData& func, const unsigned int &newSize, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgent::scatterNew(const AgentFunctionData& func, const unsigned int newSize, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // Confirm agent output is set
     if (auto oa = func.agent_output.lock()) {
         auto sm = state_map.find(func.agent_output_state);
@@ -630,12 +630,12 @@ const CUDAAgent::CUDARTCFuncMap& CUDAAgent::getRTCFunctions() const {
     return rtc_func_map;
 }
 
-void CUDAAgent::initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgent::initUnmappedVars(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     for (auto &s : state_map) {
         s.second->initUnmappedVars(scatter, streamId, stream);
     }
 }
-void CUDAAgent::initExcludedVars(const std::string &state, const unsigned int&count, const unsigned int&offset, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream) {
+void CUDAAgent::initExcludedVars(const std::string &state, const unsigned int count, const unsigned int offset, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t& stream) {
     // check the cuda agent state map to find the correct state list
     const auto& sm = state_map.find(state);
 

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -25,7 +25,7 @@ namespace flamegpu {
 CUDAAgentStateList::CUDAAgentStateList(
     const std::shared_ptr<CUDAFatAgentStateList> &fat_list,
     CUDAAgent& cuda_agent,
-    const unsigned int &_fat_index,
+    const unsigned int _fat_index,
     const AgentData& description,
     bool _isSubStateList)
     : fat_index(_fat_index)
@@ -40,7 +40,7 @@ CUDAAgentStateList::CUDAAgentStateList(
 CUDAAgentStateList::CUDAAgentStateList(
     const std::shared_ptr<CUDAFatAgentStateList> &fat_list,
     CUDAAgent& cuda_agent,
-    const unsigned int &_fat_index,
+    const unsigned int _fat_index,
     const AgentData& description,
     bool _isSubStateList,
     const SubAgentData::Mapping &varMap)
@@ -235,7 +235,7 @@ unsigned int CUDAAgentStateList::scatterNew(void * d_newBuff, const unsigned int
 bool CUDAAgentStateList::getIsSubStatelist() {
     return isSubStateList;
 }
-void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     assert(parent_list->getSizeWithDisabled() == parent_list->getSize());
     if (parent_list->getSize()) {
         assert(isSubStateList);
@@ -245,7 +245,7 @@ void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned i
         }
     }
 }
-void CUDAAgentStateList::initExcludedVars(const unsigned int& count, const unsigned int& offset, CUDAScatter& scatter, const unsigned int& streamId, const cudaStream_t& stream) {
+void CUDAAgentStateList::initExcludedVars(const unsigned int count, const unsigned int offset, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t& stream) {
     std::set<std::shared_ptr<VariableBuffer>> exclusionSet;
     for (auto& a : variables)
         exclusionSet.insert(a.second);
@@ -254,7 +254,7 @@ void CUDAAgentStateList::initExcludedVars(const unsigned int& count, const unsig
 void CUDAAgentStateList::clear() {
     parent_list->setAgentCount(0, true);
 }
-void CUDAAgentStateList::setAgentCount(const unsigned int& newSize) {
+void CUDAAgentStateList::setAgentCount(const unsigned int newSize) {
     parent_list->setAgentCount(newSize, false);
 }
 std::list<std::shared_ptr<VariableBuffer>> CUDAAgentStateList::getUnboundVariableBuffers() {

--- a/src/flamegpu/gpu/CUDAAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAAgentStateList.cu
@@ -235,7 +235,7 @@ unsigned int CUDAAgentStateList::scatterNew(void * d_newBuff, const unsigned int
 bool CUDAAgentStateList::getIsSubStatelist() {
     return isSubStateList;
 }
-void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     assert(parent_list->getSizeWithDisabled() == parent_list->getSize());
     if (parent_list->getSize()) {
         assert(isSubStateList);
@@ -245,7 +245,7 @@ void CUDAAgentStateList::initUnmappedVars(CUDAScatter &scatter, const unsigned i
         }
     }
 }
-void CUDAAgentStateList::initExcludedVars(const unsigned int count, const unsigned int offset, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t& stream) {
+void CUDAAgentStateList::initExcludedVars(const unsigned int count, const unsigned int offset, CUDAScatter& scatter, const unsigned int streamId, const cudaStream_t stream) {
     std::set<std::shared_ptr<VariableBuffer>> exclusionSet;
     for (auto& a : variables)
         exclusionSet.insert(a.second);

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -79,7 +79,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     if (device_count == 0) {
         THROW exception::InvalidCUDAdevice("Error no CUDA devices found!, in CUDAEnsemble::simulate()");
     }
-    for (const int &id : config.devices) {
+    for (const int id : config.devices) {
         if (id >= device_count) {
             THROW exception::InvalidCUDAdevice("Requested CUDA device %d is not valid, only %d CUDA devices available!, in CUDAEnsemble::simulate()", id, device_count);
         }

--- a/src/flamegpu/gpu/CUDAFatAgent.cu
+++ b/src/flamegpu/gpu/CUDAFatAgent.cu
@@ -87,7 +87,7 @@ void CUDAFatAgent::addSubAgent(
     mappedAgentCount++;
 }
 
-void CUDAFatAgent::processDeath(const unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAFatAgent::processDeath(const unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     auto sm = states.find({agent_fat_id, state_name});
     if (sm == states.end()) {
         THROW exception::InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
@@ -168,7 +168,7 @@ void CUDAFatAgent::transitionState(unsigned int agent_fat_id, const std::string 
     }
 }
 
-void CUDAFatAgent::processFunctionCondition(const unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAFatAgent::processFunctionCondition(const unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     auto sm = states.find({agent_fat_id, state_name});
     if (sm == states.end()) {
         THROW exception::InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
@@ -231,7 +231,7 @@ void CUDAFatAgent::setConditionState(const unsigned int agent_fat_id, const std:
     sm->second->setDisabledAgents(numberOfDisabled);
 }
 
-void *CUDAFatAgent::allocNewBuffer(const size_t &total_agent_size, const unsigned int new_agents, const size_t &varCount) {
+void *CUDAFatAgent::allocNewBuffer(const size_t total_agent_size, const unsigned int new_agents, const size_t varCount) {
     std::lock_guard<std::mutex> guard(d_newLists_mutex);
     // It is assumed that the buffer will be split into sub-buffers, each 64bit aligned
     // So for total number of variables-1, add 64 bits incase required for alignment.

--- a/src/flamegpu/gpu/CUDAFatAgent.cu
+++ b/src/flamegpu/gpu/CUDAFatAgent.cu
@@ -39,7 +39,7 @@ CUDAFatAgent::~CUDAFatAgent() {
     }
     d_newLists.clear();
 }
-std::unordered_map<std::string, std::shared_ptr<CUDAFatAgentStateList>> CUDAFatAgent::getStateMap(const unsigned int &fat_index) {
+std::unordered_map<std::string, std::shared_ptr<CUDAFatAgentStateList>> CUDAFatAgent::getStateMap(const unsigned int fat_index) {
     std::unordered_map<std::string, std::shared_ptr<CUDAFatAgentStateList>> rtn;
     // For each state
     for (const auto &s : states) {
@@ -53,7 +53,7 @@ std::unordered_map<std::string, std::shared_ptr<CUDAFatAgentStateList>> CUDAFatA
 }
 void CUDAFatAgent::addSubAgent(
   const AgentData &description,
-  const unsigned int &master_fat_index,
+  const unsigned int master_fat_index,
   const std::shared_ptr<SubAgentData> &mapping) {
     assert(states.size());
     assert(states_unique.size());
@@ -87,7 +87,7 @@ void CUDAFatAgent::addSubAgent(
     mappedAgentCount++;
 }
 
-void CUDAFatAgent::processDeath(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAFatAgent::processDeath(const unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     auto sm = states.find({agent_fat_id, state_name});
     if (sm == states.end()) {
         THROW exception::InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
@@ -168,7 +168,7 @@ void CUDAFatAgent::transitionState(unsigned int agent_fat_id, const std::string 
     }
 }
 
-void CUDAFatAgent::processFunctionCondition(const unsigned int &agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAFatAgent::processFunctionCondition(const unsigned int agent_fat_id, const std::string &state_name, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     auto sm = states.find({agent_fat_id, state_name});
     if (sm == states.end()) {
         THROW exception::InvalidCudaAgentState("Error: Agent ('%s') state ('%s') was not found "
@@ -220,7 +220,7 @@ void CUDAFatAgent::processFunctionCondition(const unsigned int &agent_fat_id, co
     }
 }
 
-void CUDAFatAgent::setConditionState(const unsigned int &agent_fat_id, const std::string &state_name, const unsigned int numberOfDisabled) {
+void CUDAFatAgent::setConditionState(const unsigned int agent_fat_id, const std::string &state_name, const unsigned int numberOfDisabled) {
     // check the cuda agent state map to find the correct state list for functions starting state
     auto sm = states.find({agent_fat_id, state_name});
     if (sm == states.end()) {
@@ -231,7 +231,7 @@ void CUDAFatAgent::setConditionState(const unsigned int &agent_fat_id, const std
     sm->second->setDisabledAgents(numberOfDisabled);
 }
 
-void *CUDAFatAgent::allocNewBuffer(const size_t &total_agent_size, const unsigned int &new_agents, const size_t &varCount) {
+void *CUDAFatAgent::allocNewBuffer(const size_t &total_agent_size, const unsigned int new_agents, const size_t &varCount) {
     std::lock_guard<std::mutex> guard(d_newLists_mutex);
     // It is assumed that the buffer will be split into sub-buffers, each 64bit aligned
     // So for total number of variables-1, add 64 bits incase required for alignment.

--- a/src/flamegpu/gpu/CUDAFatAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAFatAgentStateList.cu
@@ -44,8 +44,8 @@ CUDAFatAgentStateList::~CUDAFatAgentStateList() {
 }
 void CUDAFatAgentStateList::addSubAgentVariables(
   const AgentData &description,
-  const unsigned int &master_fat_index,
-  const unsigned int &sub_fat_index,
+  const unsigned int master_fat_index,
+  const unsigned int sub_fat_index,
   const std::shared_ptr<SubAgentData> &mapping) {
     for (const auto &v : description.variables) {
         const auto &mapped = mapping->variables.find(v.first);
@@ -62,7 +62,7 @@ void CUDAFatAgentStateList::addSubAgentVariables(
         }
     }
 }
-std::shared_ptr<VariableBuffer> CUDAFatAgentStateList::getVariableBuffer(const unsigned int &fat_index, const std::string &name) {
+std::shared_ptr<VariableBuffer> CUDAFatAgentStateList::getVariableBuffer(const unsigned int fat_index, const std::string &name) {
     const AgentVariable variable = {fat_index, name};
     return variables.at(variable);
 }
@@ -132,7 +132,7 @@ unsigned int CUDAFatAgentStateList::getSizeWithDisabled() const {
 unsigned int CUDAFatAgentStateList::getAllocatedSize() const {
     return bufferLen;
 }
-void CUDAFatAgentStateList::setAgentCount(const unsigned int &newCount, const bool &resetDisabled) {
+void CUDAFatAgentStateList::setAgentCount(const unsigned int newCount, const bool resetDisabled) {
     if ((resetDisabled && newCount > bufferLen) || (!resetDisabled && (newCount + disabledAgents> bufferLen))) {
         THROW exception::InvalidMemoryCapacity("Agent count will exceed allocated buffer size, "
         "in CUDAFatAgentStateList::setAgentCount()\n");
@@ -142,7 +142,7 @@ void CUDAFatAgentStateList::setAgentCount(const unsigned int &newCount, const bo
     }
     aliveAgents = disabledAgents + newCount;
 }
-unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // Build scatter data
     std::vector<CUDAScatter::ScatterData> sd;
     for (const auto &v : variables_unique) {
@@ -166,7 +166,7 @@ unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const uns
 
     return living_agents;
 }
-unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // This makes no sense if we have disabled agents (it's supposed to reorder to create disabled agents)
     assert(disabledAgents == 0);
     // Build scatter data
@@ -183,7 +183,7 @@ unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatt
         aliveAgents, 0, false, disabledAgents);
     return scattered_agents;
 }
-unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionTrue(const unsigned int &conditionFailCount, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionTrue(const unsigned int conditionFailCount, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // This makes no sense if we have disabled agents (it's suppose to reorder to create disabled agents)
     assert(disabledAgents == 0);
     // Build scatter data
@@ -206,7 +206,7 @@ unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionTrue(const unsi
     disabledAgents = conditionFailCount;
     return scattered_agents;
 }
-void CUDAFatAgentStateList::setDisabledAgents(const unsigned int &numberOfDisabled) {
+void CUDAFatAgentStateList::setDisabledAgents(const unsigned int numberOfDisabled) {
     assert(numberOfDisabled <= aliveAgents);
     disabledAgents = numberOfDisabled;
     // update data_condition for each unique variable
@@ -231,7 +231,7 @@ void CUDAFatAgentStateList::scatterSort_async(CUDAScatter &scatter, unsigned int
     }
     scatter.scatterPosition_async(streamId, stream, CUDAScatter::Type::MESSAGE_OUTPUT, sd, aliveAgents);
 }
-void CUDAFatAgentStateList::initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAFatAgentStateList::initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     if (initCount && exclusionSet.size()) {
         assert(initCount + initOffset <= bufferLen);
         std::list<std::shared_ptr<VariableBuffer>> initVars;

--- a/src/flamegpu/gpu/CUDAFatAgentStateList.cu
+++ b/src/flamegpu/gpu/CUDAFatAgentStateList.cu
@@ -142,7 +142,7 @@ void CUDAFatAgentStateList::setAgentCount(const unsigned int newCount, const boo
     }
     aliveAgents = disabledAgents + newCount;
 }
-unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // Build scatter data
     std::vector<CUDAScatter::ScatterData> sd;
     for (const auto &v : variables_unique) {
@@ -166,7 +166,7 @@ unsigned int CUDAFatAgentStateList::scatterDeath(CUDAScatter &scatter, const uns
 
     return living_agents;
 }
-unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // This makes no sense if we have disabled agents (it's supposed to reorder to create disabled agents)
     assert(disabledAgents == 0);
     // Build scatter data
@@ -183,7 +183,7 @@ unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionFalse(CUDAScatt
         aliveAgents, 0, false, disabledAgents);
     return scattered_agents;
 }
-unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionTrue(const unsigned int conditionFailCount, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+unsigned int CUDAFatAgentStateList::scatterAgentFunctionConditionTrue(const unsigned int conditionFailCount, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // This makes no sense if we have disabled agents (it's suppose to reorder to create disabled agents)
     assert(disabledAgents == 0);
     // Build scatter data
@@ -231,7 +231,7 @@ void CUDAFatAgentStateList::scatterSort_async(CUDAScatter &scatter, unsigned int
     }
     scatter.scatterPosition_async(streamId, stream, CUDAScatter::Type::MESSAGE_OUTPUT, sd, aliveAgents);
 }
-void CUDAFatAgentStateList::initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAFatAgentStateList::initVariables(std::set<std::shared_ptr<VariableBuffer>> &exclusionSet, const unsigned int initCount, const unsigned initOffset, CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     if (initCount && exclusionSet.size()) {
         assert(initCount + initOffset <= bufferLen);
         std::list<std::shared_ptr<VariableBuffer>> initVars;

--- a/src/flamegpu/gpu/CUDAMessage.cu
+++ b/src/flamegpu/gpu/CUDAMessage.cu
@@ -69,7 +69,7 @@ unsigned int CUDAMessage::getMaximumListSize() const {
 unsigned int CUDAMessage::getMessageCount() const {
     return message_count;
 }
-void CUDAMessage::setMessageCount(const unsigned int &_message_count) {
+void CUDAMessage::setMessageCount(const unsigned int _message_count) {
     if (_message_count > max_list_size) {
         THROW exception::OutOfBoundsException("message count exceeds allocated message list size (%u > %u) in CUDAMessage::setMessageCount().", _message_count, max_list_size);
     }
@@ -121,7 +121,7 @@ void *CUDAMessage::getReadPtr(const std::string &var_name) {
     }
     return message_list->getReadMessageListVariablePointer(var_name);
 }
-void CUDAMessage::mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int &writeLen, cudaStream_t stream) const {
+void CUDAMessage::mapWriteRuntimeVariables(const AgentFunctionData& func, const CUDAAgent& cuda_agent, const unsigned int writeLen, cudaStream_t stream) const {
     // check that the message list has been allocated
     if (!message_list) {
         THROW exception::InvalidMessageData("Error: Initial message list for message '%s' has not been allocated, "
@@ -196,7 +196,7 @@ void CUDAMessage::swap() {
     message_list->swap();
 }
 
-void CUDAMessage::buildIndex(CUDAScatter &scatter, const unsigned int &streamId, const cudaStream_t &stream) {
+void CUDAMessage::buildIndex(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
     // Build the index if required.
     if (pbm_construction_required) {
         specialisation_handler->buildIndex(scatter, streamId, stream);

--- a/src/flamegpu/gpu/CUDAMessage.cu
+++ b/src/flamegpu/gpu/CUDAMessage.cu
@@ -196,7 +196,7 @@ void CUDAMessage::swap() {
     message_list->swap();
 }
 
-void CUDAMessage::buildIndex(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t &stream) {
+void CUDAMessage::buildIndex(CUDAScatter &scatter, const unsigned int streamId, const cudaStream_t stream) {
     // Build the index if required.
     if (pbm_construction_required) {
         specialisation_handler->buildIndex(scatter, streamId, stream);

--- a/src/flamegpu/gpu/CUDAScanCompaction.cu
+++ b/src/flamegpu/gpu/CUDAScanCompaction.cu
@@ -9,7 +9,7 @@ namespace flamegpu {
 /**
  * CUDAScanCompaction methods
  */
-void CUDAScanCompaction::resize(const unsigned int& newCount, const Type& type, const unsigned int& streamId) {
+void CUDAScanCompaction::resize(const unsigned int newCount, const Type& type, const unsigned int streamId) {
     assert(streamId < MAX_STREAMS);
     assert(type < MAX_TYPES);
     configs[type][streamId].resize_scan_flag(newCount);
@@ -21,10 +21,10 @@ void CUDAScanCompaction::zero_async(const Type& type, cudaStream_t stream, unsig
     configs[type][streamId].zero_scan_flag_async(stream);
 }
 
-const CUDAScanCompactionConfig &CUDAScanCompaction::getConfig(const Type& type, const unsigned int& streamId) {
+const CUDAScanCompactionConfig &CUDAScanCompaction::getConfig(const Type& type, const unsigned int streamId) {
     return configs[type][streamId];
 }
-CUDAScanCompactionConfig &CUDAScanCompaction::Config(const Type& type, const unsigned int& streamId) {
+CUDAScanCompactionConfig &CUDAScanCompaction::Config(const Type& type, const unsigned int streamId) {
     return configs[type][streamId];
 }
 /**
@@ -53,7 +53,7 @@ void CUDAScanCompactionConfig::zero_scan_flag_async(cudaStream_t stream) {
     }
 }
 
-void CUDAScanCompactionConfig::resize_scan_flag(const unsigned int& count) {
+void CUDAScanCompactionConfig::resize_scan_flag(const unsigned int count) {
     if (count + 1 > scan_flag_len) {
         free_scan_flag();
         gpuErrchk(cudaMalloc(&d_ptrs.scan_flag, (count + 1) * sizeof(unsigned int)));  // +1 so we can get the total from the scan

--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -36,7 +36,7 @@ CUDAScatter::StreamData::~StreamData() {
     d_data = nullptr;
     data_len = 0;
 }
-void CUDAScatter::StreamData::resize(const unsigned int &newLen) {
+void CUDAScatter::StreamData::resize(const unsigned int newLen) {
     if (newLen > data_len) {
         if (d_data) {
             gpuErrchk(cudaFree(d_data));
@@ -99,16 +99,16 @@ __global__ void scatter_all_generic(
 }
 
 unsigned int CUDAScatter::scatter(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const Type &messageOrAgent,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,
-    const unsigned int &itemCount,
-    const unsigned int &out_index_offset,
-    const bool &invert_scan_flag,
-    const unsigned int &scatter_all_count) {
+    const unsigned int itemCount,
+    const unsigned int out_index_offset,
+    const bool invert_scan_flag,
+    const unsigned int scatter_all_count) {
     std::vector<ScatterData> scatterData;
     for (const auto &v : vars) {
         char *in_p = reinterpret_cast<char*>(in.at(v.first));
@@ -118,14 +118,14 @@ unsigned int CUDAScatter::scatter(
     return scatter(streamResourceId, stream, messageOrAgent, scatterData, itemCount, out_index_offset, invert_scan_flag, scatter_all_count);
 }
 unsigned int CUDAScatter::scatter(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const Type &messageOrAgent,
     const std::vector<ScatterData> &sd,
-    const unsigned int &itemCount,
-    const unsigned int &out_index_offset,
-    const bool &invert_scan_flag,
-    const unsigned int &scatter_all_count) {
+    const unsigned int itemCount,
+    const unsigned int out_index_offset,
+    const bool invert_scan_flag,
+    const unsigned int scatter_all_count) {
     int blockSize = 0;  // The launch configurator returned block size
     int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
     int gridSize = 0;  // The actual grid size needed, based on input size
@@ -192,22 +192,22 @@ void CUDAScatter::scatterPosition_async(
     gpuErrchkLaunch();
 }
 unsigned int CUDAScatter::scatterCount(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const Type &messageOrAgent,
-    const unsigned int &itemCount,
-    const unsigned int &scatter_all_count) {
+    const unsigned int itemCount,
+    const unsigned int scatter_all_count) {
     unsigned int rtn = 0;
     gpuErrchk(cudaMemcpy(&rtn, scan.Config(messageOrAgent, streamResourceId).d_ptrs.position + itemCount - scatter_all_count, sizeof(unsigned int), cudaMemcpyDeviceToHost));
     return rtn;
 }
 
 unsigned int CUDAScatter::scatterAll(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const std::vector<ScatterData> &sd,
-    const unsigned int &itemCount,
-    const unsigned int &out_index_offset) {
+    const unsigned int itemCount,
+    const unsigned int out_index_offset) {
     if (!itemCount)
         return itemCount;  // No work to do
     int blockSize = 0;  // The launch configurator returned block size
@@ -231,13 +231,13 @@ unsigned int CUDAScatter::scatterAll(
     return itemCount;
 }
 unsigned int CUDAScatter::scatterAll(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,
-    const unsigned int &itemCount,
-    const unsigned int &out_index_offset) {
+    const unsigned int itemCount,
+    const unsigned int out_index_offset) {
     std::vector<ScatterData> scatterData;
     for (const auto &v : vars) {
         char *in_p = reinterpret_cast<char*>(in.at(v.first));
@@ -268,12 +268,12 @@ __global__ void pbm_reorder_generic(
 }
 
 void CUDAScatter::pbm_reorder(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,
-    const unsigned int &itemCount,
+    const unsigned int itemCount,
     const unsigned int *d_bin_index,
     const unsigned int *d_bin_sub_index,
     const unsigned int *d_pbm) {
@@ -340,12 +340,12 @@ __global__ void scatter_new_agents(
     memcpy(out_ptr, in_ptr, scatter_data[var_out].typeLen);
 }
 void CUDAScatter::scatterNewAgents(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const std::vector<ScatterData> &sd,
     const size_t &totalAgentSize,
-    const unsigned int &inCount,
-    const unsigned int &outIndexOffset) {
+    const unsigned int inCount,
+    const unsigned int outIndexOffset) {
     // 1 thread per agent variable
     const unsigned int threadCount = static_cast<unsigned int>(sd.size()) * inCount;
     int blockSize = 0;  // The launch configurator returned block size
@@ -539,13 +539,13 @@ __global__ void reorder_array_messages(
     }
 }
 void CUDAScatter::arrayMessageReorder(
-    const unsigned int &streamResourceId,
+    const unsigned int streamResourceId,
     const cudaStream_t &stream,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,
-    const unsigned int &itemCount,
-    const unsigned int &array_length,
+    const unsigned int itemCount,
+    const unsigned int array_length,
     unsigned int *d_write_flag) {
     // If itemCount is 0, then there is no work to be done.
     if (itemCount == 0) {

--- a/src/flamegpu/gpu/CUDAScatter.cu
+++ b/src/flamegpu/gpu/CUDAScatter.cu
@@ -100,7 +100,7 @@ __global__ void scatter_all_generic(
 
 unsigned int CUDAScatter::scatter(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const Type &messageOrAgent,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
@@ -119,7 +119,7 @@ unsigned int CUDAScatter::scatter(
 }
 unsigned int CUDAScatter::scatter(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const Type &messageOrAgent,
     const std::vector<ScatterData> &sd,
     const unsigned int itemCount,
@@ -193,7 +193,7 @@ void CUDAScatter::scatterPosition_async(
 }
 unsigned int CUDAScatter::scatterCount(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const Type &messageOrAgent,
     const unsigned int itemCount,
     const unsigned int scatter_all_count) {
@@ -204,7 +204,7 @@ unsigned int CUDAScatter::scatterCount(
 
 unsigned int CUDAScatter::scatterAll(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const std::vector<ScatterData> &sd,
     const unsigned int itemCount,
     const unsigned int out_index_offset) {
@@ -232,7 +232,7 @@ unsigned int CUDAScatter::scatterAll(
 }
 unsigned int CUDAScatter::scatterAll(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,
@@ -269,7 +269,7 @@ __global__ void pbm_reorder_generic(
 
 void CUDAScatter::pbm_reorder(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,
@@ -341,9 +341,9 @@ __global__ void scatter_new_agents(
 }
 void CUDAScatter::scatterNewAgents(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const std::vector<ScatterData> &sd,
-    const size_t &totalAgentSize,
+    const size_t totalAgentSize,
     const unsigned int inCount,
     const unsigned int outIndexOffset) {
     // 1 thread per agent variable
@@ -540,7 +540,7 @@ __global__ void reorder_array_messages(
 }
 void CUDAScatter::arrayMessageReorder(
     const unsigned int streamResourceId,
-    const cudaStream_t &stream,
+    const cudaStream_t stream,
     const VariableMap &vars,
     const std::map<std::string, void*> &in,
     const std::map<std::string, void*> &out,

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1655,7 +1655,7 @@ void CUDASimulation::initOffsetsAndMap() {
     }
 }
 
-void CUDASimulation::processHostAgentCreation(const unsigned int &streamId) {
+void CUDASimulation::processHostAgentCreation(const unsigned int streamId) {
     size_t t_bufflen = 0;
     char *t_buff = nullptr;
     char *dt_buff = nullptr;

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -1490,7 +1490,7 @@ void CUDASimulation::applyConfig_derived() {
     reseed(getSimulationConfig().random_seed);
 }
 
-void CUDASimulation::reseed(const uint64_t &seed) {
+void CUDASimulation::reseed(const uint64_t seed) {
     SimulationConfig().random_seed = seed;
     singletons->rng.reseed(seed);
 
@@ -1788,7 +1788,7 @@ void CUDASimulation::resetLog() {
 #endif
     run_log->performance_specs.flamegpu_version = VERSION_FULL;
 }
-void CUDASimulation::processStepLog(const double &step_time_seconds) {
+void CUDASimulation::processStepLog(const double step_time_seconds) {
     if (!step_log_config)
         return;
     if (step_count % step_log_config->frequency != 0)

--- a/src/flamegpu/io/JSONLogger.cu
+++ b/src/flamegpu/io/JSONLogger.cu
@@ -26,7 +26,7 @@ void JSONLogger::log(const RunLog &log, bool logConfig, bool logSteps, bool logE
 }
 
 template<typename T>
-void JSONLogger::writeAny(T &writer, const util::Any &value, const unsigned int &elements) const {
+void JSONLogger::writeAny(T &writer, const util::Any &value, const unsigned int elements) const {
     // Output value
     if (elements > 1) {
         writer.StartArray();

--- a/src/flamegpu/io/JSONStateReader.cpp
+++ b/src/flamegpu/io/JSONStateReader.cpp
@@ -64,7 +64,7 @@ class JSONStateReader_impl : public rapidjson::BaseReaderHandler<rapidjson::UTF8
         , env_init(_env_init)
         , model_state(_model_state) { }
     template<typename T>
-    bool processValue(const T&val) {
+    bool processValue(const T val) {
         Mode isArray = Nop;
         if (mode.top() == VariableArray) {
             isArray = mode.top();
@@ -289,7 +289,7 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
         , cudamodel_instance(dynamic_cast<CUDASimulation*>(_sim_instance)) { }
 
     template<typename T>
-    bool processValue(const T&val) {
+    bool processValue(const T val) {
         Mode isArray = Nop;
         if (mode.top() == VariableArray) {
             isArray = mode.top();

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -20,7 +20,7 @@ JSONStateWriter::JSONStateWriter(
     const std::string &model_name,
     const std::shared_ptr<EnvironmentManager> &env_manager,
     const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>&model,
-    const unsigned int &iterations,
+    const unsigned int iterations,
     const std::string &output_file,
     const Simulation *_sim_instance)
     : StateWriter(model_name, env_manager, model, iterations, output_file, _sim_instance) {}

--- a/src/flamegpu/io/XMLLogger.cu
+++ b/src/flamegpu/io/XMLLogger.cu
@@ -282,7 +282,7 @@ void XMLLogger::writeCommonLogFrame(tinyxml2::XMLDocument &doc, tinyxml2::XMLEle
     }
 }
 
-void XMLLogger::writeAny(tinyxml2::XMLElement *pElement, const util::Any &value, const unsigned int &elements) const {
+void XMLLogger::writeAny(tinyxml2::XMLElement *pElement, const util::Any &value, const unsigned int elements) const {
     std::stringstream ss;
     // Loop through elements, to construct csv string
     for (unsigned int el = 0; el < elements; ++el) {

--- a/src/flamegpu/io/XMLStateWriter.cpp
+++ b/src/flamegpu/io/XMLStateWriter.cpp
@@ -65,7 +65,7 @@ XMLStateWriter::XMLStateWriter(
     const std::string &model_name,
     const std::shared_ptr<EnvironmentManager>& env_manager,
     const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model,
-    const unsigned int &iterations,
+    const unsigned int iterations,
     const std::string &output_file,
     const Simulation *_sim_instance)
     : StateWriter(model_name, env_manager, model, iterations, output_file, _sim_instance) {}

--- a/src/flamegpu/model/AgentFunctionDescription.cpp
+++ b/src/flamegpu/model/AgentFunctionDescription.cpp
@@ -286,7 +286,7 @@ void AgentFunctionDescription::setMessageOutput(MessageBruteForce::Description &
             mdl->name.c_str(), message.getName().c_str());
     }
 }
-void AgentFunctionDescription::setMessageOutputOptional(const bool &output_is_optional) {
+void AgentFunctionDescription::setMessageOutputOptional(const bool output_is_optional) {
     if (output_is_optional != this->function->message_output_optional) {
         this->function->message_output_optional = output_is_optional;
         if (auto b = this->function->message_output.lock()) {
@@ -362,7 +362,7 @@ void AgentFunctionDescription::setAgentOutput(AgentDescription &agent, const std
             mdl->name.c_str(), agent.getName().c_str());
     }
 }
-void AgentFunctionDescription::setAllowAgentDeath(const bool &has_death) {
+void AgentFunctionDescription::setAllowAgentDeath(const bool has_death) {
     function->has_agent_death = has_death;
 }
 

--- a/src/flamegpu/model/SubModelDescription.cpp
+++ b/src/flamegpu/model/SubModelDescription.cpp
@@ -127,7 +127,7 @@ const SubEnvironmentDescription &SubModelDescription::getSubEnvironment(bool aut
     return *data->subenvironment->description;
 }
 
-void SubModelDescription::setMaxSteps(const unsigned int &max_steps) {
+void SubModelDescription::setMaxSteps(const unsigned int max_steps) {
     data->max_steps = max_steps;
 }
 unsigned int SubModelDescription::getMaxSteps() const {

--- a/src/flamegpu/pop/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/pop/DeviceAgentVector_impl.cu
@@ -5,7 +5,7 @@ namespace flamegpu {
 
 DeviceAgentVector_impl::DeviceAgentVector_impl(CUDAAgent& _cuda_agent, const std::string &_cuda_agent_state,
     const VarOffsetStruct& _agentOffsets, std::vector<NewAgentStorage>& _newAgentData,
-    CUDAScatter& _scatter, const unsigned int& _streamId, const cudaStream_t& _stream)
+    CUDAScatter& _scatter, const unsigned int _streamId, const cudaStream_t& _stream)
     : AgentVector(_cuda_agent.getAgentDescription(), 0)
     , unbound_buffers_has_changed(false)
     , known_device_buffer_size(_cuda_agent.getStateSize(_cuda_agent_state))
@@ -142,7 +142,7 @@ void DeviceAgentVector_impl::reinitUnboundBuffers() {
     unbound_buffers_has_changed = true;  // Probably not required, but if they are being init, high chance they're going to be changed
     unbound_host_buffer_invalid = false;
 }
-void DeviceAgentVector_impl::resizeUnboundBuffers(const unsigned int& new_capacity, bool init) {
+void DeviceAgentVector_impl::resizeUnboundBuffers(const unsigned int new_capacity, bool init) {
     // Resize to match agent_count
     for (auto& buff : unbound_buffers) {
         if (!buff.host) {

--- a/src/flamegpu/pop/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/pop/DeviceAgentVector_impl.cu
@@ -5,7 +5,7 @@ namespace flamegpu {
 
 DeviceAgentVector_impl::DeviceAgentVector_impl(CUDAAgent& _cuda_agent, const std::string &_cuda_agent_state,
     const VarOffsetStruct& _agentOffsets, std::vector<NewAgentStorage>& _newAgentData,
-    CUDAScatter& _scatter, const unsigned int _streamId, const cudaStream_t& _stream)
+    CUDAScatter& _scatter, const unsigned int _streamId, const cudaStream_t _stream)
     : AgentVector(_cuda_agent.getAgentDescription(), 0)
     , unbound_buffers_has_changed(false)
     , known_device_buffer_size(_cuda_agent.getStateSize(_cuda_agent_state))

--- a/src/flamegpu/runtime/HostAPI.cu
+++ b/src/flamegpu/runtime/HostAPI.cu
@@ -14,7 +14,7 @@ HostAPI::HostAPI(CUDASimulation &_agentModel,
     AgentDataMap &_agentData,
     const std::shared_ptr<EnvironmentManager>& env,
     CUDAMacroEnvironment &macro_env,
-    const unsigned int& _streamId,
+    const unsigned int _streamId,
     cudaStream_t _stream)
     : random(rng)
     , environment(_agentModel.getInstanceID(), env, macro_env)

--- a/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
+++ b/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
@@ -185,7 +185,7 @@ $DYNAMIC_ENV_GETVARIABLE_IMPL
 }
 
 template<typename T, unsigned int N, unsigned int M>
-__device__ __forceinline__ T ReadOnlyDeviceEnvironment::getProperty(const char(&name)[M], const unsigned int &index) const {
+__device__ __forceinline__ T ReadOnlyDeviceEnvironment::getProperty(const char(&name)[M], const unsigned int index) const {
 $DYNAMIC_ENV_GETARRAYVARIABLE_IMPL
 }
 

--- a/src/flamegpu/runtime/messaging/MessageArray.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray.cu
@@ -122,7 +122,7 @@ std::type_index MessageArray::Data::getType() const { return std::type_index(typ
 MessageArray::Description::Description(const std::shared_ptr<const ModelData>&_model, Data *const data)
     : MessageBruteForce::Description(_model, data) { }
 
-void MessageArray::Description::setLength(const size_type &len) {
+void MessageArray::Description::setLength(const size_type len) {
     if (len == 0) {
         THROW exception::InvalidArgument("Array messaging length must not be zero.\n");
     }

--- a/src/flamegpu/runtime/messaging/MessageArray2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray2D.cu
@@ -123,7 +123,7 @@ std::type_index MessageArray2D::Data::getType() const { return std::type_index(t
 MessageArray2D::Description::Description(const std::shared_ptr<const ModelData> &_model, Data *const data)
     : MessageBruteForce::Description(_model, data) { }
 
-void MessageArray2D::Description::setDimensions(const size_type& len_x, const size_type& len_y) {
+void MessageArray2D::Description::setDimensions(const size_type len_x, const size_type len_y) {
     setDimensions({ len_x , len_y });
 }
 void MessageArray2D::Description::setDimensions(const std::array<size_type, 2> &dims) {

--- a/src/flamegpu/runtime/messaging/MessageArray3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray3D.cu
@@ -123,7 +123,7 @@ std::type_index MessageArray3D::Data::getType() const { return std::type_index(t
 MessageArray3D::Description::Description(const std::shared_ptr<const ModelData> &_model, Data *const data)
     : MessageBruteForce::Description(_model, data) { }
 
-void MessageArray3D::Description::setDimensions(const size_type& len_x, const size_type& len_y, const size_type& len_z) {
+void MessageArray3D::Description::setDimensions(const size_type len_x, const size_type len_y, const size_type len_z) {
     setDimensions({ len_x , len_y, len_z});
 }
 void MessageArray3D::Description::setDimensions(const std::array<size_type, 3> &dims) {

--- a/src/flamegpu/runtime/messaging/MessageBucket.cu
+++ b/src/flamegpu/runtime/messaging/MessageBucket.cu
@@ -128,7 +128,7 @@ void MessageBucket::CUDAModelHandler::resizeCubTemp() {
     }
 }
 
-void MessageBucket::CUDAModelHandler::resizeKeysVals(const unsigned int &newSize) {
+void MessageBucket::CUDAModelHandler::resizeKeysVals(const unsigned int newSize) {
     size_t bytesCheck = newSize * sizeof(unsigned int);
     if (bytesCheck > d_keys_vals_storage_bytes) {
         if (d_keys) {

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -138,7 +138,7 @@ void MessageSpatial2D::CUDAModelHandler::resizeCubTemp(cudaStream_t stream) {
     }
 }
 
-void MessageSpatial2D::CUDAModelHandler::resizeKeysVals(const unsigned int &newSize) {
+void MessageSpatial2D::CUDAModelHandler::resizeKeysVals(const unsigned int newSize) {
     size_t bytesCheck = newSize * sizeof(unsigned int);
     if (bytesCheck > d_keys_vals_storage_bytes) {
         if (d_keys) {

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -202,27 +202,27 @@ flamegpu::MessageSortingType MessageSpatial2D::Data::getSortingType() const {
 MessageSpatial2D::Description::Description(const std::shared_ptr<const ModelData> &_model, Data *const data)
     : MessageBruteForce::Description(_model, data) { }
 
-void MessageSpatial2D::Description::setRadius(const float &r) {
+void MessageSpatial2D::Description::setRadius(const float r) {
     if (r <= 0) {
         THROW exception::InvalidArgument("Spatial messaging radius must be a positive value, %f is not valid.", r);
     }
     reinterpret_cast<Data *>(message)->radius = r;
 }
-void MessageSpatial2D::Description::setMinX(const float &x) {
+void MessageSpatial2D::Description::setMinX(const float x) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxX) &&
         x >= reinterpret_cast<Data *>(message)->maxX) {
         THROW exception::InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", x, reinterpret_cast<Data *>(message)->maxX);
     }
     reinterpret_cast<Data *>(message)->minX = x;
 }
-void MessageSpatial2D::Description::setMinY(const float &y) {
+void MessageSpatial2D::Description::setMinY(const float y) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxY) &&
         y >= reinterpret_cast<Data *>(message)->maxY) {
         THROW exception::InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", y, reinterpret_cast<Data *>(message)->maxY);
     }
     reinterpret_cast<Data *>(message)->minY = y;
 }
-void MessageSpatial2D::Description::setMin(const float &x, const float &y) {
+void MessageSpatial2D::Description::setMin(const float x, const float y) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxX) &&
         x >= reinterpret_cast<Data *>(message)->maxX) {
         THROW exception::InvalidArgument("Spatial messaging minimum bound must be lower than max bound, %f !< %f.", x, reinterpret_cast<Data *>(message)->maxX);
@@ -234,21 +234,21 @@ void MessageSpatial2D::Description::setMin(const float &x, const float &y) {
     reinterpret_cast<Data *>(message)->minX = x;
     reinterpret_cast<Data *>(message)->minY = y;
 }
-void MessageSpatial2D::Description::setMaxX(const float &x) {
+void MessageSpatial2D::Description::setMaxX(const float x) {
     if (!isnan(reinterpret_cast<Data *>(message)->minX) &&
         x <= reinterpret_cast<Data *>(message)->minX) {
         THROW exception::InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f.", x, reinterpret_cast<Data *>(message)->minX);
     }
     reinterpret_cast<Data *>(message)->maxX = x;
 }
-void MessageSpatial2D::Description::setMaxY(const float &y) {
+void MessageSpatial2D::Description::setMaxY(const float y) {
     if (!isnan(reinterpret_cast<Data *>(message)->minY) &&
         y <= reinterpret_cast<Data *>(message)->minY) {
         THROW exception::InvalidArgument("Spatial messaging max y bound must be greater than min bound, %f !> %f.", y, reinterpret_cast<Data *>(message)->minY);
     }
     reinterpret_cast<Data *>(message)->maxY = y;
 }
-void MessageSpatial2D::Description::setMax(const float &x, const float &y) {
+void MessageSpatial2D::Description::setMax(const float x, const float y) {
     if (!isnan(reinterpret_cast<Data *>(message)->minX) &&
         x <= reinterpret_cast<Data *>(message)->minX) {
         THROW exception::InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f.", x, reinterpret_cast<Data *>(message)->minX);

--- a/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
@@ -184,34 +184,34 @@ flamegpu::MessageSortingType MessageSpatial3D::Data::getSortingType() const {
 MessageSpatial3D::Description::Description(const std::shared_ptr<const ModelData> &_model, Data *const data)
     : MessageBruteForce::Description(_model, data) { }
 
-void MessageSpatial3D::Description::setRadius(const float &r) {
+void MessageSpatial3D::Description::setRadius(const float r) {
     if (r <= 0) {
         THROW exception::InvalidArgument("Spatial messaging radius must be a positive value, %f is not valid.", r);
     }
     reinterpret_cast<Data *>(message)->radius = r;
 }
-void MessageSpatial3D::Description::setMinX(const float &x) {
+void MessageSpatial3D::Description::setMinX(const float x) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxX) &&
         x >= reinterpret_cast<Data *>(message)->maxX) {
         THROW exception::InvalidArgument("Spatial messaging min x bound must be lower than max bound, %f !< %f", x, reinterpret_cast<Data *>(message)->maxX);
     }
     reinterpret_cast<Data *>(message)->minX = x;
 }
-void MessageSpatial3D::Description::setMinY(const float &y) {
+void MessageSpatial3D::Description::setMinY(const float y) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxY) &&
         y >= reinterpret_cast<Data *>(message)->maxY) {
         THROW exception::InvalidArgument("Spatial messaging min bound must be lower than max bound, %f !< %f", y, reinterpret_cast<Data *>(message)->maxY);
     }
     reinterpret_cast<Data *>(message)->minY = y;
 }
-void MessageSpatial3D::Description::setMinZ(const float &z) {
+void MessageSpatial3D::Description::setMinZ(const float z) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxZ) &&
         z >= reinterpret_cast<Data *>(message)->maxZ) {
         THROW exception::InvalidArgument("Spatial messaging min z bound must be lower than max bound, %f !< %f", z, reinterpret_cast<Data *>(message)->maxZ);
     }
     reinterpret_cast<Data *>(message)->minZ = z;
 }
-void MessageSpatial3D::Description::setMin(const float &x, const float &y, const float &z) {
+void MessageSpatial3D::Description::setMin(const float x, const float y, const float z) {
     if (!isnan(reinterpret_cast<Data *>(message)->maxX) &&
         x >= reinterpret_cast<Data *>(message)->maxX) {
         THROW exception::InvalidArgument("Spatial messaging min x bound must be lower than max bound, %f !< %f", x, reinterpret_cast<Data *>(message)->maxX);
@@ -228,28 +228,28 @@ void MessageSpatial3D::Description::setMin(const float &x, const float &y, const
     reinterpret_cast<Data *>(message)->minY = y;
     reinterpret_cast<Data *>(message)->minZ = z;
 }
-void MessageSpatial3D::Description::setMaxX(const float &x) {
+void MessageSpatial3D::Description::setMaxX(const float x) {
     if (!isnan(reinterpret_cast<Data *>(message)->minX) &&
         x <= reinterpret_cast<Data *>(message)->minX) {
         THROW exception::InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f", x, reinterpret_cast<Data *>(message)->minX);
     }
     reinterpret_cast<Data *>(message)->maxX = x;
 }
-void MessageSpatial3D::Description::setMaxY(const float &y) {
+void MessageSpatial3D::Description::setMaxY(const float y) {
     if (!isnan(reinterpret_cast<Data *>(message)->minY) &&
         y <= reinterpret_cast<Data *>(message)->minY) {
         THROW exception::InvalidArgument("Spatial messaging max y bound must be greater than min bound, %f !> %f", y, reinterpret_cast<Data *>(message)->minY);
     }
     reinterpret_cast<Data *>(message)->maxY = y;
 }
-void MessageSpatial3D::Description::setMaxZ(const float &z) {
+void MessageSpatial3D::Description::setMaxZ(const float z) {
     if (!isnan(reinterpret_cast<Data *>(message)->minZ) &&
         z <= reinterpret_cast<Data *>(message)->minZ) {
         THROW exception::InvalidArgument("Spatial messaging max z bound must be greater than min bound, %f !> %f", z, reinterpret_cast<Data *>(message)->minZ);
     }
     reinterpret_cast<Data *>(message)->maxZ = z;
 }
-void MessageSpatial3D::Description::setMax(const float &x, const float &y, const float &z) {
+void MessageSpatial3D::Description::setMax(const float x, const float y, const float z) {
     if (!isnan(reinterpret_cast<Data *>(message)->minX) &&
         x <= reinterpret_cast<Data *>(message)->minX) {
         THROW exception::InvalidArgument("Spatial messaging max x bound must be greater than min bound, %f !> %f", x, reinterpret_cast<Data *>(message)->minX);

--- a/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
@@ -137,7 +137,7 @@ void MessageSpatial3D::CUDAModelHandler::resizeCubTemp(cudaStream_t stream) {
     }
 }
 
-void MessageSpatial3D::CUDAModelHandler::resizeKeysVals(const unsigned int &newSize) {
+void MessageSpatial3D::CUDAModelHandler::resizeKeysVals(const unsigned int newSize) {
     size_t bytesCheck = newSize * sizeof(unsigned int);
     if (bytesCheck > d_keys_vals_storage_bytes) {
         if (d_keys) {

--- a/src/flamegpu/runtime/utility/HostEnvironment.cu
+++ b/src/flamegpu/runtime/utility/HostEnvironment.cu
@@ -2,7 +2,7 @@
 
 namespace flamegpu {
 
-HostEnvironment::HostEnvironment(const unsigned int &_instance_id, const std::shared_ptr<EnvironmentManager> &env, CUDAMacroEnvironment& _macro_env)
+HostEnvironment::HostEnvironment(const unsigned int _instance_id, const std::shared_ptr<EnvironmentManager> &env, CUDAMacroEnvironment& _macro_env)
     : env_mgr(env)
     , macro_env(_macro_env)
     , instance_id(_instance_id) { }

--- a/src/flamegpu/runtime/utility/HostRandom.cu
+++ b/src/flamegpu/runtime/utility/HostRandom.cu
@@ -2,7 +2,7 @@
 
 namespace flamegpu {
 
-void HostRandom::setSeed(const uint64_t &seed) {
+void HostRandom::setSeed(const uint64_t seed) {
     rng.reseed(seed);
 }
 uint64_t HostRandom::getSeed() const {

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -109,7 +109,7 @@ __global__ void init_curand(util::detail::curandState *d_random_state, unsigned 
     if (id < threadCount)
         curand_init(seed, offset + id, 0, &d_random_state[offset + id]);
 }
-void RandomManager::resizeDeviceArray(const size_type &_length, cudaStream_t stream) {
+void RandomManager::resizeDeviceArray(const size_type _length, cudaStream_t stream) {
     // Mark that the device hsa now been initialised.
     deviceInitialised = true;
     if (_length > h_max_random_size) {

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -41,7 +41,7 @@ void RandomManager::reseedDevice() {
     // curand is initialised on access if length does not match. This would need a second device length?
 }
 
-void RandomManager::reseed(const uint64_t &seed) {
+void RandomManager::reseed(const uint64_t seed) {
     // Set the instance's seed to the new value
     mSeed = seed;
 

--- a/src/flamegpu/sim/LogFrame.cu
+++ b/src/flamegpu/sim/LogFrame.cu
@@ -8,7 +8,7 @@ LogFrame::LogFrame()
 
 LogFrame::LogFrame(const std::map<std::string, util::Any> &_environment,
 const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>> &_agents,
-const unsigned int &_step_count)
+const unsigned int _step_count)
     : environment(_environment)
     , agents(_agents)
     , step_count(_step_count) { }
@@ -29,7 +29,7 @@ AgentLogFrame LogFrame::getAgent(const std::string &agent_name, const std::strin
     return AgentLogFrame(it->second.first, it->second.second);
 }
 
-AgentLogFrame::AgentLogFrame(const std::map<LoggingConfig::NameReductionFn, util::Any> &_data, const unsigned int &_count)
+AgentLogFrame::AgentLogFrame(const std::map<LoggingConfig::NameReductionFn, util::Any> &_data, const unsigned int _count)
     : data(_data)
     , count(_count) { }
 
@@ -66,7 +66,7 @@ StepLogFrame::StepLogFrame()
 
 StepLogFrame::StepLogFrame(const std::map<std::string, util::Any>&& _environment,
     const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>>&& _agents,
-    const unsigned int& _step_count)
+    const unsigned int _step_count)
     : LogFrame(_environment, _agents, _step_count)
     , step_time(0.0) { }
 
@@ -80,7 +80,7 @@ ExitLogFrame::ExitLogFrame()
 
 ExitLogFrame::ExitLogFrame(const std::map<std::string, util::Any>&& _environment,
     const std::map<util::StringPair, std::pair<std::map<LoggingConfig::NameReductionFn, util::Any>, unsigned int>>&& _agents,
-    const unsigned int& _step_count)
+    const unsigned int _step_count)
     : LogFrame(_environment, _agents, _step_count)
     , rtc_time(0.0)
     , init_time(0.0)

--- a/src/flamegpu/sim/LoggingConfig.cu
+++ b/src/flamegpu/sim/LoggingConfig.cu
@@ -68,7 +68,7 @@ StepLoggingConfig::StepLoggingConfig(const StepLoggingConfig &other)
 StepLoggingConfig::StepLoggingConfig(const LoggingConfig &other)
     : LoggingConfig(other)
     , frequency(1) { }
-void StepLoggingConfig::setFrequency(const unsigned int &steps) {
+void StepLoggingConfig::setFrequency(const unsigned int steps) {
     frequency = steps;
 }
 

--- a/src/flamegpu/sim/RunPlan.cpp
+++ b/src/flamegpu/sim/RunPlan.cpp
@@ -8,7 +8,7 @@ namespace flamegpu {
 RunPlan::RunPlan(const ModelDescription &model)
     : RunPlan(std::make_shared<std::unordered_map<std::string, EnvironmentDescription::PropData> const>(model.model->environment->getPropertiesMap()),
       model.model->exitConditions.size() + model.model->exitConditionCallbacks.size() > 0) { }
-RunPlan::RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>>  &environment, const bool &allow_0)
+RunPlan::RunPlan(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>>  &environment, const bool allow_0)
     : random_seed(0)
     , steps(1)
     , environment(environment)
@@ -28,7 +28,7 @@ RunPlan& RunPlan::operator=(const RunPlan& other) {
 void RunPlan::setRandomSimulationSeed(const uint64_t &_random_seed) {
     random_seed = _random_seed;
 }
-void RunPlan::setSteps(const unsigned int &_steps) {
+void RunPlan::setSteps(const unsigned int _steps) {
     if (_steps == 0 && !allow_0_steps) {
         throw exception::OutOfBoundsException("Model description requires atleast 1 exit condition to have unlimited steps, "
             "in RunPlan::setSteps()");
@@ -73,7 +73,7 @@ RunPlanVector RunPlan::operator+(const RunPlanVector& rhs) const {
     rtn+=*this;
     return rtn;
 }
-RunPlanVector RunPlan::operator*(const unsigned int& rhs) const {
+RunPlanVector RunPlan::operator*(const unsigned int rhs) const {
     // Operation
     RunPlanVector rtn(this->environment, this->allow_0_steps);
     for (unsigned int i = 0; i < rhs; ++i) {

--- a/src/flamegpu/sim/RunPlan.cpp
+++ b/src/flamegpu/sim/RunPlan.cpp
@@ -25,7 +25,7 @@ RunPlan& RunPlan::operator=(const RunPlan& other) {
         this->property_overrides.emplace(i.first, util::Any(i.second));
     return *this;
 }
-void RunPlan::setRandomSimulationSeed(const uint64_t &_random_seed) {
+void RunPlan::setRandomSimulationSeed(const uint64_t _random_seed) {
     random_seed = _random_seed;
 }
 void RunPlan::setSteps(const unsigned int _steps) {

--- a/src/flamegpu/sim/RunPlanVector.cpp
+++ b/src/flamegpu/sim/RunPlanVector.cpp
@@ -18,7 +18,7 @@ RunPlanVector::RunPlanVector(const std::shared_ptr<const std::unordered_map<std:
     , rand(randomPropertySeed)
     , environment(_environment)
     , allow_0_steps(_allow_0_steps) { }
-void RunPlanVector::setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int step) {
+void RunPlanVector::setRandomSimulationSeed(const uint64_t initial_seed, const unsigned int step) {
     uint64_t current_seed = initial_seed;
     for (auto &i : *this) {
         i.setRandomSimulationSeed(current_seed);
@@ -39,7 +39,7 @@ void RunPlanVector::setOutputSubdirectory(const std::string &subdir) {
         i.setOutputSubdirectory(subdir);
     }
 }
-void RunPlanVector::setRandomPropertySeed(const uint64_t &seed) {
+void RunPlanVector::setRandomPropertySeed(const uint64_t seed) {
     randomPropertySeed = seed;
     rand.seed(randomPropertySeed);
 }

--- a/src/flamegpu/sim/RunPlanVector.cpp
+++ b/src/flamegpu/sim/RunPlanVector.cpp
@@ -12,20 +12,20 @@ RunPlanVector::RunPlanVector(const ModelDescription &model, unsigned int initial
     this->resize(initial_length, RunPlan(environment, allow_0_steps));
 }
 
-RunPlanVector::RunPlanVector(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &_environment, const bool &_allow_0_steps)
+RunPlanVector::RunPlanVector(const std::shared_ptr<const std::unordered_map<std::string, EnvironmentDescription::PropData>> &_environment, const bool _allow_0_steps)
     : std::vector<RunPlan>()
     , randomPropertySeed(std::random_device()())
     , rand(randomPropertySeed)
     , environment(_environment)
     , allow_0_steps(_allow_0_steps) { }
-void RunPlanVector::setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int &step) {
+void RunPlanVector::setRandomSimulationSeed(const uint64_t &initial_seed, const unsigned int step) {
     uint64_t current_seed = initial_seed;
     for (auto &i : *this) {
         i.setRandomSimulationSeed(current_seed);
         current_seed += step;
     }
 }
-void RunPlanVector::setSteps(const unsigned int &steps) {
+void RunPlanVector::setSteps(const unsigned int steps) {
     if (steps == 0 && !allow_0_steps) {
         throw exception::OutOfBoundsException("Model description requires atleast 1 exit condition to have unlimited steps, "
             "in RunPlanVector::setSteps()");
@@ -104,7 +104,7 @@ RunPlanVector& RunPlanVector::operator+=(const RunPlanVector& rhs) {
     }
     return *this;
 }
-RunPlanVector& RunPlanVector::operator*=(const unsigned int& rhs) {
+RunPlanVector& RunPlanVector::operator*=(const unsigned int rhs) {
     RunPlanVector copy(*this);
     this->clear();
     this->reserve(copy.size() * rhs);
@@ -116,7 +116,7 @@ RunPlanVector& RunPlanVector::operator*=(const unsigned int& rhs) {
     }
     return *this;
 }
-RunPlanVector RunPlanVector::operator*(const unsigned int& rhs) const {
+RunPlanVector RunPlanVector::operator*(const unsigned int rhs) const {
     RunPlanVector rtn(this->environment, this->allow_0_steps);
     rtn.reserve(size() * rhs);
     for (unsigned int i = 0; i < rhs; ++i) {

--- a/src/flamegpu/util/detail/compute_capability.cu
+++ b/src/flamegpu/util/detail/compute_capability.cu
@@ -90,7 +90,7 @@ std::vector<int> compute_capability::getNVRTCSupportedComputeCapabilties() {
 
 int compute_capability::selectAppropraiteComputeCapability(const int target, const std::vector<int>& architectures) {
     int maxArch = 0;
-    for (const int arch : architectures) {
+    for (const int &arch : architectures) {
         if (arch <= target && arch > maxArch) {
             maxArch = arch;
             // The vector is in ascending order, so we can potentially early exit

--- a/src/flamegpu/util/detail/compute_capability.cu
+++ b/src/flamegpu/util/detail/compute_capability.cu
@@ -90,7 +90,7 @@ std::vector<int> compute_capability::getNVRTCSupportedComputeCapabilties() {
 
 int compute_capability::selectAppropraiteComputeCapability(const int target, const std::vector<int>& architectures) {
     int maxArch = 0;
-    for (const int &arch : architectures) {
+    for (const int arch : architectures) {
         if (arch <= target && arch > maxArch) {
             maxArch = arch;
             // The vector is in ascending order, so we can potentially early exit

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -627,7 +627,7 @@ class ModelVis;
  * It is required to ingore the original defintion of uniform and separate the two functions to have a distinct name
  */
 %extend flamegpu::HostRandom{
-    template<typename T> inline T uniformRange(const T& min, const T& max) const {
+    template<typename T> inline T uniformRange(const T min, const T max) const {
         return $self->uniform<T>(min, max);
     }
 

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -654,7 +654,7 @@ class ModelVis;
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
    }
-   void RunPlanVector::__setitem__(const size_t &index, flamegpu::RunPlan &value) {
+   void RunPlanVector::__setitem__(const size_t index, flamegpu::RunPlan &value) {
         $self->operator[](index) = value;
    }
 }

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -672,7 +672,7 @@ class ModelVis;
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
     }
-    void flamegpu::DeviceAgentVector_impl::__setitem__(const size_type &index, const Agent &value) {
+    void flamegpu::DeviceAgentVector_impl::__setitem__(const size_type index, const Agent &value) {
         $self->operator[](index).setData(value);
     }
 }

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -614,7 +614,7 @@ class ModelVis;
         def __len__(self):
             return self.size()
     }
-    flamegpu::AgentVector::Agent flamegpu::AgentVector::__getitem__(const int &index) {
+    flamegpu::AgentVector::Agent flamegpu::AgentVector::__getitem__(const int index) {
         if (index >= 0)
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
@@ -649,7 +649,7 @@ class ModelVis;
         else: # "insert" is used as if the vector is a native C++ container
             return self.insert(self, i, x)
    }
-   flamegpu::RunPlan &flamegpu::RunPlanVector::__getitem__(const int &index) {
+   flamegpu::RunPlan &flamegpu::RunPlanVector::__getitem__(const int index) {
         if (index >= 0)
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
@@ -667,7 +667,7 @@ class ModelVis;
         def __len__(self):
             return self.size()
     }
-    flamegpu::DeviceAgentVector_impl::Agent flamegpu::DeviceAgentVector_impl::__getitem__(const int &index) {
+    flamegpu::DeviceAgentVector_impl::Agent flamegpu::DeviceAgentVector_impl::__getitem__(const int index) {
         if (index >= 0)
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
@@ -992,7 +992,7 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
             def __len__(self):
                 return self.size()
         }
-        flamegpu::visualiser::Color flamegpu::visualiser::Palette::__getitem__(const int &index) {
+        flamegpu::visualiser::Color flamegpu::visualiser::Palette::__getitem__(const int index) {
             if (index >= 0)
                 return $self->operator[](index);
             return $self->operator[]($self->size() + index);

--- a/tests/test_cases/model/test_environment_description.cu
+++ b/tests/test_cases/model/test_environment_description.cu
@@ -105,9 +105,9 @@ void AddGet_SetGet_array_vec_test() {
 #endif
 /**
  * Tests void EnvDesc::newProperty<T, N>(const std::string &, const std::array<T, N>&)
- * Tests T EnvDesc::get<T, N>(const std::string &, const size_type &)
- * Tests T EnvDesc::set<T, N>(const std::string &, const size_type &, const T &)
- * Tests T EnvDesc::get<T, N>(const std::string &, const size_type &)
+ * Tests T EnvDesc::get<T, N>(const std::string &, size_type)
+ * Tests T EnvDesc::set<T, N>(const std::string &, size_type, const T &)
+ * Tests T EnvDesc::get<T, N>(const std::string &, size_type)
  */
 template<typename T>
 void AddGet_SetGet_array_element_test() {

--- a/tests/test_cases/model/test_environment_description.cu
+++ b/tests/test_cases/model/test_environment_description.cu
@@ -20,9 +20,9 @@ namespace {
 const int ARRAY_TEST_LEN = 5;
 
 /**
- * Tests void EnvDesc::newProperty<T>(const std::string &, const T&) 
+ * Tests void EnvDesc::newProperty<T>(const std::string &, T) 
  * Tests T EnvDesc::get<T>(const std::string &)
- * Tests T EnvDesc::set<T>(const std::string &, const T&) 
+ * Tests T EnvDesc::set<T>(const std::string &, T) 
  * Tests T EnvDesc::get<T>(const std::string &)
  */
 template<typename T>
@@ -106,7 +106,7 @@ void AddGet_SetGet_array_vec_test() {
 /**
  * Tests void EnvDesc::newProperty<T, N>(const std::string &, const std::array<T, N>&)
  * Tests T EnvDesc::get<T, N>(const std::string &, size_type)
- * Tests T EnvDesc::set<T, N>(const std::string &, size_type, const T &)
+ * Tests T EnvDesc::set<T, N>(const std::string &, size_type, T)
  * Tests T EnvDesc::get<T, N>(const std::string &, size_type)
  */
 template<typename T>

--- a/tests/test_cases/pop/test_agent_instance.cu
+++ b/tests/test_cases/pop/test_agent_instance.cu
@@ -243,7 +243,7 @@ TEST(AgentInstanceTest, getsetVariable) {
         // Wrong type
         EXPECT_THROW((ai.setVariable<float, 3>)("int3", float3_ref), exception::InvalidVarType);
     }
-    {  // setVariable(const std::string &variable_name, const unsigned int &array_index, const T &value)
+    {  // setVariable(const std::string &variable_name, unsigned int array_index, const T &value)
         // Bad name
         EXPECT_THROW(ai.setVariable<int>("wrong", 0, 1), exception::InvalidAgentVar);
         // Index out of bounds
@@ -275,7 +275,7 @@ TEST(AgentInstanceTest, getsetVariable) {
         // Wrong type
         EXPECT_THROW((ai.getVariable<float, 3>)("int3"), exception::InvalidVarType);
     }
-    {  // getVariable(const std::string &variable_name, const unsigned int &array_index) const
+    {  // getVariable(const std::string &variable_name, unsigned int array_index) const
         // Bad name
         EXPECT_THROW(ai.getVariable<int>("wrong", 0), exception::InvalidAgentVar);
         // Index out of bounds

--- a/tests/test_cases/pop/test_agent_instance.cu
+++ b/tests/test_cases/pop/test_agent_instance.cu
@@ -222,7 +222,7 @@ TEST(AgentInstanceTest, getsetVariable) {
     }
 
     // Check various exceptions
-    {  // setVariable(const std::string &variable_name, const T &value)
+    {  // setVariable(const std::string &variable_name, T value)
         // Bad name
         EXPECT_THROW(ai.setVariable<int>("wrong", 1), exception::InvalidAgentVar);
         // Array passed to non-array method
@@ -243,7 +243,7 @@ TEST(AgentInstanceTest, getsetVariable) {
         // Wrong type
         EXPECT_THROW((ai.setVariable<float, 3>)("int3", float3_ref), exception::InvalidVarType);
     }
-    {  // setVariable(const std::string &variable_name, unsigned int array_index, const T &value)
+    {  // setVariable(const std::string &variable_name, unsigned int array_index, T value)
         // Bad name
         EXPECT_THROW(ai.setVariable<int>("wrong", 0, 1), exception::InvalidAgentVar);
         // Index out of bounds

--- a/tests/test_cases/pop/test_agent_vector.cu
+++ b/tests/test_cases/pop/test_agent_vector.cu
@@ -1427,7 +1427,7 @@ TEST(AgentVectorTest, AgentVector_Agent) {
 
     // Check various exceptions
     AgentVector::Agent ai = pop.front();
-    {  // setVariable(const std::string &variable_name, const T &value)
+    {  // setVariable(const std::string &variable_name, T value)
         // Bad name
         EXPECT_THROW(ai.setVariable<int>("wrong", 1), exception::InvalidAgentVar);
         // Array passed to non-array method
@@ -1448,7 +1448,7 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         // Wrong type
         EXPECT_THROW((ai.setVariable<float, 3>)("int3", float3_ref), exception::InvalidVarType);
     }
-    {  // setVariable(const std::string &variable_name, unsigned int array_index, const T &value)
+    {  // setVariable(const std::string &variable_name, unsigned int array_index, T value)
         // Bad name
         EXPECT_THROW(ai.setVariable<int>("wrong", 0, 1), exception::InvalidAgentVar);
         // Index out of bounds

--- a/tests/test_cases/pop/test_agent_vector.cu
+++ b/tests/test_cases/pop/test_agent_vector.cu
@@ -1448,7 +1448,7 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         // Wrong type
         EXPECT_THROW((ai.setVariable<float, 3>)("int3", float3_ref), exception::InvalidVarType);
     }
-    {  // setVariable(const std::string &variable_name, const unsigned int &array_index, const T &value)
+    {  // setVariable(const std::string &variable_name, unsigned int array_index, const T &value)
         // Bad name
         EXPECT_THROW(ai.setVariable<int>("wrong", 0, 1), exception::InvalidAgentVar);
         // Index out of bounds
@@ -1480,7 +1480,7 @@ TEST(AgentVectorTest, AgentVector_Agent) {
         // Wrong type
         EXPECT_THROW((ai.getVariable<float, 3>)("int3"), exception::InvalidVarType);
     }
-    {  // getVariable(const std::string &variable_name, const unsigned int &array_index)
+    {  // getVariable(const std::string &variable_name, unsigned int array_index)
         // Bad name
         EXPECT_THROW(ai.getVariable<int>("wrong", 0), exception::InvalidAgentVar);
         // Index out of bounds

--- a/tests/test_cases/runtime/host_reduction/test_histogram_even.cu
+++ b/tests/test_cases/runtime/host_reduction/test_histogram_even.cu
@@ -39,7 +39,7 @@ FLAMEGPU_STEP_FUNCTION(step_histogramEvenuint64_t) {
  * Doesn't work great with odd boundaries and ranges near integer limits
  */
 template<typename InT, typename OutT>
-std::vector<OutT> histogramEven(const std::array<InT, TEST_LEN> &variables, const unsigned int &histogramBins, const InT &lowerBound, const InT &upperBound) {
+std::vector<OutT> histogramEven(const std::array<InT, TEST_LEN> &variables, const unsigned int histogramBins, const InT &lowerBound, const InT &upperBound) {
     assert(upperBound > lowerBound);
     std::vector<OutT> rtn(histogramBins);
     for (auto &i : rtn)

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -89,7 +89,7 @@ TEST(TestRunPlan, setProperty) {
     flamegpu::RunPlan plan(model);
     // Set properties to new values
     // Compare the old and new values, to ensure that thy do not match
-    // RunPlan::setProperty(const std::string &name, const T&value)
+    // RunPlan::setProperty(const std::string &name, T value)
     plan.setProperty<float>("f", 2.0f);
     plan.setProperty<int32_t>("i", 2);
     plan.setProperty<uint32_t>("u", 2u);
@@ -98,7 +98,7 @@ TEST(TestRunPlan, setProperty) {
     plan.setProperty<float, 3>("f_a", {-2.0f, 0.0f, 2.0f});
     plan.setProperty<int32_t, 3>("i_a", {-2, 0, 2});
     // Set individual elements at a time
-    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
     plan.setProperty<uint32_t>("u_a", 0, 3u);
     plan.setProperty<uint32_t>("u_a", 1, 4u);
     plan.setProperty<uint32_t>("u_a", 2, 5u);
@@ -129,7 +129,7 @@ TEST(TestRunPlan, setProperty) {
 #endif
 
     // Update properties again (previous bug)
-    // RunPlan::setProperty(const std::string &name, const T&value)
+    // RunPlan::setProperty(const std::string &name, T value)
     plan.setProperty<float>("f", 3.0f);
     plan.setProperty<int32_t>("i", 3);
     plan.setProperty<uint32_t>("u", 3u);
@@ -138,7 +138,7 @@ TEST(TestRunPlan, setProperty) {
     plan.setProperty<float, 3>("f_a", { 3.0f, 0.0f, -3.0f });
     plan.setProperty<int32_t, 3>("i_a", { 3, 0, 5 });
     // Set individual elements at a time
-    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
     plan.setProperty<uint32_t>("u_a", 0, 13u);
     plan.setProperty<uint32_t>("u_a", 1, 14u);
     plan.setProperty<uint32_t>("u_a", 2, 15u);
@@ -171,17 +171,17 @@ TEST(TestRunPlan, setProperty) {
     // Tests for exceptions
     // --------------------
     // Note literals used must match the templated type not the incorrect types used, to appease MSVC warnings.
-    // RunPlan::setProperty(const std::string &name, const T&value)
+    // RunPlan::setProperty(const std::string &name, T value)
     EXPECT_THROW(plan.setProperty<float>("does_not_exist", 1.f), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW(plan.setProperty<float>("i", 1.f), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW(plan.setProperty<uint32_t>("u_a", 1u), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((plan.setProperty<float, 3>("does_not_exist", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.setProperty<float, 3>("u_a", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.setProperty<int32_t, 2>("i_a", {-2, 0})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.setProperty<int32_t, 4>("i_a", {-2, 0, 2, 2})), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
     EXPECT_THROW((plan.setProperty<float>("does_not_exist", 0u, 3.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.setProperty<float>("u_a", 0u, 3.f)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.setProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1), 3)), exception::OutOfBoundsException);
@@ -191,13 +191,13 @@ TEST(TestRunPlan, setProperty) {
     EXPECT_THROW(plan.getProperty<float>("does_not_exist"), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW(plan.getProperty<float>("i"), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW(plan.getProperty<uint32_t>("u_a"), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index)
+    // RunPlan::getProperty(const std::string &name, EnvironmentManager::size_type index)
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((plan.getProperty<float, 3>("does_not_exist")), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.getProperty<float, 3>("u_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 2>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 4>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index)
+    // RunPlan::getProperty(const std::string &name, EnvironmentManager::size_type index)
     EXPECT_THROW((plan.getProperty<float>("does_not_exist", 0u)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.getProperty<float>("u_a", 0u)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1))), exception::OutOfBoundsException);
@@ -274,7 +274,7 @@ TEST(TestRunPlan, getProperty) {
     EXPECT_THROW((plan.getProperty<float, 3>("u_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 2>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 4>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
-    // T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type &index) const
+    // T RunPlan::getProperty(const std::string &name, EnvironmentManager::size_type index) const
     EXPECT_THROW((plan.getProperty<float>("does_not_exist", 0u)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.getProperty<float>("u_a", 0u)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1))), exception::OutOfBoundsException);

--- a/tests/test_cases/sim/test_RunPlanVector.cu
+++ b/tests/test_cases/sim/test_RunPlanVector.cu
@@ -625,7 +625,7 @@ TEST(TestRunPlanVector, operatorAddition) {
     EXPECT_THROW((planVector += otherPlanVector), flamegpu::exception::InvalidArgument);
     EXPECT_THROW((otherPlanVector += planVector), flamegpu::exception::InvalidArgument);
 }
-// RunPlanVector operator*(const unsigned int& rhs) const;
+// RunPlanVector operator*(unsigned int rhs) const;
 TEST(TestRunPlanVector, operatorMultiplication) {
     // Define the simple model to use
     flamegpu::ModelDescription model("test");
@@ -635,14 +635,14 @@ TEST(TestRunPlanVector, operatorMultiplication) {
     EXPECT_EQ(plans.size(), totalPlans);
 
     // Multiply the plan vector by a fixed size
-    // RunPlanVector operator*(const unsigned int& rhs) const;
+    // RunPlanVector operator*(unsigned int rhs) const;
     const uint32_t mult = 2u;
     flamegpu::RunPlanVector morePlans = plans * mult;
     const uint32_t expectedSize = mult * totalPlans;
     EXPECT_EQ(morePlans.size(), expectedSize);
 
     // multiply a plan in-place
-    // RunPlanVector& operator*=(const unsigned int& rhs);
+    // RunPlanVector& operator*=(unsigned int rhs);
     plans *= mult;
     EXPECT_EQ(plans.size(), expectedSize);
 }

--- a/tests/test_cases/sim/test_RunPlanVector.cu
+++ b/tests/test_cases/sim/test_RunPlanVector.cu
@@ -114,7 +114,7 @@ TEST(TestRunPlanVector, setProperty) {
     const int32_t iNew = 2;
     const std::array<uint32_t, 3> u3New = {{3u, 4u, 5u}};
     const std::array<double, 3> d3New = {{3., 4., 5.}};
-    // void RunPlanVector::setProperty(const std::string &name, const T &value) {
+    // void RunPlanVector::setProperty(const std::string &name, T value) {
     plans.setProperty("f", fNew);
     plans.setProperty("i", iNew);
     // Check setting full arrays
@@ -122,7 +122,7 @@ TEST(TestRunPlanVector, setProperty) {
     // Explicit type is required, to coerce the std::array. Might need partial template specialisation for  where the value is a stdarray of T?
     plans.setProperty<uint32_t, 3>("u3", u3New);
     // Check setting individual array elements
-    // void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value) {
+    // void RunPlanVector::setProperty(const std::string &name, EnvironmentManager::size_type index, T value) {
     plans.setProperty<double>("d3", 0, d3New[0]);
     plans.setProperty<double>("d3", 1, d3New[1]);
     plans.setProperty<double>("d3", 2, d3New[2]);
@@ -153,7 +153,7 @@ TEST(TestRunPlanVector, setProperty) {
     // Tests for exceptions
     // --------------------
     // Note litereals used must match the templated type not the incorrect types used, to appease MSVC warnings.
-    // void RunPlanVector::setProperty(const std::string &name, const T &value)
+    // void RunPlanVector::setProperty(const std::string &name, T value)
     EXPECT_THROW(plans.setProperty<float>("does_not_exist", 1.f), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW(plans.setProperty<float>("i", 1.f), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW(plans.setProperty<uint32_t>("u3", 1u), flamegpu::exception::InvalidEnvPropertyType);
@@ -163,7 +163,7 @@ TEST(TestRunPlanVector, setProperty) {
     EXPECT_THROW((plans.setProperty<float, 3>("u3", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setProperty<double, 2>("d3", {-2, 0})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setProperty<double, 4>("d3", {-2, 0, 2, 2})), flamegpu::exception::InvalidEnvPropertyType);
-    // void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type &index, const T &value)
+    // void RunPlanVector::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
     EXPECT_THROW((plans.setProperty<float>("does_not_exist", 0u, 3.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setProperty<float>("u3", 0u, 3.f)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setProperty<double>("d3", static_cast<EnvironmentManager::size_type>(-1), 3)), exception::OutOfBoundsException);
@@ -174,7 +174,7 @@ TEST(TestRunPlanVector, setProperty) {
 #endif
 }
 template<typename T>
-double t_lerp(const T &_min, const T &_max, const double &a) {
+double t_lerp(const T _min, const T _max, const double a) {
     double min = static_cast<double>(_min);
     double max = static_cast<double>(_max);
     return min * (1.0 - a) + max * a;
@@ -212,12 +212,12 @@ TEST(TestRunPlanVector, setPropertyUniformDistribution) {
     const std::array<uint32_t, 3> u3Max = {{100u, 200u, 300u}};
     const std::array<float, 2> f2Min = { {1.0f, 100.f} };
     const std::array<float, 2> f2Max = { {0.0f, -100.0f} };
-    // void setPropertyUniformDistribution(const std::string &name, const T &min, const T &max);
+    // void setPropertyUniformDistribution(const std::string &name, T min, T max);
     plans.setPropertyUniformDistribution("f", fMin, fMax);
     plans.setPropertyUniformDistribution("fb", fbMin, fbMax);
     plans.setPropertyUniformDistribution("i", iMin, iMax);
     // Check setting individual array elements
-    // void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &max);
+    // void setPropertyUniformDistribution(const std::string &name, EnvironmentManager::size_type index, T min, T max);
     plans.setPropertyUniformDistribution("u3", 0, u3Min[0], u3Max[0]);
     plans.setPropertyUniformDistribution("u3", 1, u3Min[1], u3Max[1]);
     plans.setPropertyUniformDistribution("u3", 2, u3Min[2], u3Max[2]);
@@ -245,7 +245,7 @@ TEST(TestRunPlanVector, setPropertyUniformDistribution) {
     // --------------------
     flamegpu::RunPlanVector singlePlanVector(model, 1);
     // Note literals used must match the templated type not the incorrect types used, to appease MSVC warnings.
-    // void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const T &min, const T &max)
+    // void RunPlanVector::setPropertyUniformDistribution(const std::string &name, T min, T max)
     EXPECT_THROW((singlePlanVector.setPropertyUniformDistribution<float>("f", 1.f, 100.f)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setPropertyUniformDistribution<float>("does_not_exist", 1.f, 100.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setPropertyUniformDistribution<float>("i", 1.f, 100.f)), flamegpu::exception::InvalidEnvPropertyType);
@@ -284,11 +284,11 @@ TEST(TestRunPlanVector, setPropertyUniformRandom) {
     const int32_t iMax = 100;
     const std::array<uint32_t, 3> u3Min = {{1u, 101u, 201u}};
     const std::array<uint32_t, 3> u3Max = {{100u, 200u, 300u}};
-    // void setPropertyUniformRandom(const std::string &name, const T &min, const T &Max);
+    // void setPropertyUniformRandom(const std::string &name, T min, T Max);
     plans.setPropertyUniformRandom("f", fMin, fMax);
     plans.setPropertyUniformRandom("i", iMin, iMax);
     // Check setting individual array elements
-    // void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &min, const T &Max);
+    // void setPropertyUniformRandom(const std::string &name, EnvironmentManager::size_type index, T min, T Max);
     plans.setPropertyUniformRandom("u3", 0, u3Min[0], u3Max[0]);
     plans.setPropertyUniformRandom("u3", 1, u3Min[1], u3Max[1]);
     plans.setPropertyUniformRandom("u3", 2, u3Min[2], u3Max[2]);
@@ -335,10 +335,10 @@ TEST(TestRunPlanVector, setPropertyNormalRandom) {
     const float fStddev = 100.f;
     const std::array<double, 3> d3Mean = {{1., 101., 201.}};
     const std::array<double, 3> d3Stddev = {{100., 200., 300.}};
-    // void setPropertyNormalRandom(const std::string &name, const T &mean, const T &stddev);
+    // void setPropertyNormalRandom(const std::string &name, T mean, T stddev);
     plans.setPropertyNormalRandom("f", fMean, fStddev);
     // Check setting individual array elements
-    // void setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev);
+    // void setPropertyNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev);
     plans.setPropertyNormalRandom("d3", 0, d3Mean[0], d3Stddev[0]);
     plans.setPropertyNormalRandom("d3", 1, d3Mean[1], d3Stddev[1]);
     plans.setPropertyNormalRandom("d3", 2, d3Mean[2], d3Stddev[2]);
@@ -391,10 +391,10 @@ TEST(TestRunPlanVector, setPropertyLogNormalRandom) {
     const float fStddev = 100.f;
     const std::array<double, 3> d3Mean = {{1., 101., 201.}};
     const std::array<double, 3> d3Stddev = {{100., 200., 300.}};
-    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T &mean, const T &stddev) {
+    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, T mean, T stddev) {
     plans.setPropertyLogNormalRandom("f", fMean, fStddev);
     // Check setting individual array elements
-    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type &index, const T &mean, const T &stddev) {
+    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev) {
     plans.setPropertyLogNormalRandom("d3", 0, d3Mean[0], d3Stddev[0]);
     plans.setPropertyLogNormalRandom("d3", 1, d3Mean[1], d3Stddev[1]);
     plans.setPropertyLogNormalRandom("d3", 2, d3Mean[2], d3Stddev[2]);
@@ -450,7 +450,7 @@ TEST(TestRunPlanVector, setPropertyRandom) {
     std::uniform_real_distribution<float> fdist(fMin, fMax);
     plans.setPropertyRandom<float>("f", fdist);
     // Check setting individual array elements
-    // void setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution);
+    // void setPropertyRandom(const std::string &name, EnvironmentManager::size_type index, rand_dist &distribution);
     std::normal_distribution<double> d3dist0(d3Mean[0], d3Stddev[0]);
     std::normal_distribution<double> d3dist1(d3Mean[1], d3Stddev[1]);
     std::normal_distribution<double> d3dist2(d3Mean[2], d3Stddev[2]);
@@ -489,7 +489,7 @@ TEST(TestRunPlanVector, setPropertyRandom) {
     EXPECT_THROW((plans.setPropertyRandom<float>("does_not_exist", fdist)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setPropertyRandom<double>("f", d3dist0)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setPropertyRandom<double>("d3", d3dist0)), flamegpu::exception::InvalidEnvPropertyType);
-    // void RunPlanVector::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type &index, rand_dist &distribution)
+    // void RunPlanVector::setPropertyRandom(const std::string &name, EnvironmentManager::size_type index, rand_dist &distribution)
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((singlePlanVector.setPropertyRandom<double>("d3", 0u, d3dist0)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setPropertyRandom<float>("does_not_exist", 0u, fdist)), flamegpu::exception::InvalidEnvProperty);


### PR DESCRIPTION
Fixes #825 

Data types fixed

- [x] unsigned int
- [x] int
- [x] bool
- [x] char
- [x] unsigned char
- [x] size_type (unsigned int)
- [x] float
- [x] double
- [x] signed char (we have some use of this)
- [x] EnvironmentManager::size_type
- [x] uint64_t
- [x] int64_t
- [x] uint16_t
- [x] int16_t
- [x] T
- [x] T2 (from use in macro properties)
- [x] cudaStream_t
- [x] size_t

Each items has been searched for using `const type &` as well as `const type&` as linting allows either.

Where const references appear in declarations they have been made primitive (pass by value) type argument and `const` has been removed as it is meaningless. Within definitions `const` primitive types are allowed as this signals an intention that the argument should not be changed in the function body.