### PR TITLE
Remove automatic `cudaDeviceReset`

### DIFF
--- a/include/flamegpu/gpu/CUDASimulation.h
+++ b/include/flamegpu/gpu/CUDASimulation.h
@@ -604,11 +604,6 @@ class CUDASimulation : public Simulation {
     std::unique_ptr<visualiser::ModelVis> visualisation;
 #endif
     /**
-     * This tracks the current number of alive CUDASimulation instances
-     * When the last is destructed, cudaDeviceReset is triggered();
-     */
-    static std::atomic<int> active_instances;
-    /**
      * Returns false if any agent functions or agent function conditions are not RTC
      * Used by constructor to set isPureRTC constant value
      * @param _model The agent model hierarchy to check
@@ -620,12 +615,6 @@ class CUDASimulation : public Simulation {
      * If true, the model is pureRTC, and hence does not use non-RTC curve
      */
     const bool isPureRTC;
-
- public:
-    /**
-     * If changed to false, will not auto cudaDeviceReset when final CUDASimulation instance is destructed
-     */
-    static bool AUTO_CUDA_DEVICE_RESET;
 };
 
 template<typename T>

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -167,12 +167,6 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     ensemble_timer.stop();
     ensemble_elapsed_time = ensemble_timer.getElapsedSeconds();
 
-    // Reset every used device
-    for (auto d = devices.begin(); d != devices.end(); ++d) {
-        gpuErrchk(cudaSetDevice(*d));
-        gpuErrchk(cudaDeviceReset());
-    }
-
     // Ensemble has finished, print summary
     if (!config.quiet) {
         printf("\rCUDAEnsemble completed %u runs successfully!\n", static_cast<unsigned int>(plans.size() - err_ct));

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -540,8 +540,8 @@ TEST(TestCUDAEnsemble, SimualteWithExistingCUDASimulation) {
     // Simulate the ensemble,
     EXPECT_NO_THROW(ensemble.simulate(plans));
 
-    // At this point, the cudaSim should still be usable (and dtor-able), but errors in the CUDAEnsemble::Simulate cudaDeviceReset logic would result in an error?
-    EXPECT_NO_THROW(simulation.step());  // alternatively checking dtor would be valid / useful?
+    // At this point, the cudaSim should still be usable (and dtor-able()
+    EXPECT_NO_THROW(simulation.step());
 }
 
 /*

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -774,6 +774,51 @@ TEST(TestCUDASimulation, setEnvironmentProperty) {
     s.simulate();
 }
 
+/*
+ * Test that use of a CUDASimulation does not break existing device memory (e.g. an existing CUDAEnsemble) by incorrectly resetting devices.
+ * This was an issue previously noticed within the python test suite, due to GC delay.
+ * see https://github.com/FLAMEGPU/FLAMEGPU2/issues/939
+ */
+TEST(TestCUDASimulation, SimulationWithExistingCUDAMalloc) {
+    // Test requires auto device reset enabled
+    flamegpu::CUDASimulation::AUTO_CUDA_DEVICE_RESET = true;
+    // Allocate some arbitraty device memory.
+    int * d_int = nullptr;
+    gpuErrchk(cudaMalloc(&d_int, sizeof(int)));
+    // Validate that the ptr is a valid device pointer
+    cudaPointerAttributes attributes = {};
+    gpuErrchk(cudaPointerGetAttributes(&attributes, d_int));
+    EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
+
+    // Add extra layer of scope, so the ensemble get's dtor'd incase the dtor triggers a reset
+    {
+        ModelDescription m(MODEL_NAME);
+        AgentDescription &a = m.newAgent(AGENT_NAME);
+        AgentVector pop(a, static_cast<unsigned int>(AGENT_COUNT));
+        m.addStepFunction(IncrementCounter);
+        // Instanciate a CUDASimulation of the model
+        CUDASimulation c(m);
+        c.setPopulationData(pop);
+        c.SimulationConfig().steps = 1;
+        // Assert that using the simulation does not trigger an exception
+        c.simulate();
+    }
+
+    // At this point, the manually allocated data should still be valid, i.e. cudaMemoryTypeDevice
+    gpuErrchk(cudaPointerGetAttributes(&attributes, d_int));
+    EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
+
+    // Free explicit device memory, if it was valid (to get the correct error)
+    if (attributes.type == cudaMemoryTypeDevice) {
+        gpuErrchk(cudaFree(d_int));
+    }
+    d_int = nullptr;
+
+    // re-disable auto device reset
+    flamegpu::CUDASimulation::AUTO_CUDA_DEVICE_RESET = false;
+}
+
+
 }  // namespace test_cuda_simulation
 }  // namespace tests
 }  // namespace flamegpu

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -50,8 +50,6 @@ FLAMEGPU_EXIT_FUNCTION(ExitIncrementCounterSlow) {
 TEST(TestCUDASimulation, ApplyConfigDerivedContextCreation) {
     // Simply get the result from the method provided by the helper file.
     ASSERT_TRUE(getCUDASimulationContextCreationTestResult());
-    // Reset the device, just to be sure.
-    ASSERT_EQ(cudaSuccess, cudaDeviceReset());
 }
 // Test that the CUDASimulation applyConfig_derived works for multiple GPU device_id values (if available)
 TEST(TestCUDASimulation, AllDeviceIdValues) {
@@ -780,8 +778,6 @@ TEST(TestCUDASimulation, setEnvironmentProperty) {
  * see https://github.com/FLAMEGPU/FLAMEGPU2/issues/939
  */
 TEST(TestCUDASimulation, SimulationWithExistingCUDAMalloc) {
-    // Test requires auto device reset enabled
-    flamegpu::CUDASimulation::AUTO_CUDA_DEVICE_RESET = true;
     // Allocate some arbitraty device memory.
     int * d_int = nullptr;
     gpuErrchk(cudaMalloc(&d_int, sizeof(int)));
@@ -813,9 +809,6 @@ TEST(TestCUDASimulation, SimulationWithExistingCUDAMalloc) {
         gpuErrchk(cudaFree(d_int));
     }
     d_int = nullptr;
-
-    // re-disable auto device reset
-    flamegpu::CUDASimulation::AUTO_CUDA_DEVICE_RESET = false;
 }
 
 

--- a/tests/test_cases/util/test_CUDAEventTimer.cu
+++ b/tests/test_cases/util/test_CUDAEventTimer.cu
@@ -46,8 +46,6 @@ TEST(TestUtilCUDAEventTimer, CUDAEventTimer) {
     EXPECT_GE(timer->getElapsedSeconds(), min_expected_seconds);
     // Trigger the destructor.
     EXPECT_NO_THROW(delete timer);
-    // Reset the device for profiling?
-    gpuErrchk(cudaDeviceReset());
 }
 
 }  // namespace test_CUDAEventTimer


### PR DESCRIPTION
The automatic `cudaDeviceReset` in `CUDASimulation` and `CUDAEnsemble` were breaking the pyhton test suite due to GC of a `CUDASimulation` being triggered after the reset in `CUDAEnsemble::simulate`. 

This PR removes the device resets for now, which will (potentially) break use of cuda-memecheck, profilers etc, but allow the python test suite to run.


The planned more significant fix is to add an implementation agnostic public api method (`cleanup`/`finalise`/`finalize`/`shutdown`) which for the current (only) implemetnation using CUDA would perform a `cudaDeviceReset` for any/all CUDA devices (potentially used, maybe not initially). However, this is non-trivial to implement in practice in a way that can be used in the same scope as a `CUDASimulation` or `CUDAEnsemble` (or any other class which uses cuda in the dtor). 

This PR is to make the python test suite usable again, while another PR (see the `device-reset-method` branch) will add the new method, but that may take some time to correctly implement.

Part of #939.