### PR TITLE
Add Compute Capabillity 90 (Hopper) to the default cuda architectures

### DIFF
--- a/cmake/cuda_arch.cmake
+++ b/cmake/cuda_arch.cmake
@@ -26,7 +26,7 @@ macro(SetCUDAGencodes)
     set_property(TARGET ${SCG_TARGET} PROPERTY CUDA_ARCHITECTURES OFF)
 
     # Define the default compute capabilites incase not provided by the user
-    set(DEFAULT_CUDA_ARCH "35;50;60;70;80;")
+    set(DEFAULT_CUDA_ARCH "35;50;60;70;80;90;")
 
     # Determine if the user has provided a non default CUDA_ARCH value 
     string(LENGTH "${CUDA_ARCH}" CUDA_ARCH_LENGTH)


### PR DESCRIPTION
Adds `SM 90` (Hopper) to our default CUDA Architecture values, so Hopper is targetted by default with CUDA >= 11.8. 

In the future we might want to add an `11.8` wheel to the matrix for Hopper users, but in general anyone with hopper could build it for themselves (i.e. HPC only).

Ada (40 series) is `SM 89` (i.e. it's closer to Ampere than Hopper), so we already target that major arch by default.


---

Configuring with CUDA 11.8 using the new default:
```
-- The CUDA compiler identification is NVIDIA 11.8.89
... 
-- Generating Compute Capabilities: 35;50;60;70;80;90
```

Configuring with CUDA 11.7 using the new default

```
-- The CUDA compiler identification is NVIDIA 11.7.99
...
-- Generating Compute Capabilities: 35;50;60;70;80
```

Building for `89,90` is fine and emits no new warnings. Unable to test execution though as we don't have the hardware.