### PR TITLE
Use of a generic size type

### DIFF
--- a/include/flamegpu/defines.h
+++ b/include/flamegpu/defines.h
@@ -18,6 +18,8 @@ constexpr const char* ID_VARIABLE_NAME = "_id";
  */
 constexpr id_t ID_NOT_SET = 0;
 
+typedef unsigned int size_type;
+
 }  // namespace flamegpu
 
 #endif  // INCLUDE_FLAMEGPU_DEFINES_H_

--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -183,7 +183,7 @@ class CUDASimulation : public Simulation {
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      * @throws exception::ReadOnlyEnvProperty If the named environment property is marked as read-only
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     void setEnvironmentProperty(const std::string &property_name, const std::array<T, N> &value);
     /**
      * Update the value of the specified element of the named environment property array
@@ -195,8 +195,8 @@ class CUDASimulation : public Simulation {
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      * @throws exception::ReadOnlyEnvProperty If the named environment property is marked as read-only
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    void setEnvironmentProperty(const std::string& property_name, EnvironmentManager::size_type index, T value);
+    template<typename T, flamegpu::size_type N = 0>
+    void setEnvironmentProperty(const std::string& property_name, flamegpu::size_type index, T value);
 #ifdef SWIG
     /**
      * Update the current value of the named environment property array
@@ -224,7 +224,7 @@ class CUDASimulation : public Simulation {
      * @tparam T Type of the elements of the environment property array
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     std::array<T, N> getEnvironmentProperty(const std::string &property_name);
     /**
      * Return the current value of the specified element of the named environment property array
@@ -234,8 +234,8 @@ class CUDASimulation : public Simulation {
      * @tparam N (Optional) The length of the array variable, available for parity with other APIs, checked if provided
      * @throws exception::InvalidEnvPropertyType If the named environment property does not exist with the specified type
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    T getEnvironmentProperty(const std::string& property_name, EnvironmentManager::size_type index);
+    template<typename T, flamegpu::size_type N = 0>
+    T getEnvironmentProperty(const std::string& property_name, flamegpu::size_type index);
 #ifdef SWIG
     /**
      * Return the current value of the named environment property array
@@ -627,7 +627,7 @@ void CUDASimulation::setEnvironmentProperty(const std::string& property_name, co
         initialiseSingletons();
     singletons->environment->setProperty<T>(property_name, value);
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const std::array<T, N>& value) {
     if (!property_name.empty() && property_name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
@@ -637,8 +637,8 @@ void CUDASimulation::setEnvironmentProperty(const std::string& property_name, co
         initialiseSingletons();
     singletons->environment->setProperty<T, N>(property_name, value);
 }
-template<typename T, EnvironmentManager::size_type N>
-void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type index, const T value) {
+template<typename T, flamegpu::size_type N>
+void CUDASimulation::setEnvironmentProperty(const std::string& property_name, const flamegpu::size_type index, const T value) {
     if (!singletonsInitialised)
         initialiseSingletons();
     singletons->environment->setProperty<T, N>(property_name, index, value);
@@ -649,14 +649,14 @@ T CUDASimulation::getEnvironmentProperty(const std::string& property_name) {
         initialiseSingletons();
     return singletons->environment->getProperty<T>(property_name);
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> CUDASimulation::getEnvironmentProperty(const std::string& property_name) {
     if (!singletonsInitialised)
         initialiseSingletons();
     return singletons->environment->getProperty<T, N>(property_name);
 }
-template<typename T, EnvironmentManager::size_type N>
-T CUDASimulation::getEnvironmentProperty(const std::string& property_name, const EnvironmentManager::size_type index) {
+template<typename T, flamegpu::size_type N>
+T CUDASimulation::getEnvironmentProperty(const std::string& property_name, const flamegpu::size_type index) {
     if (!singletonsInitialised)
         initialiseSingletons();
     return singletons->environment->getProperty<T, N>(property_name, index);

--- a/include/flamegpu/model/AgentDescription.h
+++ b/include/flamegpu/model/AgentDescription.h
@@ -42,7 +42,7 @@ class AgentDescription {
     /**
      * AgentVector takes a clone of AgentData
      */
-    friend AgentVector::AgentVector(const AgentDescription& agent_desc, AgentVector::size_type);
+    friend AgentVector::AgentVector(const AgentDescription& agent_desc, flamegpu::size_type);
     friend AgentInstance::AgentInstance(const AgentDescription& agent_desc);
     friend bool AgentVector::matchesAgentType(const AgentDescription& other) const;
     /**
@@ -117,7 +117,7 @@ class AgentDescription {
      * @throws exception::InvalidAgentVar If a variable already exists within the agent with the same name
      * @throws exception::InvalidAgentVar If N is <= 0
      */
-    template<typename T, ModelData::size_type N>
+    template<typename T, flamegpu::size_type N>
     void newVariable(const std::string &variable_name, const std::array<T, N> &default_value = {});
 #ifndef SWIG
     /**
@@ -152,7 +152,7 @@ class AgentDescription {
      * @throws exception::InvalidAgentVar If length is <= 0
      */
     template<typename T>
-    void newVariableArray(const std::string &variable_name, const ModelData::size_type &length, const std::vector<T>&default_value = {});
+    void newVariableArray(const std::string &variable_name, const flamegpu::size_type &length, const std::vector<T>&default_value = {});
 #endif
 
     /**
@@ -204,7 +204,7 @@ class AgentDescription {
     /**
      * @return The number of possible states agents of this type can enter
      */
-    ModelData::size_type getStatesCount() const;
+    flamegpu::size_type getStatesCount() const;
     /**
      * @return The state which newly created agents of this type begin in
      */
@@ -226,13 +226,13 @@ class AgentDescription {
      * @return The number of elements in the name variable (1 if it isn't an array)
      * @throws exception::InvalidAgentVar If a variable with the name does not exist within the agent
      */
-    ModelData::size_type getVariableLength(const std::string &variable_name) const;
+    flamegpu::size_type getVariableLength(const std::string &variable_name) const;
     /**
      * Get the total number of variables this agent has
      * @return The total number of variables within the agent
      * @note This count includes internal variables used to track things such as agent ID
      */
-    ModelData::size_type getVariablesCount() const;
+    flamegpu::size_type getVariablesCount() const;
     /**
      * Returns an immutable reference to the named agent function
      * @param function_name Name used to refer to the desired agent function
@@ -245,13 +245,13 @@ class AgentDescription {
      * Get the total number of functions this agent has
      * @return The total number of functions within the agent
      */
-    ModelData::size_type getFunctionsCount() const;
+    flamegpu::size_type getFunctionsCount() const;
     /**
      * The total number of agent functions, within the ModelDescription hierarchy, which create new agents of this type
      * @return The total number of agent functions within the ModelDescription hierarchy which create new agents of this type
      * @see AgentDescription::isOutputOnDevice()
      */
-    ModelData::size_type getAgentOutputsCount() const;
+    flamegpu::size_type getAgentOutputsCount() const;
     /**
      * @param state_name Name of the state to check
      * @return True when a state with the specified name exists within the agent
@@ -298,7 +298,7 @@ class AgentDescription {
 /**
  * Template implementation
  */
-template <typename T, ModelData::size_type N>
+template <typename T, flamegpu::size_type N>
 void AgentDescription::newVariable(const std::string &variable_name, const std::array<T, N> &default_value) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
@@ -333,7 +333,7 @@ void AgentDescription::newVariable(const std::string &variable_name, const T def
 }
 #ifdef SWIG
 template<typename T>
-void AgentDescription::newVariableArray(const std::string& variable_name, const ModelData::size_type& length, const std::vector<T>& default_value) {
+void AgentDescription::newVariableArray(const std::string& variable_name, const flamegpu::size_type& length, const std::vector<T>& default_value) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Agent variable names cannot begin with '_', this is reserved for internal usage, "
             "in AgentDescription::newVariable().");

--- a/include/flamegpu/model/EnvironmentDescription.h
+++ b/include/flamegpu/model/EnvironmentDescription.h
@@ -140,7 +140,7 @@ class EnvironmentDescription {
      * @tparam N Length of the environmental property array to be created
      * @throws exception::DuplicateEnvProperty If a property of the same name already exists
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     void newProperty(const std::string &name, const std::array<T, N> &value, bool isConst = false);
 #ifdef SWIG
     /**
@@ -167,7 +167,7 @@ class EnvironmentDescription {
      * @tparam K Length of the third dimension of the macro property, default 1
      * @tparam W Length of the fourth dimension of the macro property, default 1
      */
-    template<typename T, EnvironmentManager::size_type I = 1, EnvironmentManager::size_type J = 1, EnvironmentManager::size_type K = 1, EnvironmentManager::size_type W = 1>
+    template<typename T, flamegpu::size_type I = 1, flamegpu::size_type J = 1, flamegpu::size_type K = 1, flamegpu::size_type W = 1>
     void newMacroProperty(const std::string& name);
 #ifdef SWIG
     /**
@@ -184,7 +184,7 @@ class EnvironmentDescription {
      * @tparam T Type of the macro property
      */
     template<typename T>
-    void newMacroProperty_swig(const std::string& name, EnvironmentManager::size_type I = 1, EnvironmentManager::size_type J = 1, EnvironmentManager::size_type K = 1, EnvironmentManager::size_type W = 1);
+    void newMacroProperty_swig(const std::string& name, flamegpu::size_type I = 1, flamegpu::size_type J = 1, flamegpu::size_type K = 1, flamegpu::size_type W = 1);
 #endif
     /**
      * Gets an environment property
@@ -201,7 +201,7 @@ class EnvironmentDescription {
      * @tparam N Length of the array to be returned
      * @throws exception::InvalidEnvProperty If a property array of the name does not exist
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     std::array<T, N> getProperty(const std::string &name) const;
     /**
      * Gets an element of an environment property array
@@ -212,7 +212,7 @@ class EnvironmentDescription {
      * @throws std::out_of_range
      */
     template<typename T>
-    T getProperty(const std::string &name, EnvironmentManager::size_type index) const;
+    T getProperty(const std::string &name, flamegpu::size_type index) const;
 #ifdef SWIG
     /**
      * Gets an environment property array
@@ -249,7 +249,7 @@ class EnvironmentDescription {
      * @return Returns the previous value
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     std::array<T, N> setProperty(const std::string &name, const std::array<T, N> &value);
     /**
      * Sets an element of an environment property array
@@ -263,7 +263,7 @@ class EnvironmentDescription {
      * @see set(const std::string &, T value)
      */
     template<typename T>
-    T setProperty(const std::string &name, EnvironmentManager::size_type index, T value);
+    T setProperty(const std::string &name, flamegpu::size_type index, T value);
 #ifdef SWIG
     /**
      * Sets an environment property array
@@ -290,7 +290,7 @@ class EnvironmentDescription {
      * @param elements How many elements does the property have (1 if it's not an array)
      * @param type value returned by typeid()
      */
-    void newProperty(const std::string &name, const char *ptr, size_t len, bool isConst, EnvironmentManager::size_type elements, const std::type_index &type);
+    void newProperty(const std::string &name, const char *ptr, size_t len, bool isConst, flamegpu::size_type elements, const std::type_index &type);
     /**
      * Main storage of all properties
      */
@@ -322,7 +322,7 @@ void EnvironmentDescription::newProperty(const std::string &name, T value, bool 
     }
     newProperty(name, reinterpret_cast<const char*>(&value), sizeof(T), isConst, type_decode<T>::len_t, typeid(typename type_decode<T>::type_t));
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 void EnvironmentDescription::newProperty(const std::string &name, const std::array<T, N> &value, bool isConst) {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
@@ -390,7 +390,7 @@ T EnvironmentDescription::getProperty(const std::string &name) const {
         "in EnvironmentDescription::getProperty().",
         name.c_str());
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> EnvironmentDescription::getProperty(const std::string &name) const {
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
@@ -418,7 +418,7 @@ std::array<T, N> EnvironmentDescription::getProperty(const std::string &name) co
         name.c_str());
 }
 template<typename T>
-T EnvironmentDescription::getProperty(const std::string &name, EnvironmentManager::size_type index) const {
+T EnvironmentDescription::getProperty(const std::string &name, flamegpu::size_type index) const {
     // Limited to Arithmetic types
     // Compound types would allow host pointers inside structs to be passed
     static_assert(std::is_arithmetic<typename type_decode<T>::type_t>::value || std::is_enum<typename type_decode<T>::type_t>::value,
@@ -513,7 +513,7 @@ T EnvironmentDescription::setProperty(const std::string &name, T value) {
         "in EnvironmentDescription::setProperty().",
         name.c_str());
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> EnvironmentDescription::setProperty(const std::string &name, const std::array<T, N> &value) {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
@@ -547,7 +547,7 @@ std::array<T, N> EnvironmentDescription::setProperty(const std::string &name, co
         name.c_str());
 }
 template<typename T>
-T EnvironmentDescription::setProperty(const std::string &name, EnvironmentManager::size_type index, T value) {
+T EnvironmentDescription::setProperty(const std::string &name, flamegpu::size_type index, T value) {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in EnvironmentDescription::setProperty().");
@@ -624,7 +624,7 @@ std::vector<T> EnvironmentDescription::setPropertyArray(const std::string& name,
         name.c_str());
 }
 #endif
-template<typename T, EnvironmentManager::size_type I, EnvironmentManager::size_type J, EnvironmentManager::size_type K, EnvironmentManager::size_type W>
+template<typename T, flamegpu::size_type I, flamegpu::size_type J, flamegpu::size_type K, flamegpu::size_type W>
 void EnvironmentDescription::newMacroProperty(const std::string& name) {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment macro property names cannot begin with '_', this is reserved for internal usage, "
@@ -647,7 +647,7 @@ void EnvironmentDescription::newMacroProperty(const std::string& name) {
 }
 #ifdef SWIG
 template<typename T>
-void EnvironmentDescription::newMacroProperty_swig(const std::string& name, EnvironmentManager::size_type I, EnvironmentManager::size_type J, EnvironmentManager::size_type K, EnvironmentManager::size_type W) {
+void EnvironmentDescription::newMacroProperty_swig(const std::string& name, flamegpu::size_type I, flamegpu::size_type J, flamegpu::size_type K, flamegpu::size_type W) {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment macro property names cannot begin with '_', this is reserved for internal usage, "
             "in EnvironmentDescription::newMacroProperty().");

--- a/include/flamegpu/model/LayerData.h
+++ b/include/flamegpu/model/LayerData.h
@@ -56,7 +56,7 @@ struct LayerData {
      * Index of the layer in the stack
      * (Eventually this will be replaced when we move to a more durable mode of layers, e.g. dependency analysis)
      */
-    ModelData::size_type index;
+    flamegpu::size_type index;
     /**
      * Equality operator, checks whether LayerData hierarchies are functionally the same
      * @returns True when layers are the same
@@ -84,7 +84,7 @@ struct LayerData {
     /**
      * Normal constructor, only to be called by ModelDescription
      */
-    LayerData(const std::shared_ptr<const ModelData> &model, const std::string &name, const ModelData::size_type &index);
+    LayerData(const std::shared_ptr<const ModelData> &model, const std::string &name, const flamegpu::size_type &index);
 };
 
 }  // namespace flamegpu

--- a/include/flamegpu/model/LayerDescription.h
+++ b/include/flamegpu/model/LayerDescription.h
@@ -154,20 +154,20 @@ class LayerDescription {
     /**
      * @return The index of the layer within the model's execution
      */
-    ModelData::size_type getIndex() const;
+    flamegpu::size_type getIndex() const;
     /**
      * @return The total number of agent functions within the layer
      */
-    ModelData::size_type getAgentFunctionsCount() const;
+    flamegpu::size_type getAgentFunctionsCount() const;
     /**
      * @return The total number of host functions within the layer
      */
-    ModelData::size_type getHostFunctionsCount() const;
+    flamegpu::size_type getHostFunctionsCount() const;
 #ifdef SWIG
     /**
      * @return The total number of host function callbacks within the layer
      */
-    inline ModelData::size_type getHostFunctionCallbackCount() const;
+    inline flamegpu::size_type getHostFunctionCallbackCount() const;
     /**
      * Adds a host function to this layer, similar to addHostFunction
      * however the runnable function is encapsulated within an object which permits cross language support in swig.
@@ -322,9 +322,9 @@ void LayerDescription::addAgentFunction(AgentFunction /*af*/) {
 void LayerDescription::addHostFunctionCallback(HostFunctionCallback* func_callback) {
     this->_addHostFunctionCallback(func_callback);
 }
-ModelData::size_type LayerDescription::getHostFunctionCallbackCount() const {
+flamegpu::size_type LayerDescription::getHostFunctionCallbackCount() const {
     // Safe down-cast
-    return static_cast<ModelData::size_type>(layer->host_functions_callbacks.size());
+    return static_cast<flamegpu::size_type>(layer->host_functions_callbacks.size());
 }
 HostFunctionCallback* LayerDescription::getHostFunctionCallback(unsigned int index) const {
     if (index < layer->host_functions_callbacks.size()) {

--- a/include/flamegpu/model/ModelData.h
+++ b/include/flamegpu/model/ModelData.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 
+#include "flamegpu/defines.h"
 #include "flamegpu/model/EnvironmentDescription.h"
 #include "flamegpu/runtime/HostAPI_macros.h"
 #include "flamegpu/runtime/messaging/MessageBruteForce.h"
@@ -36,10 +37,6 @@ struct ModelData : std::enable_shared_from_this<ModelData>{
      * Description needs full access
      */
     friend class ModelDescription;
-    /**
-     * Common size type used in the definition of models
-     */
-    typedef unsigned int size_type;
     /**
      * Map of name:agent definition
      * map<string, AgentData>
@@ -161,7 +158,7 @@ struct ModelData : std::enable_shared_from_this<ModelData>{
     /**
      * @return The maximum layer width within the model's hierarchy
      */
-    ModelData::size_type getMaxLayerWidth() const;
+    flamegpu::size_type getMaxLayerWidth() const;
 
  protected:
     friend SubModelData;  // Uses private copy constructor

--- a/include/flamegpu/model/ModelDescription.h
+++ b/include/flamegpu/model/ModelDescription.h
@@ -161,7 +161,7 @@ class ModelDescription {
      * @param name Name used to refer to the desired layer within the model description hierarchy
      * @return A mutable reference to the specified LayerDescription
      * @throws exception::InvalidFuncLayerIndx If a layer with the name does not exist within the model description hierarchy
-     * @see ModelDescription::Layer(const ModelData::size_type &)
+     * @see ModelDescription::Layer(const flamegpu::size_type &)
      * @see ModelDescription::getLayer(const std::string &) for the immutable version
      */
     LayerDescription& Layer(const std::string &name);
@@ -171,9 +171,9 @@ class ModelDescription {
      * @return A mutable reference to the specified LayerDescription
      * @throws exception::InvalidFuncLayerIndx If a layer with the name does not exist within the model description hierarchy
      * @see ModelDescription::Layer(const std::string &)
-     * @see ModelDescription::getLayer(const ModelData::size_type &) for the immutable version
+     * @see ModelDescription::getLayer(const flamegpu::size_type &) for the immutable version
      */
-    LayerDescription& Layer(const ModelData::size_type &layer_index);
+    LayerDescription& Layer(const flamegpu::size_type &layer_index);
 
     /**
      * Adds an init function to the simulation
@@ -330,7 +330,7 @@ class ModelDescription {
      * @param name Name used to refer to the desired layer within the model description hierarchy
      * @return An immutable reference to the specified LayerDescription
      * @throws exception::InvalidFuncLayerIndx If a layer with the name does not exist within the model description hierarchy
-     * @see ModelDescription::getLayer(const ModelData::size_type &)
+     * @see ModelDescription::getLayer(const flamegpu::size_type &)
      * @see ModelDescription::Layer(const std::string &) for the mutable version
      */
     const LayerDescription& getLayer(const std::string &name) const;
@@ -340,9 +340,9 @@ class ModelDescription {
      * @return An immutable reference to the specified LayerDescription
      * @throws exception::InvalidFuncLayerIndx If a layer with the name does not exist within the model description hierarchy
      * @see ModelDescription::getLayer(const std::string &)
-     * @see ModelDescription::Layer(const ModelData::size_type &) for the mutable version
+     * @see ModelDescription::Layer(const flamegpu::size_type &) for the mutable version
      */
-    const LayerDescription& getLayer(const ModelData::size_type &layer_index) const;
+    const LayerDescription& getLayer(const flamegpu::size_type &layer_index) const;
 
     /**
      * @param agent_name Name of the agent to check
@@ -372,7 +372,7 @@ class ModelDescription {
      * @param layer_index Index of the agent to check
      * @return True when a layer with the specified index exists within the model's hierarchy
      */
-    bool hasLayer(const ModelData::size_type &layer_index) const;
+    bool hasLayer(const flamegpu::size_type &layer_index) const;
     /**
      * @param submodel_name Name of the submodel to check
      * @return True when a submodel with the specified name exists within the model's hierarchy
@@ -382,15 +382,15 @@ class ModelDescription {
     /**
      * @return The number of agents within the model's hierarchy
      */
-    ModelData::size_type getAgentsCount() const;
+    flamegpu::size_type getAgentsCount() const;
     /**
      * @return The number of messages within the model's hierarchy
      */
-    ModelData::size_type getMessagesCount() const;
+    flamegpu::size_type getMessagesCount() const;
     /**
      * @return The number of layers within the model's hierarchy
      */
-    ModelData::size_type getLayersCount() const;
+    flamegpu::size_type getLayersCount() const;
 
  private:
     /**

--- a/include/flamegpu/pop/AgentInstance.h
+++ b/include/flamegpu/pop/AgentInstance.h
@@ -20,8 +20,8 @@ class AgentDescription;
  * @note Not 100% on the name, might change
  */
 class AgentInstance {
-    friend AgentVector::iterator AgentVector::insert(AgentVector::const_iterator pos, AgentVector::size_type count, const AgentInstance& value);
-    friend AgentVector::iterator AgentVector::insert(AgentVector::size_type pos, AgentVector::size_type count, const AgentInstance& value);
+    friend AgentVector::iterator AgentVector::insert(AgentVector::const_iterator pos, flamegpu::size_type count, const AgentInstance& value);
+    friend AgentVector::iterator AgentVector::insert(flamegpu::size_type pos, flamegpu::size_type count, const AgentInstance& value);
 
  public:
     /**

--- a/include/flamegpu/pop/AgentVector.h
+++ b/include/flamegpu/pop/AgentVector.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <map>
 
+#include "flamegpu/defines.h"
 #include "flamegpu/pop/detail/MemoryVector.h"
 #include "flamegpu/model/AgentData.h"
 
@@ -37,7 +38,6 @@ class AgentVector {
     friend class AgentVector_Agent;
 
  public:
-    typedef unsigned int size_type;
     /**
      * View into the AgentVector to provide mutable access to a specific Agent's data
      */

--- a/include/flamegpu/pop/AgentVector_Agent.h
+++ b/include/flamegpu/pop/AgentVector_Agent.h
@@ -23,10 +23,10 @@ class AgentInstance;
  * const view into AgentVector
  */
 class AgentVector_CAgent {
-    friend AgentVector::CAgent AgentVector::at(AgentVector::size_type) const;
+    friend AgentVector::CAgent AgentVector::at(flamegpu::size_type) const;
     friend AgentVector::CAgent AgentVector::const_iterator::operator*() const;
     friend AgentVector::CAgent AgentVector::const_reverse_iterator::operator*() const;
-    friend AgentVector::iterator AgentVector::insert(AgentVector::size_type pos, AgentVector::size_type count, const AgentVector::Agent&);
+    friend AgentVector::iterator AgentVector::insert(flamegpu::size_type pos, flamegpu::size_type count, const AgentVector::Agent&);
     friend class AgentInstance;
     // friend AgentInstance::AgentInstance(const AgentVector::CAgent&);
     // friend AgentInstance& AgentInstance::operator=(const AgentVector::CAgent&);
@@ -50,7 +50,7 @@ class AgentVector_CAgent {
     /**
      * Constructor, only ever called by AgentVector
      */
-    AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, AgentVector::size_type pos);
+    AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, flamegpu::size_type pos);
     /**
      * Index within _data
      */
@@ -76,7 +76,7 @@ class AgentVector_CAgent {
  * @note To set an agent's id, the agent must be part of a model which has begun (id's are automatically assigned before initialisation functions and can not be manually set by users)
  */
 class AgentVector_Agent : public AgentVector_CAgent {
-    friend AgentVector::Agent AgentVector::at(AgentVector::size_type);
+    friend AgentVector::Agent AgentVector::at(flamegpu::size_type);
     friend AgentVector::Agent AgentVector::iterator::operator*() const;
     friend AgentVector::Agent AgentVector::reverse_iterator::operator*() const;
 
@@ -129,7 +129,7 @@ class AgentVector_Agent : public AgentVector_CAgent {
     /**
      * Constructor, only ever called by AgentVector
      */
-    AgentVector_Agent(AgentVector* parent, const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, AgentVector::size_type pos);
+    AgentVector_Agent(AgentVector* parent, const std::shared_ptr<const AgentData> &agent, const std::weak_ptr<AgentVector::AgentDataMap> &data, flamegpu::size_type pos);
 };
 
 template <typename T>

--- a/include/flamegpu/runtime/messaging/MessageArray.h
+++ b/include/flamegpu/runtime/messaging/MessageArray.h
@@ -20,11 +20,6 @@ namespace flamegpu {
  */
 class MessageArray {
  public:
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
     // Host
     struct Data;        // Forward declare inner classes
     class Description;  // Forward declare inner classes

--- a/include/flamegpu/runtime/messaging/MessageArray/MessageArrayDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray/MessageArrayDevice.cuh
@@ -82,7 +82,7 @@ class MessageArray::In {
          * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
-        template<typename T, MessageNone::size_type N, unsigned int M>
+        template<typename T, flamegpu::size_type N, unsigned int M>
         __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
     /**
@@ -181,7 +181,7 @@ class MessageArray::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M> __device__
+            template<typename T, flamegpu::size_type N, unsigned int M> __device__
             T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -380,7 +380,7 @@ class MessageArray::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -646,7 +646,7 @@ __device__ T MessageArray::In::Message::getVariable(const char(&variable_name)[N
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
@@ -672,7 +672,7 @@ __device__ T MessageArray::In::WrapFilter::Message::getVariable(const char(&vari
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
@@ -698,7 +698,7 @@ __device__ T MessageArray::In::Filter::Message::getVariable(const char(&variable
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS

--- a/include/flamegpu/runtime/messaging/MessageArray2D.h
+++ b/include/flamegpu/runtime/messaging/MessageArray2D.h
@@ -19,11 +19,6 @@ namespace flamegpu {
  */
 class MessageArray2D {
  public:
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
     // Host
     struct Data;        // Forward declare inner classes
     class Description;  // Forward declare inner classes

--- a/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray2D/MessageArray2DDevice.cuh
@@ -78,7 +78,7 @@ class MessageArray2D::In {
          * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
-        template<typename T, MessageNone::size_type N, unsigned int M>
+        template<typename T, flamegpu::size_type N, unsigned int M>
         __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
 
@@ -195,7 +195,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -410,7 +410,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -628,7 +628,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -843,7 +843,7 @@ class MessageArray2D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -1196,7 +1196,7 @@ __device__ T MessageArray2D::In::Message::getVariable(const char(&variable_name)
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray2D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1221,7 +1221,7 @@ __device__ T MessageArray2D::In::WrapFilter::Message::getVariable(const char(&va
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray2D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1246,7 +1246,7 @@ __device__ T MessageArray2D::In::Filter::Message::getVariable(const char(&variab
     // get the value from curve using the stored hashes and message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray2D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1271,7 +1271,7 @@ __device__ T MessageArray2D::In::VonNeumannWrapFilter::Message::getVariable(cons
     // get the value from curve using the stored hashes and message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray2D::In::VonNeumannWrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -1296,7 +1296,7 @@ __device__ T MessageArray2D::In::VonNeumannFilter::Message::getVariable(const ch
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray2D::In::VonNeumannFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.

--- a/include/flamegpu/runtime/messaging/MessageArray3D.h
+++ b/include/flamegpu/runtime/messaging/MessageArray3D.h
@@ -20,11 +20,6 @@ namespace flamegpu {
  */
 class MessageArray3D {
  public:
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
     // Host
     struct Data;        // Forward declare inner classes
     class Description;  // Forward declare inner classes

--- a/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageArray3D/MessageArray3DDevice.cuh
@@ -84,7 +84,7 @@ class MessageArray3D::In {
          * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
-        template<typename T, MessageNone::size_type N, unsigned int M>
+        template<typename T, flamegpu::size_type N, unsigned int M>
         __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
     /**
@@ -216,7 +216,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -446,7 +446,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -680,7 +680,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -910,7 +910,7 @@ class MessageArray3D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -1285,7 +1285,7 @@ __device__ T MessageArray3D::In::Message::getVariable(const char(&variable_name)
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray3D::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
@@ -1311,7 +1311,7 @@ __device__ T MessageArray3D::In::WrapFilter::Message::getVariable(const char(&va
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
@@ -1337,7 +1337,7 @@ __device__ T MessageArray3D::In::Filter::Message::getVariable(const char(&variab
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
@@ -1363,7 +1363,7 @@ __device__ T MessageArray3D::In::VonNeumannWrapFilter::Message::getVariable(cons
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray3D::In::VonNeumannWrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS
@@ -1389,7 +1389,7 @@ __device__ T MessageArray3D::In::VonNeumannFilter::Message::getVariable(const ch
     // get the value from curve using the message index.
     return detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, index_1d);
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageArray3D::In::VonNeumannFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
 #if !defined(SEATBELTS) || SEATBELTS

--- a/include/flamegpu/runtime/messaging/MessageBruteForce.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce.h
@@ -15,11 +15,6 @@ struct ModelData;
  */
 class MessageBruteForce {
  public:
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
     // Host
     struct Data;        // Forward declare inner classes
     class Description;  // Forward declare inner classes

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh
@@ -124,7 +124,7 @@ class MessageBruteForce::In {
          * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
          * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
          */
-        template<typename T, MessageNone::size_type N, unsigned int M> __device__
+        template<typename T, flamegpu::size_type N, unsigned int M> __device__
         T getVariable(const char(&variable_name)[M], unsigned int index) const;
     };
 
@@ -236,7 +236,7 @@ __device__ T MessageBruteForce::In::Message::getVariable(const char(&variable_na
 #endif
     return value;
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageBruteForce::In::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
     // simple indexing assumes index is the thread number (this may change later)
     const unsigned int index = (blockDim.x * blockIdx.x) + threadIdx.x;

--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
@@ -220,7 +220,7 @@ class MessageBruteForce::Description {
      * @throws exception::InvalidMessageVar If a variable already exists within the message with the same name
      * @throws exception::InvalidMessageVar If N is <= 0
      */
-    template<typename T, MessageNone::size_type N>
+    template<typename T, flamegpu::size_type N>
     void newVariable(const std::string& variable_name);
 #ifdef SWIG
     /**
@@ -283,7 +283,7 @@ template<typename T>
 void MessageBruteForce::Description::newVariable(const std::string &variable_name) {
     newVariable<T, 1>(variable_name);
 }
-template<typename T, MessageNone::size_type N>
+template<typename T, flamegpu::size_type N>
 void MessageBruteForce::Description::newVariable(const std::string& variable_name) {
     if (!variable_name.empty() && variable_name[0] == '_') {
         THROW exception::ReservedName("Message variable names cannot begin with '_', this is reserved for internal usage, "

--- a/include/flamegpu/runtime/messaging/MessageBucket.h
+++ b/include/flamegpu/runtime/messaging/MessageBucket.h
@@ -24,11 +24,6 @@ typedef int IntT;
  */
 class MessageBucket {
  public:
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
     // Host
     struct Data;
     class Description;

--- a/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketDevice.cuh
@@ -88,7 +88,7 @@ class MessageBucket::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M> __device__
+            template<typename T, flamegpu::size_type N, unsigned int M> __device__
             T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -329,7 +329,7 @@ __device__ T MessageBucket::In::Filter::Message::getVariable(const char(&variabl
     T value = detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, cell_index);
     return value;
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageBucket::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.

--- a/include/flamegpu/runtime/messaging/MessageNone.h
+++ b/include/flamegpu/runtime/messaging/MessageNone.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_MESSAGENONE_H_
 #define INCLUDE_FLAMEGPU_RUNTIME_MESSAGING_MESSAGENONE_H_
 
+#include "flamegpu/defines.h"
+
 namespace flamegpu {
 
 /**
@@ -9,10 +11,6 @@ namespace flamegpu {
  */
 class MessageNone {
  public:
-    /**
-     * Common size type
-     */
-    typedef unsigned int size_type;
     // Host (Data and Description not required for None)
     class CUDAModelHandler;
     // Device

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D.h
@@ -15,11 +15,6 @@ namespace flamegpu {
  * Unlike FLAMEGPU1, these spatial messages do not wrap over environment bounds.
  */
 class MessageSpatial2D {
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
  public:
     // Host
     struct Data;        // Forward declare inner classes

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
@@ -115,7 +115,7 @@ class MessageSpatial2D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M> __device__
+            template<typename T, flamegpu::size_type N, unsigned int M> __device__
             T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -323,7 +323,7 @@ class MessageSpatial2D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M>
+            template<typename T, flamegpu::size_type N, unsigned int M>
             __device__ T getVariable(const char(&variable_name)[M], unsigned int index) const;
             /**
              * Returns the virtual x variable of the message, relative to the search origin
@@ -554,7 +554,7 @@ __device__ T MessageSpatial2D::In::Filter::Message::getVariable(const char(&vari
     T value = detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, cell_index);
     return value;
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageSpatial2D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -580,7 +580,7 @@ __device__ T MessageSpatial2D::In::WrapFilter::Message::getVariable(const char(&
     T value = detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, cell_index);
     return value;
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageSpatial2D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D.h
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D.h
@@ -15,11 +15,6 @@ namespace flamegpu {
  * Unlike FLAMEGPU1, these spatial messages do not wrap over environment bounds.
  */
 class MessageSpatial3D {
-    /**
-     * Common size type
-     */
-    typedef MessageNone::size_type size_type;
-
  public:
     // Host
     struct Data;        // Forward declare inner classes

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
@@ -123,7 +123,7 @@ class MessageSpatial3D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M> __device__
+            template<typename T, flamegpu::size_type N, unsigned int M> __device__
             T getVariable(const char(&variable_name)[M], unsigned int index) const;
         };
         /**
@@ -342,7 +342,7 @@ class MessageSpatial3D::In {
              * @throws exception::DeviceError If T is not the type of variable 'name' within the message (flamegpu must be built with SEATBELTS enabled for device error checking)
              * @throws exception::DeviceError If index is out of bounds for the variable array specified by name (flamegpu must be built with SEATBELTS enabled for device error checking)
              */
-            template<typename T, MessageNone::size_type N, unsigned int M> __device__
+            template<typename T, flamegpu::size_type N, unsigned int M> __device__
             T getVariable(const char(&variable_name)[M], unsigned int index) const;
             /**
              * Returns the virtual x variable of the message, relative to the search origin
@@ -595,7 +595,7 @@ __device__ T MessageSpatial3D::In::Filter::Message::getVariable(const char(&vari
     T value = detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, cell_index);
     return value;
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageSpatial3D::In::Filter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.
@@ -621,7 +621,7 @@ __device__ T MessageSpatial3D::In::WrapFilter::Message::getVariable(const char(&
     T value = detail::curve::DeviceCurve::getMessageVariable<T>(variable_name, cell_index);
     return value;
 }
-template<typename T, MessageNone::size_type N, unsigned int M> __device__
+template<typename T, flamegpu::size_type N, unsigned int M> __device__
 T MessageSpatial3D::In::WrapFilter::Message::getVariable(const char(&variable_name)[M], const unsigned int array_index) const {
 #if !defined(SEATBELTS) || SEATBELTS
     // Ensure that the message is within bounds.

--- a/include/flamegpu/runtime/utility/EnvironmentManager.cuh
+++ b/include/flamegpu/runtime/utility/EnvironmentManager.cuh
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "flamegpu/defines.h"
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/runtime/detail/curve/HostCurve.cuh"
 #include "flamegpu/util/type_decode.h"
@@ -36,13 +37,6 @@ class EnvironmentManager : public std::enable_shared_from_this<EnvironmentManage
      * The latter could probably be moved into EnvironmentManager (behind a private method)
      */
     friend class CUDASimulation;
-
- public:
-    /**
-     * Offset relative to c_buffer
-     * Length in bytes
-     */
-    typedef unsigned int size_type;
 
  private:
     /**
@@ -412,7 +406,7 @@ T EnvironmentManager::setProperty(const std::string &name, const T value) {
     propagateMappedPropertyValue(name, dest_ptr);
     return rtn;
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> EnvironmentManager::setProperty(const std::string &name, const std::array<T, N> &value) {
     const EnvProp& prop = findProperty<T>(name, true, N);
     // Copy old data to return
@@ -425,7 +419,7 @@ std::array<T, N> EnvironmentManager::setProperty(const std::string &name, const 
     propagateMappedPropertyValue(name, dest_ptr);
     return rtn;
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 T EnvironmentManager::setProperty(const std::string &name, const size_type index, const T value) {
     const EnvProp& prop = findProperty<T>(name, true, 0);
     if (N && N != prop.elements / type_decode<T>::len_t) {
@@ -474,7 +468,7 @@ T EnvironmentManager::getProperty(const std::string &name) {
     memcpy(&rtn, h_buffer + prop.offset, sizeof(T));
     return rtn;
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> EnvironmentManager::getProperty(const std::string &name) {
     const EnvProp& prop = findProperty<T>(name, false, N);
     // Copy old data to return
@@ -482,7 +476,7 @@ std::array<T, N> EnvironmentManager::getProperty(const std::string &name) {
     memcpy(rtn.data(), h_buffer + prop.offset, sizeof(T) * N);
     return rtn;
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 T EnvironmentManager::getProperty(const std::string &name, const size_type index) {
     const EnvProp& prop = findProperty<T>(name, false, 0);
     if (N && N != prop.elements / type_decode<T>::len_t) {

--- a/include/flamegpu/runtime/utility/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/utility/HostEnvironment.cuh
@@ -67,7 +67,7 @@ class HostEnvironment {
      * @tparam N Length of the environment property array
      * @throws exception::InvalidEnvProperty If a property array of the name does not exist
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     std::array<T, N> getProperty(const std::string &name) const;
     /**
      * Gets an element of an environment property array
@@ -79,8 +79,8 @@ class HostEnvironment {
      * @throws std::out_of_range
      * @see get(const std::string &)
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    T getProperty(const std::string &name, EnvironmentManager::size_type index) const;
+    template<typename T, flamegpu::size_type N = 0>
+    T getProperty(const std::string &name, flamegpu::size_type index) const;
 #ifdef SWIG
     /**
      * Gets an environment property array
@@ -112,7 +112,7 @@ class HostEnvironment {
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::ReadOnlyEnvProperty If the named property is marked as const
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     std::array<T, N> setProperty(const std::string &name, const std::array<T, N> &value) const;
     /**
      * Sets an element of an environment property array
@@ -126,8 +126,8 @@ class HostEnvironment {
      * @throws std::out_of_range
      * @see get(const std::string &)
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    T setProperty(const std::string &name, EnvironmentManager::size_type index, T value) const;
+    template<typename T, flamegpu::size_type N = 0>
+    T setProperty(const std::string &name, flamegpu::size_type index, T value) const;
 #ifdef SWIG
     /**
      * Sets an environment property array
@@ -168,7 +168,7 @@ T HostEnvironment::setProperty(const std::string &name, const T value) const {
     }
     return env_mgr->setProperty<T>(name, value);
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> HostEnvironment::setProperty(const std::string &name, const std::array<T, N> &value) const {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
@@ -176,8 +176,8 @@ std::array<T, N> HostEnvironment::setProperty(const std::string &name, const std
     }
     return env_mgr->setProperty<T, N>(name, value);
 }
-template<typename T, EnvironmentManager::size_type N>
-T HostEnvironment::setProperty(const std::string &name, EnvironmentManager::size_type index, const T value) const {
+template<typename T, flamegpu::size_type N>
+T HostEnvironment::setProperty(const std::string &name, flamegpu::size_type index, const T value) const {
     if (!name.empty() && name[0] == '_') {
         THROW exception::ReservedName("Environment property names cannot begin with '_', this is reserved for internal usage, "
             "in HostEnvironment::set().");
@@ -202,12 +202,12 @@ template<typename T>
 T HostEnvironment::getProperty(const std::string &name) const  {
     return env_mgr->getProperty<T>(name);
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> HostEnvironment::getProperty(const std::string &name) const  {
     return env_mgr->getProperty<T, N>(name);
 }
-template<typename T, EnvironmentManager::size_type N>
-T HostEnvironment::getProperty(const std::string &name, const EnvironmentManager::size_type index) const  {
+template<typename T, flamegpu::size_type N>
+T HostEnvironment::getProperty(const std::string &name, const flamegpu::size_type index) const  {
     return env_mgr->getProperty<T, N>(name, index);
 }
 #ifdef SWIG

--- a/include/flamegpu/runtime/utility/RandomManager.cuh
+++ b/include/flamegpu/runtime/utility/RandomManager.cuh
@@ -5,6 +5,7 @@
 #include <random>
 #include <string>
 
+#include "flamegpu/defines.h"
 #include "flamegpu/util/detail/curand.cuh"
 #include "flamegpu/sim/Simulation.h"
 
@@ -35,10 +36,6 @@ class RandomManager {
      */
     friend class CUDASimulation;  // bool CUDASimulation::step(const Simulation&)
  public:
-    /**
-     * Inherit size_type from include-public partner class
-     */
-    typedef unsigned int size_type;
     /**
      * Creates the random manager and calls reseed() with the return value from seedFromTime()
      */

--- a/include/flamegpu/sim/AgentInterface.h
+++ b/include/flamegpu/sim/AgentInterface.h
@@ -18,7 +18,7 @@ class AgentInterface {
     virtual ~AgentInterface() = default;
     virtual const AgentData &getAgentDescription() const = 0;
     virtual void *getStateVariablePtr(const std::string &state_name, const std::string &variable_name) = 0;
-    virtual ModelData::size_type getStateSize(const std::string &state_name) const = 0;
+    virtual flamegpu::size_type getStateSize(const std::string &state_name) const = 0;
     /**
      * Returns the next free agent id, and increments the ID tracker by the specified count
      * @param count Number that will be added to the return value on next call to this function

--- a/include/flamegpu/sim/RunPlan.h
+++ b/include/flamegpu/sim/RunPlan.h
@@ -80,7 +80,7 @@ class RunPlan {
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     void setProperty(const std::string &name, const std::array<T, N> &value);
     /**
      * Set the environment property override for this run of the model
@@ -94,8 +94,8 @@ class RunPlan {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is not in range of the length of the property array
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    void setProperty(const std::string &name, EnvironmentManager::size_type index, T value);
+    template<typename T, flamegpu::size_type N = 0>
+    void setProperty(const std::string &name, flamegpu::size_type index, T value);
 #ifdef SWIG
     /**
      * Set the environment property override for this run of the model
@@ -142,7 +142,7 @@ class RunPlan {
      * @throws exception::InvalidEnvProperty If a property array of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     std::array<T, N> getProperty(const std::string &name) const;
     /**
      * Gets an element of the currently configured environment property array
@@ -154,8 +154,8 @@ class RunPlan {
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T
      * @throws exception::OutOfBoundsException If index is not in range of the length of the property array
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    T getProperty(const std::string &name, EnvironmentManager::size_type index) const;
+    template<typename T, flamegpu::size_type N = 0>
+    T getProperty(const std::string &name, flamegpu::size_type index) const;
 #ifdef SWIG
     /**
      * Gets the currently configured environment property array value
@@ -215,7 +215,7 @@ void RunPlan::setProperty(const std::string &name, T value) {
     property_overrides.erase(name);
     property_overrides.emplace(name, util::Any(&value, sizeof(T), typeid(typename type_decode<T>::type_t), type_decode<T>::len_t));
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 void RunPlan::setProperty(const std::string &name, const std::array<T, N> &value) {
     // Validation
     const auto it = environment->find(name);
@@ -238,8 +238,8 @@ void RunPlan::setProperty(const std::string &name, const std::array<T, N> &value
     property_overrides.erase(name);
     property_overrides.emplace(name, util::Any(value.data(), sizeof(T) * N, typeid(typename type_decode<T>::type_t), type_decode<T>::len_t * N));
 }
-template<typename T, EnvironmentManager::size_type N>
-void RunPlan::setProperty(const std::string &name, const EnvironmentManager::size_type index, T value) {
+template<typename T, flamegpu::size_type N>
+void RunPlan::setProperty(const std::string &name, const flamegpu::size_type index, T value) {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {
@@ -326,7 +326,7 @@ T RunPlan::getProperty(const std::string &name) const {
         return *static_cast<T *>(it->second.data.ptr);
     }
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 std::array<T, N> RunPlan::getProperty(const std::string &name) const {
     // Validation
     const auto it = environment->find(name);
@@ -357,8 +357,8 @@ std::array<T, N> RunPlan::getProperty(const std::string &name) const {
     }
     return rtn;
 }
-template<typename T, EnvironmentManager::size_type N>
-T RunPlan::getProperty(const std::string &name, const EnvironmentManager::size_type index) const {
+template<typename T, flamegpu::size_type N>
+T RunPlan::getProperty(const std::string &name, const flamegpu::size_type index) const {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {

--- a/include/flamegpu/sim/RunPlanVector.h
+++ b/include/flamegpu/sim/RunPlanVector.h
@@ -72,7 +72,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::InvalidEnvProperty If a property of the name does not exist
      * @throws exception::InvalidEnvPropertyType If a property with the name has a type different to T, or length to N
      */
-    template<typename T, EnvironmentManager::size_type N>
+    template<typename T, flamegpu::size_type N>
     void setProperty(const std::string &name, const std::array<T, N> &value);
     /**
      * Array property element equivalent of setProperty()
@@ -86,7 +86,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setProperty(const std::string &name, T value)
      */
     template<typename T>
-    void setProperty(const std::string &name, const EnvironmentManager::size_type index, const T value);
+    void setProperty(const std::string &name, const flamegpu::size_type index, const T value);
 #ifdef SWIG
     /**
      * Set named environment property array to a specific value
@@ -132,7 +132,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setPropertyUniformDistribution(const std::string &name, T min, T max)
      */
     template<typename T>
-    void setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max);
+    void setPropertyUniformDistribution(const std::string &name, const flamegpu::size_type index, const T min, const T max);
     /**
      * Seed the internal random generator used for random property distributions
      * This will only affect subsequent calls to setPropertyRandom()
@@ -176,7 +176,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setPropertyUniformRandom(const std::string &name, T min, T max)
      */
     template<typename T>
-    void setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max);
+    void setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const T min, const T max);
     /**
      * Sweep named environment property over a normal random distribution
      * Only floating point types are supported
@@ -206,7 +206,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setPropertyNormalRandom(const std::string &name, T mean, T stddev)
      */
     template<typename T>
-    void setPropertyNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev);
+    void setPropertyNormalRandom(const std::string &name, flamegpu::size_type index, T mean, T stddev);
     /**
      * Sweep named environment property over a log normal random distribution
      * Only floating point types are supported
@@ -236,7 +236,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @see setPropertyNormalRandom(const std::string &name, T mean, T stddev)
      */
     template<typename T>
-    void setPropertyLogNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev);
+    void setPropertyLogNormalRandom(const std::string &name, flamegpu::size_type index, T mean, T stddev);
     /**
      * Use a random distribution to generate parameters for the named environment property
      * @param name The name of the environment property to set
@@ -263,7 +263,7 @@ class RunPlanVector : private std::vector<RunPlan>  {
      * @throws exception::OutOfBoundsException If this vector has a length less than 2
      */
     template<typename T, typename rand_dist>
-    void setPropertyRandom(const std::string &name, EnvironmentManager::size_type index, rand_dist &distribution);
+    void setPropertyRandom(const std::string &name, flamegpu::size_type index, rand_dist &distribution);
 
     /**
      * Expose inherited std::vector methods/classes
@@ -328,7 +328,7 @@ void RunPlanVector::setProperty(const std::string &name, const T value) {
         i.setProperty<T>(name, value);
     }
 }
-template<typename T, EnvironmentManager::size_type N>
+template<typename T, flamegpu::size_type N>
 void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> &value) {
     // Validation
     const auto it = environment->find(name);
@@ -352,7 +352,7 @@ void RunPlanVector::setProperty(const std::string &name, const std::array<T, N> 
     }
 }
 template<typename T>
-void RunPlanVector::setProperty(const std::string &name, const EnvironmentManager::size_type index, const T value) {
+void RunPlanVector::setProperty(const std::string &name, const flamegpu::size_type index, const T value) {
     // Validation
     const auto it = environment->find(name);
     if (it == environment->end()) {
@@ -434,7 +434,7 @@ void RunPlanVector::setPropertyUniformDistribution(const std::string &name, cons
     }
 }
 template<typename T>
-void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max) {
+void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const flamegpu::size_type index, const T min, const T max) {
     // Validation
     if (this->size() < 2) {
         THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
@@ -495,7 +495,7 @@ void RunPlanVector::setPropertyRandom(const std::string &name, rand_dist &distri
     }
 }
 template<typename T, typename rand_dist>
-void RunPlanVector::setPropertyRandom(const std::string &name, const EnvironmentManager::size_type index, rand_dist &distribution) {
+void RunPlanVector::setPropertyRandom(const std::string &name, const flamegpu::size_type index, rand_dist &distribution) {
     // Validation
     if (this->size() < 2) {
         THROW exception::OutOfBoundsException("Unable to apply a property distribution a vector with less than 2 elements, "
@@ -531,8 +531,8 @@ void RunPlanVector::setPropertyUniformRandom(const std::string &name, const T mi
     setPropertyRandom<T>(name, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const T min, const T max) {
-    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for RunPlanVector::setPropertyUniformRandom(const std::string &name, EnvironmentManager::size_type index, T min, T max)");
+void RunPlanVector::setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const T min, const T max) {
+    static_assert(util::detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for RunPlanVector::setPropertyUniformRandom(const std::string &name, flamegpu::size_type index, T min, T max)");
     std::uniform_int_distribution<T> dist(min, max);
     setPropertyRandom<T>(name, index, dist);
 }
@@ -543,9 +543,9 @@ void RunPlanVector::setPropertyNormalRandom(const std::string &name, const T mea
     setPropertyRandom<T>(name, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev) {
+void RunPlanVector::setPropertyNormalRandom(const std::string &name, const flamegpu::size_type index, const T mean, const T stddev) {
     static_assert(util::detail::StaticAssert::_Is_RealType<T>::value,
-        "Invalid template argument for RunPlanVector::setPropertyNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev)");
+        "Invalid template argument for RunPlanVector::setPropertyNormalRandom(const std::string &name, flamegpu::size_type index, T mean, T stddev)");
     std::normal_distribution<T> dist(mean, stddev);
     setPropertyRandom<T>(name, index, dist);
 }
@@ -557,9 +557,9 @@ void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const T 
     setPropertyRandom<T>(name, dist);
 }
 template<typename T>
-void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const EnvironmentManager::size_type index, const T mean, const T stddev) {
+void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, const flamegpu::size_type index, const T mean, const T stddev) {
     static_assert(util::detail::StaticAssert::_Is_RealType<T>::value,
-    "Invalid template argument for RunPlanVector::setPropertyLogNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev)");
+    "Invalid template argument for RunPlanVector::setPropertyLogNormalRandom(const std::string &name, flamegpu::size_type index, T mean, T stddev)");
     std::lognormal_distribution<T> dist(mean, stddev);
     setPropertyRandom<T>(name, index, dist);
 }
@@ -574,7 +574,7 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<float>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const float min, const float max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const float min, const float max) {
     std::uniform_real_distribution<float> dist(min, max);
     setPropertyRandom<float>(name, index, dist);
 }
@@ -584,7 +584,7 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<double>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const double min, const double max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const double min, const double max) {
     std::uniform_real_distribution<double> dist(min, max);
     setPropertyRandom<double>(name, index, dist);
 }
@@ -594,7 +594,7 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const char min, const char max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const char min, const char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<char>(name, index, dist);
 }
@@ -604,7 +604,7 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<unsigned char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const unsigned char min, const unsigned char max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const unsigned char min, const unsigned char max) {
     std::uniform_int_distribution<uint16_t> dist(min, max);
     setPropertyRandom<unsigned char>(name, index, dist);
 }
@@ -614,7 +614,7 @@ inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, con
     setPropertyRandom<signed char>(name, dist);
 }
 template<>
-inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const EnvironmentManager::size_type index, const signed char min, const signed char max) {
+inline void RunPlanVector::setPropertyUniformRandom(const std::string &name, const flamegpu::size_type index, const signed char min, const signed char max) {
     std::uniform_int_distribution<int16_t> dist(min, max);
     setPropertyRandom<signed char>(name, index, dist);
 }

--- a/include/flamegpu/visualiser/PanelVis.h
+++ b/include/flamegpu/visualiser/PanelVis.h
@@ -65,8 +65,8 @@ class PanelVis {
      * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
      * @note Environment property arrays cannot be added as a whole, each element must be specified individually
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    void newEnvironmentPropertySlider(const std::string& property_name, EnvironmentManager::size_type index, T min, T max);
+    template<typename T, flamegpu::size_type N = 0>
+    void newEnvironmentPropertySlider(const std::string& property_name, flamegpu::size_type index, T min, T max);
     /**
      * Add a drag element which displays the named environment property (or environment property array element) and allows it's value to be updated by
      * clicking and dragging the mouse left/right. Double click can also be used to enter a new value via typing.
@@ -85,8 +85,8 @@ class PanelVis {
      * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
      * @note Environment property arrays cannot be added as a whole, each element must be specified individually
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    void newEnvironmentPropertyDrag(const std::string& property_name, EnvironmentManager::size_type index, T min, T max, float speed);
+    template<typename T, flamegpu::size_type N = 0>
+    void newEnvironmentPropertyDrag(const std::string& property_name, flamegpu::size_type index, T min, T max, float speed);
     /**
      * Add a input box (with +/- step buttons) which displays the named environment property (or environment property array element) and allows it's value to be updated by
      * clicking and dragging the mouse left/right. Double click can also be used to enter a new value via typing.
@@ -104,8 +104,8 @@ class PanelVis {
      * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
      * @note Environment property arrays cannot be added as a whole, each element must be specified individually
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    void newEnvironmentPropertyInput(const std::string& property_name, EnvironmentManager::size_type index, T step, T step_fast);
+    template<typename T, flamegpu::size_type N = 0>
+    void newEnvironmentPropertyInput(const std::string& property_name, flamegpu::size_type index, T step, T step_fast);
     /**
      * Add a checkbox element which displays the named environment property (or environment property array element) and allows it's value to be toggled
      * between 0 and 1 by clicking.
@@ -122,8 +122,8 @@ class PanelVis {
      * @tparam N Optional, length of the named environment property. 0 can be provided to ignore this check
      * @note Environment property arrays cannot be added as a whole, each element must be specified individually
      */
-    template<typename T, EnvironmentManager::size_type N = 0>
-    void newEnvironmentPropertyToggle(const std::string& property_name, EnvironmentManager::size_type index);
+    template<typename T, flamegpu::size_type N = 0>
+    void newEnvironmentPropertyToggle(const std::string& property_name, flamegpu::size_type index);
 
  private:
     /**
@@ -138,10 +138,10 @@ class PanelVis {
      * Each property can only be added to a specific panel once
      * ImGui appears to use their names to classify input, so dupes cause odd behaviour
      */
-    std::set<std::pair<std::string, EnvironmentManager::size_type>> added_properties;
+    std::set<std::pair<std::string, flamegpu::size_type>> added_properties;
 };
-template<typename T, EnvironmentManager::size_type N>
-void PanelVis::newEnvironmentPropertySlider(const std::string& property_name, EnvironmentManager::size_type index, T min, T max) {
+template<typename T, flamegpu::size_type N>
+void PanelVis::newEnvironmentPropertySlider(const std::string& property_name, flamegpu::size_type index, T min, T max) {
     {  // Validate name/type/length
         const auto it = env_properties.find(property_name);
         if (it == env_properties.end()) {
@@ -178,8 +178,8 @@ template<typename T>
 void PanelVis::newEnvironmentPropertySlider(const std::string& property_name, T min, T max) {
     newEnvironmentPropertySlider<T, 0>(property_name, 0, min, max);
 }
-template<typename T, EnvironmentManager::size_type N>
-void PanelVis::newEnvironmentPropertyDrag(const std::string& property_name, EnvironmentManager::size_type index, T min, T max, float speed) {
+template<typename T, flamegpu::size_type N>
+void PanelVis::newEnvironmentPropertyDrag(const std::string& property_name, flamegpu::size_type index, T min, T max, float speed) {
     {  // Validate name/type/length
         const auto it = env_properties.find(property_name);
         if (it == env_properties.end()) {
@@ -216,8 +216,8 @@ template<typename T>
 void PanelVis::newEnvironmentPropertyDrag(const std::string& property_name, T min, T max, float speed) {
     newEnvironmentPropertyDrag<T, 0>(property_name, 0, min, max, speed);
 }
-template<typename T, EnvironmentManager::size_type N>
-void PanelVis::newEnvironmentPropertyInput(const std::string& property_name, EnvironmentManager::size_type index, T step, T step_fast) {
+template<typename T, flamegpu::size_type N>
+void PanelVis::newEnvironmentPropertyInput(const std::string& property_name, flamegpu::size_type index, T step, T step_fast) {
     {  // Validate name/type/length
         const auto it = env_properties.find(property_name);
         if (it == env_properties.end()) {
@@ -250,8 +250,8 @@ template<typename T>
 void PanelVis::newEnvironmentPropertyInput(const std::string& property_name, T step, T step_fast) {
     newEnvironmentPropertyInput<T, 0>(property_name, 0, step, step_fast);
 }
-template<typename T, EnvironmentManager::size_type N>
-void PanelVis::newEnvironmentPropertyToggle(const std::string& property_name, EnvironmentManager::size_type index) {
+template<typename T, flamegpu::size_type N>
+void PanelVis::newEnvironmentPropertyToggle(const std::string& property_name, flamegpu::size_type index) {
     static_assert(std::is_integral<T>::value, "PanelVis::newEnvironmentPropertyToggle() only supports integer type properties.");
     {  // Validate name/type/length
         const auto it = env_properties.find(property_name);

--- a/src/flamegpu/model/AgentDescription.cpp
+++ b/src/flamegpu/model/AgentDescription.cpp
@@ -79,9 +79,9 @@ std::string AgentDescription::getName() const {
     return agent->name;
 }
 
-ModelData::size_type AgentDescription::getStatesCount() const {
+flamegpu::size_type AgentDescription::getStatesCount() const {
     // Downcast, will never have more than UINT_MAX VARS
-    return static_cast<ModelData::size_type>(agent->states.size());
+    return static_cast<flamegpu::size_type>(agent->states.size());
 }
 std::string AgentDescription::getInitialState() const {
     return agent->initial_state;
@@ -104,7 +104,7 @@ size_t AgentDescription::getVariableSize(const std::string &variable_name) const
         "in AgentDescription::getVariableSize().",
         agent->name.c_str(), variable_name.c_str());
 }
-ModelData::size_type AgentDescription::getVariableLength(const std::string &variable_name) const {
+flamegpu::size_type AgentDescription::getVariableLength(const std::string &variable_name) const {
     auto f = agent->variables.find(variable_name);
     if (f != agent->variables.end()) {
         return f->second.elements;
@@ -113,9 +113,9 @@ ModelData::size_type AgentDescription::getVariableLength(const std::string &vari
         "in AgentDescription::getVariableLength().",
         agent->name.c_str(), variable_name.c_str());
 }
-ModelData::size_type AgentDescription::getVariablesCount() const {
+flamegpu::size_type AgentDescription::getVariablesCount() const {
     // Downcast, will never have more than UINT_MAX VARS
-    return static_cast<ModelData::size_type>(agent->variables.size());
+    return static_cast<flamegpu::size_type>(agent->variables.size());
 }
 const AgentFunctionDescription& AgentDescription::getFunction(const std::string &function_name) const {
     auto f = agent->functions.find(function_name);
@@ -126,12 +126,12 @@ const AgentFunctionDescription& AgentDescription::getFunction(const std::string 
         "in AgentDescription::getFunction().",
         agent->name.c_str(), function_name.c_str());
 }
-ModelData::size_type AgentDescription::getFunctionsCount() const {
+flamegpu::size_type AgentDescription::getFunctionsCount() const {
     // Downcast, will never have more than UINT_MAX VARS
-    return static_cast<ModelData::size_type>(agent->functions.size());
+    return static_cast<flamegpu::size_type>(agent->functions.size());
 }
 
-ModelData::size_type AgentDescription::getAgentOutputsCount() const {
+flamegpu::size_type AgentDescription::getAgentOutputsCount() const {
     return agent->agent_outputs;
 }
 

--- a/src/flamegpu/model/EnvironmentDescription.cu
+++ b/src/flamegpu/model/EnvironmentDescription.cu
@@ -38,7 +38,7 @@ bool EnvironmentDescription::operator!=(const EnvironmentDescription& rhs) const
     return !(*this == rhs);
 }
 
-void EnvironmentDescription::newProperty(const std::string &name, const char *ptr, size_t length, bool isConst, EnvironmentManager::size_type elements, const std::type_index &type) {
+void EnvironmentDescription::newProperty(const std::string &name, const char *ptr, size_t length, bool isConst, flamegpu::size_type elements, const std::type_index &type) {
     properties.emplace(name, PropData(isConst, util::Any(ptr, length, type, elements)));
 }
 

--- a/src/flamegpu/model/LayerData.cpp
+++ b/src/flamegpu/model/LayerData.cpp
@@ -5,7 +5,7 @@
 
 namespace flamegpu {
 
-LayerData::LayerData(const std::shared_ptr<const ModelData> &model, const std::string &layer_name, const ModelData::size_type &layer_index)
+LayerData::LayerData(const std::shared_ptr<const ModelData> &model, const std::string &layer_name, const flamegpu::size_type &layer_index)
     : description(new LayerDescription(model, this))
     , name(layer_name)
     , index(layer_index) { }

--- a/src/flamegpu/model/LayerDescription.cpp
+++ b/src/flamegpu/model/LayerDescription.cpp
@@ -192,18 +192,18 @@ std::string LayerDescription::getName() const {
     return layer->name;
 }
 
-ModelData::size_type LayerDescription::getIndex() const {
+flamegpu::size_type LayerDescription::getIndex() const {
     return layer->index;
 }
 
 
-ModelData::size_type LayerDescription::getAgentFunctionsCount() const {
+flamegpu::size_type LayerDescription::getAgentFunctionsCount() const {
     // Safe down-cast
-    return static_cast<ModelData::size_type>(layer->agent_functions.size());
+    return static_cast<flamegpu::size_type>(layer->agent_functions.size());
 }
-ModelData::size_type LayerDescription::getHostFunctionsCount() const {
+flamegpu::size_type LayerDescription::getHostFunctionsCount() const {
     // Safe down-cast
-    return static_cast<ModelData::size_type>(layer->host_functions.size());
+    return static_cast<flamegpu::size_type>(layer->host_functions.size());
 }
 
 const AgentFunctionDescription &LayerDescription::getAgentFunction(unsigned int index) const {

--- a/src/flamegpu/model/ModelData.cpp
+++ b/src/flamegpu/model/ModelData.cpp
@@ -180,10 +180,10 @@ bool ModelData::hasSubModelRecursive(const std::shared_ptr<const ModelData> &sub
     return false;
 }
 
-ModelData::size_type ModelData::getMaxLayerWidth() const {
+flamegpu::size_type ModelData::getMaxLayerWidth() const {
     unsigned int maxWidth = 0u;
     for (auto &layer : layers) {
-        maxWidth = (std::max)(maxWidth, static_cast<ModelData::size_type>(layer->agent_functions.size()));
+        maxWidth = (std::max)(maxWidth, static_cast<flamegpu::size_type>(layer->agent_functions.size()));
     }
     return maxWidth;
 }

--- a/src/flamegpu/model/ModelDescription.cpp
+++ b/src/flamegpu/model/ModelDescription.cpp
@@ -112,7 +112,7 @@ LayerDescription& ModelDescription::newLayer(const std::string &name) {
     model->layers.push_back(rtn);
     return *rtn->description;
 }
-LayerDescription& ModelDescription::Layer(const ModelData::size_type &layer_index) {
+LayerDescription& ModelDescription::Layer(const flamegpu::size_type &layer_index) {
     if (model->layers.size() > layer_index) {
         auto it = model->layers.begin();
         for (auto i = 0u; i < layer_index; ++i)
@@ -220,7 +220,7 @@ const LayerDescription& ModelDescription::getLayer(const std::string &name) cons
         "in ModelDescription::getAgent().",
         name.c_str());
 }
-const LayerDescription& ModelDescription::getLayer(const ModelData::size_type &layer_index) const {
+const LayerDescription& ModelDescription::getLayer(const flamegpu::size_type &layer_index) const {
     if (model->layers.size() > layer_index) {
         auto it = model->layers.begin();
         for (auto i = 0u; i < layer_index; ++i)
@@ -250,7 +250,7 @@ bool ModelDescription::hasLayer(const std::string &name) const {
     }
     return false;
 }
-bool ModelDescription::hasLayer(const ModelData::size_type &layer_index) const {
+bool ModelDescription::hasLayer(const flamegpu::size_type &layer_index) const {
     return layer_index < model->layers.size();
 }
 
@@ -261,17 +261,17 @@ std::string ModelDescription::getConstructedLayersString() const {
     return model->dependencyGraph->getConstructedLayersString();
 }
 
-ModelData::size_type ModelDescription::getAgentsCount() const {
+flamegpu::size_type ModelDescription::getAgentsCount() const {
     // This down-cast is safe
-    return static_cast<ModelData::size_type>(model->agents.size());
+    return static_cast<flamegpu::size_type>(model->agents.size());
 }
-ModelData::size_type ModelDescription::getMessagesCount() const {
+flamegpu::size_type ModelDescription::getMessagesCount() const {
     // This down-cast is safe
-    return static_cast<ModelData::size_type>(model->messages.size());
+    return static_cast<flamegpu::size_type>(model->messages.size());
 }
-ModelData::size_type ModelDescription::getLayersCount() const {
+flamegpu::size_type ModelDescription::getLayersCount() const {
     // This down-cast is safe
-    return static_cast<ModelData::size_type>(model->layers.size());
+    return static_cast<flamegpu::size_type>(model->layers.size());
 }
 
 }  // namespace flamegpu

--- a/src/flamegpu/pop/AgentVector.cpp
+++ b/src/flamegpu/pop/AgentVector.cpp
@@ -207,17 +207,17 @@ bool AgentVector::empty() const {
     _requireLength();
     return _size == 0;
 }
-AgentVector::size_type AgentVector::size() const {
+flamegpu::size_type AgentVector::size() const {
     _requireLength();
     return _size;
 }
-AgentVector::size_type AgentVector::max_size() { return std::numeric_limits<size_type>::max() - 1; }
+flamegpu::size_type AgentVector::max_size() { return std::numeric_limits<size_type>::max() - 1; }
 void AgentVector::reserve(size_type new_cap) {
     if (new_cap > _capacity) {
         internal_resize(new_cap, true);
     }
 }
-AgentVector::size_type AgentVector::capacity() const { return _capacity; }
+flamegpu::size_type AgentVector::capacity() const { return _capacity; }
 void AgentVector::shrink_to_fit() {
     _requireLength();
     if (_size > _capacity) {

--- a/src/flamegpu/pop/AgentVector_Agent.cpp
+++ b/src/flamegpu/pop/AgentVector_Agent.cpp
@@ -2,7 +2,7 @@
 
 namespace flamegpu {
 
-AgentVector_CAgent::AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, AgentVector::size_type pos)
+AgentVector_CAgent::AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, flamegpu::size_type pos)
     : index(pos)
     , _data(data)
     , _agent(agent)
@@ -19,10 +19,11 @@ id_t AgentVector_CAgent::getID() const {
         THROW exception::UnknownInternalError("Internal Error: Unable to read internal ID variable for agent '%s', in AgentVector::CAgent::getID()\n", _agent->name.c_str());
     }
 }
+
 unsigned int AgentVector_CAgent::getIndex() const {
     return index;
 }
-AgentVector_Agent::AgentVector_Agent(AgentVector *parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, AgentVector::size_type pos)
+AgentVector_Agent::AgentVector_Agent(AgentVector* parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, flamegpu::size_type pos)
     : AgentVector_CAgent(parent, agent, data, pos) { }
 
 void AgentVector_Agent::resetID() {

--- a/src/flamegpu/runtime/messaging/MessageArray.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray.cu
@@ -128,7 +128,7 @@ void MessageArray::Description::setLength(const size_type len) {
     }
     reinterpret_cast<Data *>(message)->length = len;
 }
-MessageArray::size_type MessageArray::Description::getLength() const {
+flamegpu::size_type MessageArray::Description::getLength() const {
     return reinterpret_cast<Data *>(message)->length;
 }
 

--- a/src/flamegpu/runtime/messaging/MessageArray2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray2D.cu
@@ -132,13 +132,13 @@ void MessageArray2D::Description::setDimensions(const std::array<size_type, 2> &
     }
     reinterpret_cast<Data *>(message)->dimensions = dims;
 }
-std::array<MessageArray2D::size_type, 2> MessageArray2D::Description::getDimensions() const {
+std::array<flamegpu::size_type, 2> MessageArray2D::Description::getDimensions() const {
     return reinterpret_cast<Data *>(message)->dimensions;
 }
-MessageArray2D::size_type MessageArray2D::Description::getDimX() const {
+flamegpu::size_type MessageArray2D::Description::getDimX() const {
     return reinterpret_cast<Data *>(message)->dimensions[0];
 }
-MessageArray2D::size_type MessageArray2D::Description::getDimY() const {
+flamegpu::size_type MessageArray2D::Description::getDimY() const {
     return reinterpret_cast<Data *>(message)->dimensions[1];
 }
 

--- a/src/flamegpu/runtime/messaging/MessageArray3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray3D.cu
@@ -132,16 +132,16 @@ void MessageArray3D::Description::setDimensions(const std::array<size_type, 3> &
     }
     reinterpret_cast<Data *>(message)->dimensions = dims;
 }
-std::array<MessageArray3D::size_type, 3> MessageArray3D::Description::getDimensions() const {
+std::array<flamegpu::size_type, 3> MessageArray3D::Description::getDimensions() const {
     return reinterpret_cast<Data *>(message)->dimensions;
 }
-MessageArray2D::size_type MessageArray3D::Description::getDimX() const {
+flamegpu::size_type MessageArray3D::Description::getDimX() const {
     return reinterpret_cast<Data *>(message)->dimensions[0];
 }
-MessageArray2D::size_type MessageArray3D::Description::getDimY() const {
+flamegpu::size_type MessageArray3D::Description::getDimY() const {
     return reinterpret_cast<Data *>(message)->dimensions[1];
 }
-MessageArray2D::size_type MessageArray3D::Description::getDimZ() const {
+flamegpu::size_type MessageArray3D::Description::getDimZ() const {
     return reinterpret_cast<Data *>(message)->dimensions[2];
 }
 

--- a/src/flamegpu/runtime/messaging/MessageBruteForce.cu
+++ b/src/flamegpu/runtime/messaging/MessageBruteForce.cu
@@ -123,7 +123,7 @@ size_t MessageBruteForce::Description::getVariableSize(const std::string &variab
         "in MessageDescription::getVariableSize().",
         message->name.c_str(), variable_name.c_str());
 }
-MessageBruteForce::size_type MessageBruteForce::Description::getVariableLength(const std::string &variable_name) const {
+flamegpu::size_type MessageBruteForce::Description::getVariableLength(const std::string &variable_name) const {
     auto f = message->variables.find(variable_name);
     if (f != message->variables.end()) {
         return f->second.elements;
@@ -132,9 +132,9 @@ MessageBruteForce::size_type MessageBruteForce::Description::getVariableLength(c
         "in MessageBruteForce::getVariableLength().",
         message->name.c_str(), variable_name.c_str());
 }
-MessageBruteForce::size_type MessageBruteForce::Description::getVariablesCount() const {
+flamegpu::size_type MessageBruteForce::Description::getVariablesCount() const {
     // Downcast, will never have more than UINT_MAX variables
-    return static_cast<MessageBruteForce::size_type>(message->variables.size());
+    return static_cast<flamegpu::size_type>(message->variables.size());
 }
 bool MessageBruteForce::Description::hasVariable(const std::string &variable_name) const {
     return message->variables.find(variable_name) != message->variables.end();

--- a/src/flamegpu/runtime/utility/RandomManager.cu
+++ b/src/flamegpu/runtime/utility/RandomManager.cu
@@ -88,10 +88,10 @@ util::detail::curandState *RandomManager::resize(size_type _length, cudaStream_t
     auto t_length = length;
     if (length) {
         while (t_length < _length) {
-            t_length = static_cast<RandomManager::size_type>(t_length * growthModifier);
+            t_length = static_cast<flamegpu::size_type>(t_length * growthModifier);
             if (shrinkModifier < 1.0f) {
                 while (t_length * shrinkModifier > _length) {
-                    t_length = static_cast<RandomManager::size_type>(t_length * shrinkModifier);
+                    t_length = static_cast<flamegpu::size_type>(t_length * shrinkModifier);
                 }
             }
         }
@@ -104,7 +104,7 @@ util::detail::curandState *RandomManager::resize(size_type _length, cudaStream_t
         resizeDeviceArray(t_length, stream);
     return d_random_state;
 }
-__global__ void init_curand(util::detail::curandState *d_random_state, unsigned int threadCount, uint64_t seed, RandomManager::size_type offset) {
+__global__ void init_curand(util::detail::curandState *d_random_state, unsigned int threadCount, uint64_t seed, flamegpu::size_type offset) {
     int id = blockIdx.x * blockDim.x + threadIdx.x;
     if (id < threadCount)
         curand_init(seed, offset + id, 0, &d_random_state[offset + id]);
@@ -190,7 +190,7 @@ void RandomManager::setShrinkModifier(float _shrinkModifier) {
 float RandomManager::getShrinkModifier() {
     return RandomManager::shrinkModifier;
 }
-RandomManager::size_type RandomManager::size() {
+flamegpu::size_type RandomManager::size() {
     return length;
 }
 uint64_t RandomManager::seed() {

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -619,7 +619,7 @@ class ModelVis;
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
     }
-    void flamegpu::AgentVector::__setitem__(const flamegpu::flamegpu::size_type &index, const flamegpu::AgentVector::Agent &value) {
+    void flamegpu::AgentVector::__setitem__(const flamegpu::size_type &index, const flamegpu::AgentVector::Agent &value) {
         $self->operator[](index).setData(value);
     }
 }

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -619,7 +619,7 @@ class ModelVis;
             return $self->operator[](index);
         return $self->operator[]($self->size() + index);
     }
-    void flamegpu::AgentVector::__setitem__(const flamegpu::AgentVector::size_type &index, const flamegpu::AgentVector::Agent &value) {
+    void flamegpu::AgentVector::__setitem__(const flamegpu::flamegpu::size_type &index, const flamegpu::AgentVector::Agent &value) {
         $self->operator[](index).setData(value);
     }
 }
@@ -998,7 +998,7 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
             return $self->operator[]($self->size() + index);
         }
         // Palettes are currently immutable
-        //void Palette::__setitem__(const AgentVector::size_type &index, const Color &value) {
+        //void Palette::__setitem__(const flamegpu::size_type &index, const Color &value) {
         //     $self->operator[](index) = value;
         //}
     }

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -98,7 +98,7 @@ TEST(TestRunPlan, setProperty) {
     plan.setProperty<float, 3>("f_a", {-2.0f, 0.0f, 2.0f});
     plan.setProperty<int32_t, 3>("i_a", {-2, 0, 2});
     // Set individual elements at a time
-    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
+    // RunPlan::setProperty(const std::string &name, flamegpu::size_type index, T value)
     plan.setProperty<uint32_t>("u_a", 0, 3u);
     plan.setProperty<uint32_t>("u_a", 1, 4u);
     plan.setProperty<uint32_t>("u_a", 2, 5u);
@@ -138,7 +138,7 @@ TEST(TestRunPlan, setProperty) {
     plan.setProperty<float, 3>("f_a", { 3.0f, 0.0f, -3.0f });
     plan.setProperty<int32_t, 3>("i_a", { 3, 0, 5 });
     // Set individual elements at a time
-    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
+    // RunPlan::setProperty(const std::string &name, flamegpu::size_type index, T value)
     plan.setProperty<uint32_t>("u_a", 0, 13u);
     plan.setProperty<uint32_t>("u_a", 1, 14u);
     plan.setProperty<uint32_t>("u_a", 2, 15u);
@@ -175,32 +175,32 @@ TEST(TestRunPlan, setProperty) {
     EXPECT_THROW(plan.setProperty<float>("does_not_exist", 1.f), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW(plan.setProperty<float>("i", 1.f), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW(plan.setProperty<uint32_t>("u_a", 1u), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
+    // RunPlan::setProperty(const std::string &name, flamegpu::size_type index, T value)
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((plan.setProperty<float, 3>("does_not_exist", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.setProperty<float, 3>("u_a", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.setProperty<int32_t, 2>("i_a", {-2, 0})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.setProperty<int32_t, 4>("i_a", {-2, 0, 2, 2})), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
+    // RunPlan::setProperty(const std::string &name, flamegpu::size_type index, T value)
     EXPECT_THROW((plan.setProperty<float>("does_not_exist", 0u, 3.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.setProperty<float>("u_a", 0u, 3.f)), flamegpu::exception::InvalidEnvPropertyType);
-    EXPECT_THROW((plan.setProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1), 3)), exception::OutOfBoundsException);
+    EXPECT_THROW((plan.setProperty<int32_t>("i_a", static_cast<flamegpu::size_type>(-1), 3)), exception::OutOfBoundsException);
     EXPECT_THROW((plan.setProperty<int32_t>("i_a", 4u, 3)), exception::OutOfBoundsException);
 
     // RunPlan::getProperty(const std::string &name)
     EXPECT_THROW(plan.getProperty<float>("does_not_exist"), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW(plan.getProperty<float>("i"), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW(plan.getProperty<uint32_t>("u_a"), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::getProperty(const std::string &name, EnvironmentManager::size_type index)
+    // RunPlan::getProperty(const std::string &name, flamegpu::size_type index)
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((plan.getProperty<float, 3>("does_not_exist")), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.getProperty<float, 3>("u_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 2>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 4>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
-    // RunPlan::getProperty(const std::string &name, EnvironmentManager::size_type index)
+    // RunPlan::getProperty(const std::string &name, flamegpu::size_type index)
     EXPECT_THROW((plan.getProperty<float>("does_not_exist", 0u)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.getProperty<float>("u_a", 0u)), flamegpu::exception::InvalidEnvPropertyType);
-    EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1))), exception::OutOfBoundsException);
+    EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<flamegpu::size_type>(-1))), exception::OutOfBoundsException);
     EXPECT_THROW((plan.getProperty<int32_t>("i_a", 4u)), exception::OutOfBoundsException);
 #ifdef USE_GLM
     EXPECT_THROW((plan.setProperty<glm::ivec3>)("ivec32", 3u, {}), exception::OutOfBoundsException);  // Out of bounds
@@ -274,10 +274,10 @@ TEST(TestRunPlan, getProperty) {
     EXPECT_THROW((plan.getProperty<float, 3>("u_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 2>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plan.getProperty<int32_t, 4>("i_a")), flamegpu::exception::InvalidEnvPropertyType);
-    // T RunPlan::getProperty(const std::string &name, EnvironmentManager::size_type index) const
+    // T RunPlan::getProperty(const std::string &name, flamegpu::size_type index) const
     EXPECT_THROW((plan.getProperty<float>("does_not_exist", 0u)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plan.getProperty<float>("u_a", 0u)), flamegpu::exception::InvalidEnvPropertyType);
-    EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<EnvironmentManager::size_type>(-1))), exception::OutOfBoundsException);
+    EXPECT_THROW((plan.getProperty<int32_t>("i_a", static_cast<flamegpu::size_type>(-1))), exception::OutOfBoundsException);
     EXPECT_THROW((plan.getProperty<int32_t>("i_a", 4u)), exception::OutOfBoundsException);
 }
 // @todo - This test could be a lot more thorough.

--- a/tests/test_cases/sim/test_RunPlanVector.cu
+++ b/tests/test_cases/sim/test_RunPlanVector.cu
@@ -122,7 +122,7 @@ TEST(TestRunPlanVector, setProperty) {
     // Explicit type is required, to coerce the std::array. Might need partial template specialisation for  where the value is a stdarray of T?
     plans.setProperty<uint32_t, 3>("u3", u3New);
     // Check setting individual array elements
-    // void RunPlanVector::setProperty(const std::string &name, EnvironmentManager::size_type index, T value) {
+    // void RunPlanVector::setProperty(const std::string &name, flamegpu::size_type index, T value) {
     plans.setProperty<double>("d3", 0, d3New[0]);
     plans.setProperty<double>("d3", 1, d3New[1]);
     plans.setProperty<double>("d3", 2, d3New[2]);
@@ -163,10 +163,10 @@ TEST(TestRunPlanVector, setProperty) {
     EXPECT_THROW((plans.setProperty<float, 3>("u3", {2.f, 2.f, 2.f})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setProperty<double, 2>("d3", {-2, 0})), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setProperty<double, 4>("d3", {-2, 0, 2, 2})), flamegpu::exception::InvalidEnvPropertyType);
-    // void RunPlanVector::setProperty(const std::string &name, EnvironmentManager::size_type index, T value)
+    // void RunPlanVector::setProperty(const std::string &name, flamegpu::size_type index, T value)
     EXPECT_THROW((plans.setProperty<float>("does_not_exist", 0u, 3.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setProperty<float>("u3", 0u, 3.f)), flamegpu::exception::InvalidEnvPropertyType);
-    EXPECT_THROW((plans.setProperty<double>("d3", static_cast<EnvironmentManager::size_type>(-1), 3)), exception::OutOfBoundsException);
+    EXPECT_THROW((plans.setProperty<double>("d3", static_cast<flamegpu::size_type>(-1), 3)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setProperty<double>("d3", 4u, 3)), exception::OutOfBoundsException);
 #ifdef USE_GLM
     EXPECT_THROW((plans.setProperty<glm::ivec3>)("ivec32", 3u, {}), exception::OutOfBoundsException);  // Out of bounds
@@ -217,7 +217,7 @@ TEST(TestRunPlanVector, setPropertyUniformDistribution) {
     plans.setPropertyUniformDistribution("fb", fbMin, fbMax);
     plans.setPropertyUniformDistribution("i", iMin, iMax);
     // Check setting individual array elements
-    // void setPropertyUniformDistribution(const std::string &name, EnvironmentManager::size_type index, T min, T max);
+    // void setPropertyUniformDistribution(const std::string &name, flamegpu::size_type index, T min, T max);
     plans.setPropertyUniformDistribution("u3", 0, u3Min[0], u3Max[0]);
     plans.setPropertyUniformDistribution("u3", 1, u3Min[1], u3Max[1]);
     plans.setPropertyUniformDistribution("u3", 2, u3Min[2], u3Max[2]);
@@ -250,12 +250,12 @@ TEST(TestRunPlanVector, setPropertyUniformDistribution) {
     EXPECT_THROW((plans.setPropertyUniformDistribution<float>("does_not_exist", 1.f, 100.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setPropertyUniformDistribution<float>("i", 1.f, 100.f)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", 1u, 100u)), flamegpu::exception::InvalidEnvPropertyType);
-    // void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const EnvironmentManager::size_type
+    // void RunPlanVector::setPropertyUniformDistribution(const std::string &name, const flamegpu::size_type
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((singlePlanVector.setPropertyUniformDistribution<uint32_t>("u3", 0u, 1u, 100u)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setPropertyUniformDistribution<float>("does_not_exist", 0u, 1.f, 100.f)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setPropertyUniformDistribution<float>("u3", 0u, 1.f, 100.f)), flamegpu::exception::InvalidEnvPropertyType);
-    EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", static_cast<EnvironmentManager::size_type>(-1), 1u, 100u)), exception::OutOfBoundsException);
+    EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", static_cast<flamegpu::size_type>(-1), 1u, 100u)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setPropertyUniformDistribution<uint32_t>("u3", 4u, 1u, 100u)), exception::OutOfBoundsException);
 }
 // Checking for uniformity of distribution would require a very large samples size.
@@ -288,12 +288,12 @@ TEST(TestRunPlanVector, setPropertyUniformRandom) {
     plans.setPropertyUniformRandom("f", fMin, fMax);
     plans.setPropertyUniformRandom("i", iMin, iMax);
     // Check setting individual array elements
-    // void setPropertyUniformRandom(const std::string &name, EnvironmentManager::size_type index, T min, T Max);
+    // void setPropertyUniformRandom(const std::string &name, flamegpu::size_type index, T min, T Max);
     plans.setPropertyUniformRandom("u3", 0, u3Min[0], u3Max[0]);
     plans.setPropertyUniformRandom("u3", 1, u3Min[1], u3Max[1]);
     plans.setPropertyUniformRandom("u3", 2, u3Min[2], u3Max[2]);
     EXPECT_THROW((plans.setPropertyUniformRandom("u3", 3, u3Min[0], u3Max[0])), exception::OutOfBoundsException);
-    EXPECT_THROW((plans.setPropertyUniformRandom("u3", static_cast<EnvironmentManager::size_type>(-1), u3Min[0], u3Max[0])), exception::OutOfBoundsException);
+    EXPECT_THROW((plans.setPropertyUniformRandom("u3", static_cast<flamegpu::size_type>(-1), u3Min[0], u3Max[0])), exception::OutOfBoundsException);
     // Check values are as expected by accessing the properties from each plan
     for (const auto &plan : plans) {
         // Floating point types are inclusive-exclusive [min, Max)
@@ -338,12 +338,12 @@ TEST(TestRunPlanVector, setPropertyNormalRandom) {
     // void setPropertyNormalRandom(const std::string &name, T mean, T stddev);
     plans.setPropertyNormalRandom("f", fMean, fStddev);
     // Check setting individual array elements
-    // void setPropertyNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev);
+    // void setPropertyNormalRandom(const std::string &name, flamegpu::size_type index, T mean, T stddev);
     plans.setPropertyNormalRandom("d3", 0, d3Mean[0], d3Stddev[0]);
     plans.setPropertyNormalRandom("d3", 1, d3Mean[1], d3Stddev[1]);
     plans.setPropertyNormalRandom("d3", 2, d3Mean[2], d3Stddev[2]);
     EXPECT_THROW((plans.setPropertyNormalRandom("d3", 3, d3Mean[0], d3Stddev[0])), exception::OutOfBoundsException);
-    EXPECT_THROW((plans.setPropertyNormalRandom("d3", static_cast<EnvironmentManager::size_type>(-1), d3Mean[0], d3Stddev[0])), exception::OutOfBoundsException);
+    EXPECT_THROW((plans.setPropertyNormalRandom("d3", static_cast<flamegpu::size_type>(-1), d3Mean[0], d3Stddev[0])), exception::OutOfBoundsException);
     bool fAtleastOneNonDefault = false;
     std::array<bool, 3> d3AtleastOneNonDefault = {{false, false, false}};
     // Check values are as expected by accessing the properties from each plan
@@ -394,7 +394,7 @@ TEST(TestRunPlanVector, setPropertyLogNormalRandom) {
     // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, T mean, T stddev) {
     plans.setPropertyLogNormalRandom("f", fMean, fStddev);
     // Check setting individual array elements
-    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, EnvironmentManager::size_type index, T mean, T stddev) {
+    // void RunPlanVector::setPropertyLogNormalRandom(const std::string &name, flamegpu::size_type index, T mean, T stddev) {
     plans.setPropertyLogNormalRandom("d3", 0, d3Mean[0], d3Stddev[0]);
     plans.setPropertyLogNormalRandom("d3", 1, d3Mean[1], d3Stddev[1]);
     plans.setPropertyLogNormalRandom("d3", 2, d3Mean[2], d3Stddev[2]);
@@ -450,7 +450,7 @@ TEST(TestRunPlanVector, setPropertyRandom) {
     std::uniform_real_distribution<float> fdist(fMin, fMax);
     plans.setPropertyRandom<float>("f", fdist);
     // Check setting individual array elements
-    // void setPropertyRandom(const std::string &name, EnvironmentManager::size_type index, rand_dist &distribution);
+    // void setPropertyRandom(const std::string &name, flamegpu::size_type index, rand_dist &distribution);
     std::normal_distribution<double> d3dist0(d3Mean[0], d3Stddev[0]);
     std::normal_distribution<double> d3dist1(d3Mean[1], d3Stddev[1]);
     std::normal_distribution<double> d3dist2(d3Mean[2], d3Stddev[2]);
@@ -489,12 +489,12 @@ TEST(TestRunPlanVector, setPropertyRandom) {
     EXPECT_THROW((plans.setPropertyRandom<float>("does_not_exist", fdist)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setPropertyRandom<double>("f", d3dist0)), flamegpu::exception::InvalidEnvPropertyType);
     EXPECT_THROW((plans.setPropertyRandom<double>("d3", d3dist0)), flamegpu::exception::InvalidEnvPropertyType);
-    // void RunPlanVector::setPropertyRandom(const std::string &name, EnvironmentManager::size_type index, rand_dist &distribution)
+    // void RunPlanVector::setPropertyRandom(const std::string &name, flamegpu::size_type index, rand_dist &distribution)
     // Extra brackets within the macro mean commas can be used due to how preproc tokenizers work
     EXPECT_THROW((singlePlanVector.setPropertyRandom<double>("d3", 0u, d3dist0)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setPropertyRandom<float>("does_not_exist", 0u, fdist)), flamegpu::exception::InvalidEnvProperty);
     EXPECT_THROW((plans.setPropertyRandom<float>("d3", 0u, fdist)), flamegpu::exception::InvalidEnvPropertyType);
-    EXPECT_THROW((plans.setPropertyRandom<double>("d3", static_cast<EnvironmentManager::size_type>(-1), d3dist0)), exception::OutOfBoundsException);
+    EXPECT_THROW((plans.setPropertyRandom<double>("d3", static_cast<flamegpu::size_type>(-1), d3dist0)), exception::OutOfBoundsException);
     EXPECT_THROW((plans.setPropertyRandom<double>("d3", 4u, d3dist0)), exception::OutOfBoundsException);
 }
 // Test getting the random property seed


### PR DESCRIPTION
Fixes #559 

Occurrences of unique `size_type` to fix. Found with regex `typedef .* size_type`.

- [x] ModelData.h
- [x] AgentVector.h
- [x] EnvironmentManager.h
- [x] RandomManager.h
- [x] MessageArray.h
- [x] MessageArray2D.h
- [x] MessageArray3D.h
- [x] MessageBruteForce.h
- [x] MessageBucket.h
- [x] MessageNone.h
- [x] MessageSpatial2D.h
- [x] MessageSpatial3D.h

New universal `size_type` is under `flamegpu` namespace.