### PR TITLE
Remove ensemble warnings

### DIFF
--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -144,8 +144,8 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     if (!config.out_directory.empty() && !config.out_format.empty()) {
         log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn,
         step_log_config.get(), exit_log_config.get(), step_log_config && step_log_config->log_timing, exit_log_config && exit_log_config->log_timing);
-    } else if (!config.out_directory.empty() ^ !config.out_format.empty())  {
-        fprintf(stderr, "Warning: Only 1 of out_directory and out_format is set, both must be set for logging to commence to file.\n");
+    } else if (config.out_directory.empty())  {
+        fprintf(stderr, "Warning: out_directory must be set for logging to commence to file.\n");
     }
 
     // Wait for all runners to exit

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -141,11 +141,9 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
 
     // Init log worker
     SimLogger *log_worker = nullptr;
-    if (!config.out_directory.empty() && !config.out_format.empty()) {
+    if (!config.out_directory.empty()) {
         log_worker = new SimLogger(run_logs, plans, config.out_directory, config.out_format, log_export_queue, log_export_queue_mutex, log_export_queue_cdn,
         step_log_config.get(), exit_log_config.get(), step_log_config && step_log_config->log_timing, exit_log_config && exit_log_config->log_timing);
-    } else if (config.out_directory.empty())  {
-        fprintf(stderr, "Warning: out_directory must be set for logging to commence to file.\n");
     }
 
     // Wait for all runners to exit

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -233,7 +233,6 @@ TEST(TestCUDAEnsemble, simulate) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     // Simulate the ensemble,
     EXPECT_NO_THROW(ensemble.simulate(plans));
     // Get the sum of sums from the atomic.
@@ -268,7 +267,6 @@ TEST(TestCUDAEnsemble, setStepLog) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     // Set the StepLog config.
     EXPECT_NO_THROW(ensemble.setStepLog(slcfg));
     // Run the ensemble, generating logs
@@ -312,7 +310,6 @@ TEST(TestCUDAEnsemble, setExitLog) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     // Set the StepLog config.
     EXPECT_NO_THROW(ensemble.setExitLog(lcfg));
     // Run the ensemble, generating logs
@@ -383,7 +380,6 @@ TEST(TestCUDAEnsemble, getEnsembleElapsedTime) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     // Get the elapsed seconds before the sim has been executed
     EXPECT_NO_THROW(ensemble.getEnsembleElapsedTime());
     // Assert that it is LE zero.
@@ -428,7 +424,6 @@ TEST(TestCUDAEnsemble, ErrorOff) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     ensemble.Config().error_level = CUDAEnsemble::EnsembleConfig::Off;
     ensemble.Config().concurrent_runs = 1;  // Single device/no concurrency to ensure we get consistent data
     ensemble.Config().devices = {0};
@@ -461,7 +456,6 @@ TEST(TestCUDAEnsemble, ErrorSlow) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     ensemble.Config().error_level = CUDAEnsemble::EnsembleConfig::Slow;
     ensemble.Config().concurrent_runs = 1;  // Single device/no concurrency to ensure we get consistent data
     ensemble.Config().devices = { 0 };
@@ -492,7 +486,6 @@ TEST(TestCUDAEnsemble, ErrorFast) {
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
     ensemble.Config().quiet = true;
-    ensemble.Config().out_format = "";  // Suppress warning
     ensemble.Config().error_level = CUDAEnsemble::EnsembleConfig::Fast;
     ensemble.Config().concurrent_runs = 1;  // Single device/no concurrency to ensure we get consistent data
     ensemble.Config().devices = { 0 };

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -365,7 +365,7 @@ TEST(TestRunPlan, operatorMultiplication) {
         // @todo - compare more than one part? Operator== might be easier / cleaner
     }
 }
-TEST(TestRunPlan, outputWarning) {
+TEST(TestRunPlan, noOutputWarning) {
     // Create a model
     flamegpu::ModelDescription model("test");
     // Create an individual run plan vector

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -365,6 +365,19 @@ TEST(TestRunPlan, operatorMultiplication) {
         // @todo - compare more than one part? Operator== might be easier / cleaner
     }
 }
+TEST(TestRunPlan, outputWarning) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an individual run plan vector
+    flamegpu::RunPlanVector runs(model, 10);
+    testing::internal::CaptureStderr();
+    // Construct the ensemble
+    flamegpu::CUDAEnsemble cuda_ensemble(model);
+    // Simulate (nothing)
+    EXPECT_THROW(cuda_ensemble.simulate(runs), flamegpu::exception::EnsembleError);  // No agents so expect exception
+    std::string output = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(output.find("Warning: ") == std::string::npos);  // No warnings should be output
+}
 /*
 getPropertyArray/setPropertyArray are only declared if SWIG is defined.
 // This is not currently the case when building the test suite, so these cannot be tested here.


### PR DESCRIPTION
Fixes #675 by removing the warning. This can be justified as a warning should not be output for default behaviour (`out_directory="", out_format=""`). Instead no logging will take place. 

If the `out_directory` is set then logging takes place. If `out_directory` is set and the user changes `out_format` to "" (which would previously raise a warning) then an exception will be thrown instead (as it would with any `out_format` which represents an unsupported format). 

The only place where this is less nice is if someone sets  `out_format` but doesn't set `out_directory` in which case there is no warning and no logging. This doesn't seem unreasonable. 