### PR TITLE
Verbosity levels

### DIFF
--- a/include/flamegpu/defines.h
+++ b/include/flamegpu/defines.h
@@ -17,6 +17,10 @@ constexpr const char* ID_VARIABLE_NAME = "_id";
  * If this value is changed, things may break
  */
 constexpr id_t ID_NOT_SET = 0;
+/**
+* Typedef for verbosity level of the API
+*/
+typedef enum {QUIET, DEFAULT, VERBOSE} verbosity;
 
 typedef unsigned int size_type;
 

--- a/include/flamegpu/defines.h
+++ b/include/flamegpu/defines.h
@@ -20,7 +20,7 @@ constexpr id_t ID_NOT_SET = 0;
 /**
 * Typedef for verbosity level of the API
 */
-typedef enum {QUIET, DEFAULT, VERBOSE} verbosity;
+enum class Verbosity {Quiet, Default, Verbose};
 
 typedef unsigned int size_type;
 

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <vector>
 
+#include "flamegpu/defines.h"
 
 namespace flamegpu {
 
@@ -51,7 +52,7 @@ class CUDAEnsemble {
          * If true progress logging to stdout will be suppressed
          * Defaults to false
          */
-        bool quiet = false;
+        verbosity verbosity = DEFAULT;
         /**
          * If true, the total runtime for the ensemble will be printed to stdout at completion
          * This is independent of the EnsembleConfig::quiet

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -52,7 +52,7 @@ class CUDAEnsemble {
          * If true progress logging to stdout will be suppressed
          * Defaults to false
          */
-        flamegpu::verbosity verbosity = DEFAULT;
+        flamegpu::Verbosity verbosity = Verbosity::Default;
         /**
          * If true, the total runtime for the ensemble will be printed to stdout at completion
          * This is independent of the EnsembleConfig::quiet

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -52,7 +52,7 @@ class CUDAEnsemble {
          * If true progress logging to stdout will be suppressed
          * Defaults to false
          */
-        verbosity verbosity = DEFAULT;
+        flamegpu::verbosity verbosity = DEFAULT;
         /**
          * If true, the total runtime for the ensemble will be printed to stdout at completion
          * This is independent of the EnsembleConfig::quiet

--- a/include/flamegpu/sim/SimRunner.h
+++ b/include/flamegpu/sim/SimRunner.h
@@ -44,7 +44,7 @@ class SimRunner {
      * @param _exit_log_config The config of which data should be logged at run exit
      * @param _device_id The GPU that all runs should execute on
      * @param _runner_id A unique index assigned to the runner
-     * @param _verbose If true more information will be written to stdout
+     * @param _verbosity Verbosity level (QUIET, DEFAULT, VERBOSE)
      * @param _fail_fast If true, the SimRunner will kill other runners and throw an exception on error
      * @param run_logs Reference to the vector to store generate run logs
      * @param log_export_queue The queue of logs to exported to disk

--- a/include/flamegpu/sim/SimRunner.h
+++ b/include/flamegpu/sim/SimRunner.h
@@ -9,6 +9,8 @@
 #include <thread>
 #include <vector>
 #include <string>
+
+#include "flamegpu/defines.h"
 #include "flamegpu/sim/LogFrame.h"
 
 namespace flamegpu {
@@ -59,7 +61,7 @@ class SimRunner {
         std::shared_ptr<const LoggingConfig> _exit_log_config,
         int _device_id,
         unsigned int _runner_id,
-        bool _verbose,
+        flamegpu::verbosity _verbosity,
         bool _fail_fast,
         std::vector<RunLog> &run_logs,
         std::queue<unsigned int> &log_export_queue,
@@ -91,7 +93,7 @@ class SimRunner {
     /**
      * Flag for whether to print progress
      */
-    const bool verbose;
+    const flamegpu::verbosity verbosity;
     /**
      * Flag for whether the ensemble should throw an exception if it errors out
      */

--- a/include/flamegpu/sim/SimRunner.h
+++ b/include/flamegpu/sim/SimRunner.h
@@ -44,7 +44,7 @@ class SimRunner {
      * @param _exit_log_config The config of which data should be logged at run exit
      * @param _device_id The GPU that all runs should execute on
      * @param _runner_id A unique index assigned to the runner
-     * @param _verbosity Verbosity level (QUIET, DEFAULT, VERBOSE)
+     * @param _verbosity Verbosity level (Verbosity::Quiet, Verbosity::Default, Verbosity::Verbose)
      * @param _fail_fast If true, the SimRunner will kill other runners and throw an exception on error
      * @param run_logs Reference to the vector to store generate run logs
      * @param log_export_queue The queue of logs to exported to disk
@@ -61,7 +61,7 @@ class SimRunner {
         std::shared_ptr<const LoggingConfig> _exit_log_config,
         int _device_id,
         unsigned int _runner_id,
-        flamegpu::verbosity _verbosity,
+        flamegpu::Verbosity _verbosity,
         bool _fail_fast,
         std::vector<RunLog> &run_logs,
         std::queue<unsigned int> &log_export_queue,
@@ -93,7 +93,7 @@ class SimRunner {
     /**
      * Flag for whether to print progress
      */
-    const flamegpu::verbosity verbosity;
+    const flamegpu::Verbosity verbosity;
     /**
      * Flag for whether the ensemble should throw an exception if it errors out
      */

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <unordered_map>
 
+#include "flamegpu/defines.h"
 #include "flamegpu/sim/AgentInterface.h"
 
 
@@ -39,7 +40,7 @@ class Simulation {
             truncate_log_files = other.truncate_log_files;
             random_seed = other.random_seed;
             steps = other.steps;
-            verbose = other.verbose;
+            verbosity = other.verbosity;
             timing = other.timing;
 #ifdef VISUALISATION
             console_mode = other.console_mode;
@@ -52,7 +53,7 @@ class Simulation {
         bool truncate_log_files = true;
         uint64_t random_seed;
         unsigned int steps = 1;
-        bool verbose = false;
+        verbosity verbosity = DEFAULT;
         bool timing = false;
 #ifdef VISUALISATION
         bool console_mode = false;

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -53,7 +53,7 @@ class Simulation {
         bool truncate_log_files = true;
         uint64_t random_seed;
         unsigned int steps = 1;
-        verbosity verbosity = DEFAULT;
+        flamegpu::verbosity verbosity = DEFAULT;
         bool timing = false;
 #ifdef VISUALISATION
         bool console_mode = false;

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -53,7 +53,7 @@ class Simulation {
         bool truncate_log_files = true;
         uint64_t random_seed;
         unsigned int steps = 1;
-        flamegpu::verbosity verbosity = DEFAULT;
+        flamegpu::Verbosity verbosity = Verbosity::Default;
         bool timing = false;
 #ifdef VISUALISATION
         bool console_mode = false;

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -180,12 +180,12 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     ensemble_elapsed_time = ensemble_timer.getElapsedSeconds();
 
     // Ensemble has finished, print summary
-    if (config.verbosity > 0) {
+    if (config.verbosity > Verbosity::Quiet) {
         printf("\rCUDAEnsemble completed %u runs successfully!\n", static_cast<unsigned int>(plans.size() - err_ct));
         if (err_ct)
             printf("There were a total of %u errors.\n", err_ct.load());
     }
-    if (config.timing || config.verbosity >= VERBOSE) {
+    if (config.timing || config.verbosity >= Verbosity::Verbose) {
         printf("Ensemble time elapsed: %fs\n", ensemble_elapsed_time);
     }
 
@@ -213,7 +213,7 @@ void CUDAEnsemble::initialise(int argc, const char** argv) {
         exit(EXIT_FAILURE);
     }
     // If verbose, output the flamegpu version and seed.
-    if (config.verbosity == VERBOSE) {
+    if (config.verbosity == Verbosity::Verbose) {
         fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
         fprintf(stdout, "Ensemble configuration:\n");
         fprintf(stdout, "\tConcurrent runs: %u\n", config.concurrent_runs);
@@ -297,12 +297,12 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
         }
         // -q/--quiet, Don't report progress to console.
         if (arg.compare("--quiet") == 0 || arg.compare("-q") == 0) {
-            config.verbosity = QUIET;
+            config.verbosity = Verbosity::Quiet;
             continue;
         }
         // -v/--verbose, Report all progress to console.
         if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
-            config.verbosity = VERBOSE;
+            config.verbosity = Verbosity::Verbose;
             continue;
         }
         // -t/--timing, Output timing information to stdout

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -214,7 +214,8 @@ void CUDAEnsemble::initialise(int argc, const char** argv) {
     }
     // If verbose, output the flamegpu version and seed.
     if (config.verbosity == VERBOSE) {
-        fprintf(stdout, "FLAME GPU %s Ensemble configuration\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "Ensemble configuration:\n");
         fprintf(stdout, "\tConcurrent runs: %u\n", config.concurrent_runs);
     }
 }
@@ -354,8 +355,8 @@ void CUDAEnsemble::printHelp(const char *executable) {
     printf(line_fmt, "-c, --concurrent <runs>", "Number of concurrent simulations to run per device");
     printf(line_fmt, "", "By default, 4 will be used.");
     printf(line_fmt, "-o, --out <directory> <filetype>", "Directory and filetype for ensemble outputs");
-    printf(line_fmt, "-q, --quiet", "Don't print information to console");
-    printf(line_fmt, "-v, --verbose", "Print addititional information to console");
+    printf(line_fmt, "-q, --quiet", "Do not print progress information to console");
+    printf(line_fmt, "-v, --verbose", "Print config, progress and timing (-t) information to console");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
     printf(line_fmt, "-e, --error <error level>", "The error level 0, 1, 2, off, slow or fast");
 #ifdef _MSC_VER

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -145,7 +145,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
                 new (&runners[i++]) SimRunner(model, err_ct, next_run, plans,
                     step_log_config, exit_log_config,
                     d, j,
-                    !config.quiet, config.error_level == EnsembleConfig::Fast,
+                    config.verbosity, config.error_level == EnsembleConfig::Fast,
                     run_logs, log_export_queue, log_export_queue_mutex, log_export_queue_cdn, fast_err_detail, TOTAL_RUNNERS);
             }
         }
@@ -180,7 +180,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
     ensemble_elapsed_time = ensemble_timer.getElapsedSeconds();
 
     // Ensemble has finished, print summary
-    if (!config.quiet) {
+    if (config.verbosity > 0) {
         printf("\rCUDAEnsemble completed %u runs successfully!\n", static_cast<unsigned int>(plans.size() - err_ct));
         if (err_ct)
             printf("There were a total of %u errors.\n", err_ct.load());
@@ -297,7 +297,12 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
         }
         // -q/--quiet, Don't report progress to console.
         if (arg.compare("--quiet") == 0 || arg.compare("-q") == 0) {
-            config.quiet = true;
+            config.verbosity = QUIET;
+            continue;
+        }
+        // -v/--verbose, Report all progress to console.
+        if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
+            config.verbosity = VERBOSE;
             continue;
         }
         // -t/--timing, Output timing information to stdout

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -185,7 +185,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
         if (err_ct)
             printf("There were a total of %u errors.\n", err_ct.load());
     }
-    if (config.timing) {
+    if (config.timing || config.verbosity >= VERBOSE) {
         printf("Ensemble time elapsed: %fs\n", ensemble_elapsed_time);
     }
 
@@ -212,12 +212,11 @@ void CUDAEnsemble::initialise(int argc, const char** argv) {
     if (!checkArgs(argc, argv)) {
         exit(EXIT_FAILURE);
     }
-    /* Disabled as this is printed prior to quiet being accessible 
-    // If verbsoe, output the flamegpu version.
-    if (!config.quiet) {
-        fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
+    // If verbose, output the flamegpu version and seed.
+    if (config.verbosity == VERBOSE) {
+        fprintf(stdout, "FLAME GPU %s Ensemble configuration\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "\tConcurrent runs: %u\n", config.concurrent_runs);
     }
-    */
 }
 int CUDAEnsemble::checkArgs(int argc, const char** argv) {
     // Parse optional args
@@ -355,7 +354,8 @@ void CUDAEnsemble::printHelp(const char *executable) {
     printf(line_fmt, "-c, --concurrent <runs>", "Number of concurrent simulations to run per device");
     printf(line_fmt, "", "By default, 4 will be used.");
     printf(line_fmt, "-o, --out <directory> <filetype>", "Directory and filetype for ensemble outputs");
-    printf(line_fmt, "-q, --quiet", "Don't print progress information to console");
+    printf(line_fmt, "-q, --quiet", "Don't print information to console");
+    printf(line_fmt, "-v, --verbose", "Print addititional information to console");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
     printf(line_fmt, "-e, --error <error level>", "The error level 0, 1, 2, off, slow or fast");
 #ifdef _MSC_VER

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -166,7 +166,7 @@ CUDASimulation::CUDASimulation(const std::shared_ptr<SubModelData> &submodel_des
         submodel_map.emplace(it_sm->first, std::unique_ptr<CUDASimulation>(new CUDASimulation(it_sm->second, this)));
     }
     // Submodels all run quiet/not verbose by default
-    SimulationConfig().verbosity = DEFAULT;
+    SimulationConfig().verbosity = Verbosity::Default;
     SimulationConfig().steps = submodel_desc->max_steps;
     CUDAConfig().is_ensemble = true;
 
@@ -235,7 +235,7 @@ void CUDASimulation::initFunctions() {
     // Record, store and output the elapsed time of the step.
     initFunctionsTimer->stop();
     this->elapsedSecondsInitFunctions = initFunctionsTimer->getElapsedSeconds();
-    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= Verbosity::Verbose) {
         fprintf(stdout, "Init Function Processing time: %.6f s\n", this->elapsedSecondsInitFunctions);
     }
 }
@@ -257,7 +257,7 @@ void CUDASimulation::exitFunctions() {
     // Record, store and output the elapsed time of the step.
     exitFunctionsTimer->stop();
     this->elapsedSecondsExitFunctions = exitFunctionsTimer->getElapsedSeconds();
-    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= Verbosity::Verbose) {
         fprintf(stdout, "Exit Function Processing time: %.6f s\n", this->elapsedSecondsExitFunctions);
     }
 }
@@ -525,7 +525,7 @@ bool CUDASimulation::step() {
     this->assignAgentIDs();
 
     // If verbose, print the step number.
-    if (getSimulationConfig().verbosity == VERBOSE) {
+    if (getSimulationConfig().verbosity == Verbosity::Verbose) {
         fprintf(stdout, "Processing Simulation Step %u\n", step_count);
     }
 
@@ -559,7 +559,7 @@ bool CUDASimulation::step() {
     stepTimer->stop();
     float stepMilliseconds = stepTimer->getElapsedSeconds();
     this->elapsedSecondsPerStep.push_back(stepMilliseconds);
-    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= Verbosity::Verbose) {
         // Resolution is 0.5 microseconds, so print to 1 us.
         fprintf(stdout, "Step %d Processing time: %.6f s\n", this->step_count, stepMilliseconds);
     }
@@ -1218,7 +1218,7 @@ void CUDASimulation::simulate() {
     // Record, store and output the elapsed simulation time
     simulationTimer->stop();
     elapsedSecondsSimulation = simulationTimer->getElapsedSeconds();
-    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= Verbosity::Verbose) {
         // Resolution is 0.5 microseconds, so print to 1 us.
         fprintf(stdout, "Total Processing time: %.6f s\n", elapsedSecondsSimulation);
     }

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -235,7 +235,7 @@ void CUDASimulation::initFunctions() {
     // Record, store and output the elapsed time of the step.
     initFunctionsTimer->stop();
     this->elapsedSecondsInitFunctions = initFunctionsTimer->getElapsedSeconds();
-    if (getSimulationConfig().timing) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
         fprintf(stdout, "Init Function Processing time: %.6f s\n", this->elapsedSecondsInitFunctions);
     }
 }
@@ -257,7 +257,7 @@ void CUDASimulation::exitFunctions() {
     // Record, store and output the elapsed time of the step.
     exitFunctionsTimer->stop();
     this->elapsedSecondsExitFunctions = exitFunctionsTimer->getElapsedSeconds();
-    if (getSimulationConfig().timing) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
         fprintf(stdout, "Exit Function Processing time: %.6f s\n", this->elapsedSecondsExitFunctions);
     }
 }
@@ -559,7 +559,7 @@ bool CUDASimulation::step() {
     stepTimer->stop();
     float stepMilliseconds = stepTimer->getElapsedSeconds();
     this->elapsedSecondsPerStep.push_back(stepMilliseconds);
-    if (getSimulationConfig().timing) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
         // Resolution is 0.5 microseconds, so print to 1 us.
         fprintf(stdout, "Step %d Processing time: %.6f s\n", this->step_count, stepMilliseconds);
     }
@@ -1218,7 +1218,7 @@ void CUDASimulation::simulate() {
     // Record, store and output the elapsed simulation time
     simulationTimer->stop();
     elapsedSecondsSimulation = simulationTimer->getElapsedSeconds();
-    if (getSimulationConfig().timing) {
+    if (getSimulationConfig().timing || getSimulationConfig().verbosity >= VERBOSE) {
         // Resolution is 0.5 microseconds, so print to 1 us.
         fprintf(stdout, "Total Processing time: %.6f s\n", elapsedSecondsSimulation);
     }

--- a/src/flamegpu/gpu/CUDASimulation.cu
+++ b/src/flamegpu/gpu/CUDASimulation.cu
@@ -166,7 +166,7 @@ CUDASimulation::CUDASimulation(const std::shared_ptr<SubModelData> &submodel_des
         submodel_map.emplace(it_sm->first, std::unique_ptr<CUDASimulation>(new CUDASimulation(it_sm->second, this)));
     }
     // Submodels all run quiet/not verbose by default
-    SimulationConfig().verbose = false;
+    SimulationConfig().verbosity = DEFAULT;
     SimulationConfig().steps = submodel_desc->max_steps;
     CUDAConfig().is_ensemble = true;
 
@@ -525,7 +525,7 @@ bool CUDASimulation::step() {
     this->assignAgentIDs();
 
     // If verbose, print the step number.
-    if (getSimulationConfig().verbose) {
+    if (getSimulationConfig().verbosity == VERBOSE) {
         fprintf(stdout, "Processing Simulation Step %u\n", step_count);
     }
 

--- a/src/flamegpu/io/JSONStateReader.cpp
+++ b/src/flamegpu/io/JSONStateReader.cpp
@@ -350,7 +350,8 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
             if (sim_instance) {
                 if (lastKey == "input_file") {
                     if (filename != str && str[0] != '\0')
-                        printf("Warning: Input file '%s' refers to second input file '%s', this will not be loaded.\n", filename.c_str(), str);
+                        if (sim_instance->getSimulationConfig().verbosity > 0)
+                            fprintf(stderr, "Warning: Input file '%s' refers to second input file '%s', this will not be loaded.\n", filename.c_str(), str);
                     // sim_instance->SimulationConfig().input_file = str;
                 } else if (lastKey == "step_log_file") {
                     sim_instance->SimulationConfig().step_log_file = str;

--- a/src/flamegpu/io/JSONStateReader.cpp
+++ b/src/flamegpu/io/JSONStateReader.cpp
@@ -306,7 +306,7 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
                 } else if (lastKey == "timing") {
                     sim_instance->SimulationConfig().timing = static_cast<bool>(val);
                 } else if (lastKey == "verbosity") {
-                    sim_instance->SimulationConfig().verbosity = static_cast<flamegpu::verbosity>(val);
+                    sim_instance->SimulationConfig().verbosity = static_cast<flamegpu::Verbosity>(val);
                 } else if (lastKey == "console_mode") {
 #ifdef VISUALISATION
                     sim_instance->SimulationConfig().console_mode = static_cast<bool>(val);
@@ -350,7 +350,7 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
             if (sim_instance) {
                 if (lastKey == "input_file") {
                     if (filename != str && str[0] != '\0')
-                        if (sim_instance->getSimulationConfig().verbosity > 0)
+                        if (sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet)
                             fprintf(stderr, "Warning: Input file '%s' refers to second input file '%s', this will not be loaded.\n", filename.c_str(), str);
                     // sim_instance->SimulationConfig().input_file = str;
                 } else if (lastKey == "step_log_file") {

--- a/src/flamegpu/io/JSONStateReader.cpp
+++ b/src/flamegpu/io/JSONStateReader.cpp
@@ -305,8 +305,8 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
                     sim_instance->SimulationConfig().steps = static_cast<unsigned int>(val);
                 } else if (lastKey == "timing") {
                     sim_instance->SimulationConfig().timing = static_cast<bool>(val);
-                } else if (lastKey == "verbose") {
-                    sim_instance->SimulationConfig().verbose = static_cast<bool>(val);
+                } else if (lastKey == "verbosity") {
+                    sim_instance->SimulationConfig().verbosity = static_cast<flamegpu::verbosity>(val);
                 } else if (lastKey == "console_mode") {
 #ifdef VISUALISATION
                     sim_instance->SimulationConfig().console_mode = static_cast<bool>(val);

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -63,7 +63,7 @@ void JSONStateWriter::doWrite(T &writer) {
                 writer.Uint(sim_cfg.steps);
                 // Verbose output
                 writer.Key("verbosity");
-                writer.Uint(sim_cfg.verbosity);
+                writer.Uint(static_cast<unsigned int>(sim_cfg.verbosity));
                 // Timing Output
                 writer.Key("timing");
                 writer.Bool(sim_cfg.timing);

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -62,8 +62,8 @@ void JSONStateWriter::doWrite(T &writer) {
                 writer.Key("steps");
                 writer.Uint(sim_cfg.steps);
                 // Verbose output
-                writer.Key("verbose");
-                writer.Bool(sim_cfg.verbose);
+                writer.Key("verbosity");
+                writer.Uint(sim_cfg.verbosity);
                 // Timing Output
                 writer.Key("timing");
                 writer.Bool(sim_cfg.timing);

--- a/src/flamegpu/io/XMLStateReader.cpp
+++ b/src/flamegpu/io/XMLStateReader.cpp
@@ -127,16 +127,8 @@ int XMLStateReader::parse() {
                     sim_instance->SimulationConfig().random_seed = static_cast<uint64_t>(stoull(val));
                 } else if (key == "steps") {
                     sim_instance->SimulationConfig().steps = static_cast<unsigned int>(stoull(val));
-                } else if (key == "verbose") {
-                    for (auto& c : val)
-                        c = static_cast<char>(::tolower(c));
-                    if (val == "true") {
-                        sim_instance->SimulationConfig().verbose = true;
-                    } else if (val == "false") {
-                        sim_instance->SimulationConfig().verbose = false;
-                    } else {
-                        sim_instance->SimulationConfig().verbose = static_cast<bool>(stoll(val));
-                    }
+                } else if (key == "verbosity") {
+                    sim_instance->SimulationConfig().verbosity = static_cast<flamegpu::verbosity>(stoull(val));
                 } else if (key == "timing") {
                     for (auto& c : val)
                         c = static_cast<char>(::tolower(c));

--- a/src/flamegpu/io/XMLStateReader.cpp
+++ b/src/flamegpu/io/XMLStateReader.cpp
@@ -105,7 +105,8 @@ int XMLStateReader::parse() {
                 std::string val = simCfgElement->GetText() ? simCfgElement->GetText() : "";
                 if (key == "input_file") {
                     if (inputFile != val && !val.empty())
-                        printf("Warning: Input file '%s' refers to second input file '%s', this will not be loaded.\n", inputFile.c_str(), val.c_str());
+                        if (sim_instance->getSimulationConfig().verbosity > QUIET)
+                            fprintf(stderr, "Warning: Input file '%s' refers to second input file '%s', this will not be loaded.\n", inputFile.c_str(), val.c_str());
                     // sim_instance->SimulationConfig().input_file = val;
                 } else if (key == "step_log_file") {
                     sim_instance->SimulationConfig().step_log_file = val;
@@ -152,10 +153,11 @@ int XMLStateReader::parse() {
                     }
 #else
                     if (val == "false") {
-                        fprintf(stderr, "Warning: Cannot disable 'console_mode' with input file '%s', FLAMEGPU2 library has not been built with visualisation support enabled.\n", inputFile.c_str());
+                        if (sim_instance->getSimulationConfig().verbosity > QUIET)
+                            fprintf(stderr, "Warning: Cannot disable 'console_mode' with input file '%s', FLAMEGPU2 library has not been built with visualisation support enabled.\n", inputFile.c_str());
                     }
 #endif
-                }  else {
+                }  else if (sim_instance->getSimulationConfig().verbosity > QUIET) {
                     fprintf(stderr, "Warning: Input file '%s' contains unexpected simulation config property '%s'.\n", inputFile.c_str(), key.c_str());
                 }
             }
@@ -179,7 +181,7 @@ int XMLStateReader::parse() {
                     } else {
                         cudamodel_instance->CUDAConfig().inLayerConcurrency = static_cast<bool>(stoll(val));
                     }
-                } else {
+                } else if (sim_instance->getSimulationConfig().verbosity > QUIET) {
                     fprintf(stderr, "Warning: Input file '%s' contains unexpected cuda config property '%s'.\n", inputFile.c_str(), key.c_str());
                 }
             }
@@ -239,12 +241,12 @@ int XMLStateReader::parse() {
                         "in XMLStateReader::parse()\n", key, val_type.name());
                 }
             }
-            if (el != elements) {
+            if (el != elements && sim_instance->getSimulationConfig().verbosity > QUIET) {
                 fprintf(stderr, "Warning: Environment array property '%s' expects '%u' elements, input file '%s' contains '%u' elements.\n",
                     key, elements, inputFile.c_str(), el);
             }
         }
-    } else {
+    } else if (sim_instance->getSimulationConfig().verbosity > QUIET) {
         fprintf(stderr, "Warning: Input file '%s' does not contain environment node.\n", inputFile.c_str());
     }
 
@@ -333,12 +335,12 @@ int XMLStateReader::parse() {
                     }
                 }
                 // Warn if var is wrong length
-                if (el != var_data.elements && !hasWarnedElements) {
+                if (el != var_data.elements && !hasWarnedElements && sim_instance->getSimulationConfig().verbosity > QUIET) {
                     fprintf(stderr, "Warning: Agent '%s' variable '%s' expects '%u' elements, input file '%s' contains '%u' elements.\n",
                         agentName, variable_name.c_str(), var_data.elements, inputFile.c_str(), el);
                     hasWarnedElements = true;
                 }
-            } else if (!hasWarnedMissingVar && variable_name.find('_', 0) != 0) {
+            } else if (!hasWarnedMissingVar && variable_name.find('_', 0) != 0 && sim_instance->getSimulationConfig().verbosity > QUIET) {
                 fprintf(stderr, "Warning: Agent '%s' variable '%s' is missing from, input file '%s'.\n",
                     agentName, variable_name.c_str(), inputFile.c_str());
                 hasWarnedMissingVar = true;

--- a/src/flamegpu/io/XMLStateReader.cpp
+++ b/src/flamegpu/io/XMLStateReader.cpp
@@ -105,7 +105,7 @@ int XMLStateReader::parse() {
                 std::string val = simCfgElement->GetText() ? simCfgElement->GetText() : "";
                 if (key == "input_file") {
                     if (inputFile != val && !val.empty())
-                        if (sim_instance->getSimulationConfig().verbosity > QUIET)
+                        if (sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet)
                             fprintf(stderr, "Warning: Input file '%s' refers to second input file '%s', this will not be loaded.\n", inputFile.c_str(), val.c_str());
                     // sim_instance->SimulationConfig().input_file = val;
                 } else if (key == "step_log_file") {
@@ -129,7 +129,7 @@ int XMLStateReader::parse() {
                 } else if (key == "steps") {
                     sim_instance->SimulationConfig().steps = static_cast<unsigned int>(stoull(val));
                 } else if (key == "verbosity") {
-                    sim_instance->SimulationConfig().verbosity = static_cast<flamegpu::verbosity>(stoull(val));
+                    sim_instance->SimulationConfig().verbosity = static_cast<flamegpu::Verbosity>(stoull(val));
                 } else if (key == "timing") {
                     for (auto& c : val)
                         c = static_cast<char>(::tolower(c));
@@ -153,11 +153,11 @@ int XMLStateReader::parse() {
                     }
 #else
                     if (val == "false") {
-                        if (sim_instance->getSimulationConfig().verbosity > QUIET)
+                        if (sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet)
                             fprintf(stderr, "Warning: Cannot disable 'console_mode' with input file '%s', FLAMEGPU2 library has not been built with visualisation support enabled.\n", inputFile.c_str());
                     }
 #endif
-                }  else if (sim_instance->getSimulationConfig().verbosity > QUIET) {
+                }  else if (sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet) {
                     fprintf(stderr, "Warning: Input file '%s' contains unexpected simulation config property '%s'.\n", inputFile.c_str(), key.c_str());
                 }
             }
@@ -181,7 +181,7 @@ int XMLStateReader::parse() {
                     } else {
                         cudamodel_instance->CUDAConfig().inLayerConcurrency = static_cast<bool>(stoll(val));
                     }
-                } else if (sim_instance->getSimulationConfig().verbosity > QUIET) {
+                } else if (sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet) {
                     fprintf(stderr, "Warning: Input file '%s' contains unexpected cuda config property '%s'.\n", inputFile.c_str(), key.c_str());
                 }
             }
@@ -241,12 +241,12 @@ int XMLStateReader::parse() {
                         "in XMLStateReader::parse()\n", key, val_type.name());
                 }
             }
-            if (el != elements && sim_instance->getSimulationConfig().verbosity > QUIET) {
+            if (el != elements && sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet) {
                 fprintf(stderr, "Warning: Environment array property '%s' expects '%u' elements, input file '%s' contains '%u' elements.\n",
                     key, elements, inputFile.c_str(), el);
             }
         }
-    } else if (sim_instance->getSimulationConfig().verbosity > QUIET) {
+    } else if (sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet) {
         fprintf(stderr, "Warning: Input file '%s' does not contain environment node.\n", inputFile.c_str());
     }
 
@@ -335,12 +335,12 @@ int XMLStateReader::parse() {
                     }
                 }
                 // Warn if var is wrong length
-                if (el != var_data.elements && !hasWarnedElements && sim_instance->getSimulationConfig().verbosity > QUIET) {
+                if (el != var_data.elements && !hasWarnedElements && sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet) {
                     fprintf(stderr, "Warning: Agent '%s' variable '%s' expects '%u' elements, input file '%s' contains '%u' elements.\n",
                         agentName, variable_name.c_str(), var_data.elements, inputFile.c_str(), el);
                     hasWarnedElements = true;
                 }
-            } else if (!hasWarnedMissingVar && variable_name.find('_', 0) != 0 && sim_instance->getSimulationConfig().verbosity > QUIET) {
+            } else if (!hasWarnedMissingVar && variable_name.find('_', 0) != 0 && sim_instance->getSimulationConfig().verbosity > Verbosity::Quiet) {
                 fprintf(stderr, "Warning: Agent '%s' variable '%s' is missing from, input file '%s'.\n",
                     agentName, variable_name.c_str(), inputFile.c_str());
                 hasWarnedMissingVar = true;

--- a/src/flamegpu/io/XMLStateWriter.cpp
+++ b/src/flamegpu/io/XMLStateWriter.cpp
@@ -118,8 +118,8 @@ int XMLStateWriter::writeStates(bool prettyPrint) {
             pListElement->SetText(sim_cfg.steps);
             pSimCfg->InsertEndChild(pListElement);
             // Verbose output
-            pListElement = doc.NewElement("verbose");
-            pListElement->SetText(sim_cfg.verbose);
+            pListElement = doc.NewElement("verbosity");
+            pListElement->SetText(sim_cfg.verbosity);
             pSimCfg->InsertEndChild(pListElement);
             // Timing Output
             pListElement = doc.NewElement("timing");

--- a/src/flamegpu/io/XMLStateWriter.cpp
+++ b/src/flamegpu/io/XMLStateWriter.cpp
@@ -119,7 +119,7 @@ int XMLStateWriter::writeStates(bool prettyPrint) {
             pSimCfg->InsertEndChild(pListElement);
             // Verbose output
             pListElement = doc.NewElement("verbosity");
-            pListElement->SetText(sim_cfg.verbosity);
+            pListElement->SetText(static_cast<unsigned int>(sim_cfg.verbosity));
             pSimCfg->InsertEndChild(pListElement);
             // Timing Output
             pListElement = doc.NewElement("timing");

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -22,7 +22,7 @@ SimRunner::SimRunner(const std::shared_ptr<const ModelData> _model,
     std::shared_ptr<const LoggingConfig> _exit_log_config,
     int _device_id,
     unsigned int _runner_id,
-    bool _verbose,
+    flamegpu::verbosity _verbosity,
     bool _fail_fast,
     std::vector<RunLog> &_run_logs,
     std::queue<unsigned int> &_log_export_queue,
@@ -35,7 +35,7 @@ SimRunner::SimRunner(const std::shared_ptr<const ModelData> _model,
       , device_id(_device_id)
       , runner_id(_runner_id)
       , total_runners(_total_runners)
-      , verbose(_verbose)
+      , verbosity(_verbosity)
       , fail_fast(_fail_fast)
       , err_ct(_err_ct)
       , next_run(_next_run)
@@ -84,7 +84,7 @@ void SimRunner::start() {
             // Copy steps and seed from runplan
             simulation->SimulationConfig().steps = plans[run_id].getSteps();
             simulation->SimulationConfig().random_seed = plans[run_id].getRandomSimulationSeed();
-            simulation->SimulationConfig().verbose = false;
+            simulation->SimulationConfig().verbosity = DEFAULT;
             simulation->SimulationConfig().timing = false;
             simulation->CUDAConfig().device_id = this->device_id;
             simulation->CUDAConfig().is_ensemble = true;
@@ -104,7 +104,7 @@ void SimRunner::start() {
             }
             log_export_queue_cdn.notify_one();
             // Print progress to console
-            if (verbose) {
+            if (verbosity == VERBOSE) {
                 const int progress = static_cast<int>(next_run.load()) - static_cast<int>(total_runners) + 1;
                 fprintf(stdout, "\rCUDAEnsemble progress: %d/%u", progress < 1 ? 1 : progress, static_cast<unsigned int>(plans.size()));
                 fflush(stdout);
@@ -125,7 +125,7 @@ void SimRunner::start() {
                 }
                 return;
             } else {
-                if (verbose) {
+                if (verbosity == VERBOSE) {
                     fprintf(stdout, "\n");
                     fflush(stdout);
                 }

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -85,6 +85,8 @@ void SimRunner::start() {
             simulation->SimulationConfig().steps = plans[run_id].getSteps();
             simulation->SimulationConfig().random_seed = plans[run_id].getRandomSimulationSeed();
             simulation->SimulationConfig().verbosity = DEFAULT;
+            if (verbosity == QUIET)  // Use quiet verbosity for sims if set in ensemble but never verbose
+                simulation->SimulationConfig().verbosity = QUIET;
             simulation->SimulationConfig().timing = false;
             simulation->CUDAConfig().device_id = this->device_id;
             simulation->CUDAConfig().is_ensemble = true;
@@ -125,11 +127,13 @@ void SimRunner::start() {
                 }
                 return;
             } else {
+                // Progress flush
                 if (verbosity == VERBOSE) {
                     fprintf(stdout, "\n");
                     fflush(stdout);
                 }
-                fprintf(stderr, "Run %u failed on device %d, thread %u with exception: \n%s\n", run_id, device_id, runner_id, e.what());
+                if (verbosity > QUIET)
+                    fprintf(stderr, "Warning: Run %u failed on device %d, thread %u with exception: \n%s\n", run_id, device_id, runner_id, e.what());
             }
         }
     }

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -22,7 +22,7 @@ SimRunner::SimRunner(const std::shared_ptr<const ModelData> _model,
     std::shared_ptr<const LoggingConfig> _exit_log_config,
     int _device_id,
     unsigned int _runner_id,
-    flamegpu::verbosity _verbosity,
+    flamegpu::Verbosity _verbosity,
     bool _fail_fast,
     std::vector<RunLog> &_run_logs,
     std::queue<unsigned int> &_log_export_queue,
@@ -84,9 +84,9 @@ void SimRunner::start() {
             // Copy steps and seed from runplan
             simulation->SimulationConfig().steps = plans[run_id].getSteps();
             simulation->SimulationConfig().random_seed = plans[run_id].getRandomSimulationSeed();
-            simulation->SimulationConfig().verbosity = DEFAULT;
-            if (verbosity == QUIET)  // Use quiet verbosity for sims if set in ensemble but never verbose
-                simulation->SimulationConfig().verbosity = QUIET;
+            simulation->SimulationConfig().verbosity = Verbosity::Default;
+            if (verbosity == Verbosity::Quiet)  // Use quiet verbosity for sims if set in ensemble but never verbose
+                simulation->SimulationConfig().verbosity = Verbosity::Quiet;
             simulation->SimulationConfig().timing = false;
             simulation->CUDAConfig().device_id = this->device_id;
             simulation->CUDAConfig().is_ensemble = true;
@@ -106,7 +106,7 @@ void SimRunner::start() {
             }
             log_export_queue_cdn.notify_one();
             // Print progress to console
-            if (verbosity >= DEFAULT) {
+            if (verbosity >= Verbosity::Default) {
                 const int progress = static_cast<int>(next_run.load()) - static_cast<int>(total_runners) + 1;
                 fprintf(stdout, "\rCUDAEnsemble progress: %d/%u", progress < 1 ? 1 : progress, static_cast<unsigned int>(plans.size()));
                 fflush(stdout);
@@ -128,11 +128,11 @@ void SimRunner::start() {
                 return;
             } else {
                 // Progress flush
-                if (verbosity >= DEFAULT) {
+                if (verbosity >= Verbosity::Default) {
                     fprintf(stdout, "\n");
                     fflush(stdout);
                 }
-                if (verbosity > QUIET)
+                if (verbosity > Verbosity::Quiet)
                     fprintf(stderr, "Warning: Run %u failed on device %d, thread %u with exception: \n%s\n", run_id, device_id, runner_id, e.what());
             }
         }

--- a/src/flamegpu/sim/SimRunner.cu
+++ b/src/flamegpu/sim/SimRunner.cu
@@ -106,7 +106,7 @@ void SimRunner::start() {
             }
             log_export_queue_cdn.notify_one();
             // Print progress to console
-            if (verbosity == VERBOSE) {
+            if (verbosity >= DEFAULT) {
                 const int progress = static_cast<int>(next_run.load()) - static_cast<int>(total_runners) + 1;
                 fprintf(stdout, "\rCUDAEnsemble progress: %d/%u", progress < 1 ? 1 : progress, static_cast<unsigned int>(plans.size()));
                 fflush(stdout);
@@ -128,7 +128,7 @@ void SimRunner::start() {
                 return;
             } else {
                 // Progress flush
-                if (verbosity == VERBOSE) {
+                if (verbosity >= DEFAULT) {
                     fprintf(stdout, "\n");
                     fflush(stdout);
                 }

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -103,7 +103,7 @@ void Simulation::applyConfig() {
         }
     }
     // If verbose, output the flamegpu version.
-    if (config.verbose) {
+    if (config.verbosity == VERBOSE) {
         fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
     }
     // Call derived class config stuff first
@@ -232,7 +232,12 @@ int Simulation::checkArgs(int argc, const char** argv) {
         }
         // -v/--verbose, Verbose FLAME GPU output.
         if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
-            config.verbose = true;
+            config.verbosity = VERBOSE;
+            continue;
+        }
+        // -q/--quiet, Verbose level quiet FLAME GPU output.
+        if (arg.compare("--quiet") == 0 || arg.compare("-q") == 0) {
+            config.verbosity = QUIET;
             continue;
         }
         // -t/--timing, Output timing information to stdout

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -105,7 +105,8 @@ void Simulation::applyConfig() {
     }
     // If verbose, output the flamegpu version and seed.
     if (config.verbosity == VERBOSE) {
-        fprintf(stdout, "FLAME GPU %s Simulation configuration\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "Simulation configuration:\n");
         fprintf(stdout, "\tRandom Seed: %" PRIu64 "\n", config.random_seed);
         fprintf(stdout, "\tSteps: %u\n", config.steps);
     }
@@ -306,7 +307,8 @@ void Simulation::printHelp(const char* executable) {
     printf(line_fmt, "    --out-log <file.xml/file.json>", "Common log file (XML or JSON)");
     printf(line_fmt, "-s, --steps <steps>", "Number of simulation iterations");
     printf(line_fmt, "-r, --random <seed>", "RandomManager seed");
-    printf(line_fmt, "-v, --verbose", "Verbose FLAME GPU output");
+    printf(line_fmt, "-q, --quiet", "Do not print progress information to console");
+    printf(line_fmt, "-v, --verbose", "Print config, progress and timing (-t) information to console.");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
 #ifdef VISUALISATION
     printf(line_fmt, "-c, --console", "Console mode, disable the visualisation");

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -104,7 +104,7 @@ void Simulation::applyConfig() {
         }
     }
     // If verbose, output the flamegpu version and seed.
-    if (config.verbosity == VERBOSE) {
+    if (config.verbosity == Verbosity::Verbose) {
         fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
         fprintf(stdout, "Simulation configuration:\n");
         fprintf(stdout, "\tRandom Seed: %" PRIu64 "\n", config.random_seed);
@@ -237,12 +237,12 @@ int Simulation::checkArgs(int argc, const char** argv) {
         }
         // -v/--verbose, Verbose FLAME GPU output.
         if (arg.compare("--verbose") == 0 || arg.compare("-v") == 0) {
-            config.verbosity = VERBOSE;
+            config.verbosity = Verbosity::Verbose;
             continue;
         }
         // -q/--quiet, Verbose level quiet FLAME GPU output.
         if (arg.compare("--quiet") == 0 || arg.compare("-q") == 0) {
-            config.verbosity = QUIET;
+            config.verbosity = Verbosity::Quiet;
             continue;
         }
         // -t/--timing, Output timing information to stdout

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cinttypes>  // For PRIu64
 
 #include "flamegpu/version.h"
 #include "flamegpu/model/ModelData.h"
@@ -105,7 +106,7 @@ void Simulation::applyConfig() {
     // If verbose, output the flamegpu version and seed.
     if (config.verbosity == VERBOSE) {
         fprintf(stdout, "FLAME GPU %s Simulation configuration\n", flamegpu::VERSION_FULL);
-        fprintf(stdout, "\tRandom Seed: %llu\n", config.random_seed);
+        fprintf(stdout, "\tRandom Seed: %" PRIu64 "\n", config.random_seed);
         fprintf(stdout, "\tSteps: %u\n", config.steps);
     }
     // Call derived class config stuff first

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -102,9 +102,11 @@ void Simulation::applyConfig() {
             THROW exception::InvalidArgument("Failed to create common log file directory: '%s': %s\n", t_path.c_str(), e.what());
         }
     }
-    // If verbose, output the flamegpu version.
+    // If verbose, output the flamegpu version and seed.
     if (config.verbosity == VERBOSE) {
-        fprintf(stdout, "FLAME GPU %s\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "FLAME GPU %s Simulation configuration\n", flamegpu::VERSION_FULL);
+        fprintf(stdout, "\tRandom Seed: %llu\n", config.random_seed);
+        fprintf(stdout, "\tSteps: %u\n", config.steps);
     }
     // Call derived class config stuff first
     applyConfig_derived();
@@ -148,6 +150,7 @@ int Simulation::checkArgs(int argc, const char** argv) {
 
     // First pass only looks for and handles input files
     // Remaining arguments can override args passed via input file
+    // Any errors to stderr have return false and are expected to raise an exception
     int i = 1;
     for (; i < argc; i++) {
         // Get arg as lowercase

--- a/tests/swig/python/gpu/test_cuda_ensemble.py
+++ b/tests/swig/python/gpu/test_cuda_ensemble.py
@@ -2,7 +2,7 @@ import pytest
 from unittest import TestCase
 from pyflamegpu import *
 from random import randint
-import time
+import time, sys
 
 
 # Global vars needed in several classes
@@ -103,21 +103,21 @@ class TestCUDAEnsemble(TestCase):
         assert mutableConfig.out_format == "json"
         assert mutableConfig.concurrent_runs == 4
         # assert mutableConfig.devices == std::set<int>()  # @todo - this will need to change
-        assert mutableConfig.quiet == False
+        assert mutableConfig.verbosity == pyflamegpu.DEFAULT
         assert mutableConfig.timing == False
         # Mutate the configuration
         mutableConfig.out_directory = "test"
         mutableConfig.out_format = "xml"
         mutableConfig.concurrent_runs = 1
         # mutableConfig.devices = std::set<int>({0}) # @todo - this will need to change.
-        mutableConfig.quiet = True
+        mutableConfig.verbosity = pyflamegpu.VERBOSE
         mutableConfig.timing = True
         # Check via the const ref, this should show the same value as config was a reference, not a copy.
         assert mutableConfig.out_directory == "test"
         assert mutableConfig.out_format == "xml"
         assert mutableConfig.concurrent_runs == 1
         # assert mutableConfig.devices == std::set<int>({0})  # @todo - this will need to change
-        assert mutableConfig.quiet == True
+        assert mutableConfig.verbosity == pyflamegpu.VERBOSE
         assert mutableConfig.timing == True
 
     @pytest.mark.skip(reason="--help cannot be tested due to exit()")
@@ -172,10 +172,29 @@ class TestCUDAEnsemble(TestCase):
         # Create an ensemble
         ensemble = pyflamegpu.CUDAEnsemble(model)
         # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
-        assert ensemble.Config().quiet == False
+        assert ensemble.Config().verbosity == pyflamegpu.DEFAULT
         argv = ["ensemble.exe", "--quiet"]
         ensemble.initialise(argv)
-        assert ensemble.Config().quiet == True
+        assert ensemble.Config().verbosity == pyflamegpu.QUIET
+    
+    def test_initialise_default(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().verbosity == pyflamegpu.DEFAULT
+
+    def test_initialise_verbose(self):
+        # Create a model
+        model = pyflamegpu.ModelDescription("test")
+        # Create an ensemble
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+        assert ensemble.Config().verbosity == pyflamegpu.DEFAULT
+        argv = ["ensemble.exe", "--verbose"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().verbosity == pyflamegpu.VERBOSE
 
     def test_initialise_timing(self):
         # Create a model
@@ -251,8 +270,7 @@ class TestCUDAEnsemble(TestCase):
         # Create an ensemble
         ensemble = pyflamegpu.CUDAEnsemble(model)
         # Make it quiet to avoid outputting during the test suite
-        ensemble.Config().quiet = True
-        ensemble.Config().out_format = ""  # Suppress warning
+        ensemble.Config().verbosity = pyflamegpu.QUIET
         # Simulate the ensemble,
         ensemble.simulate(plans)
 

--- a/tests/swig/python/gpu/test_cuda_ensemble.py
+++ b/tests/swig/python/gpu/test_cuda_ensemble.py
@@ -103,21 +103,21 @@ class TestCUDAEnsemble(TestCase):
         assert mutableConfig.out_format == "json"
         assert mutableConfig.concurrent_runs == 4
         # assert mutableConfig.devices == std::set<int>()  # @todo - this will need to change
-        assert mutableConfig.verbosity == pyflamegpu.DEFAULT
+        assert mutableConfig.verbosity == pyflamegpu.Verbosity_Default
         assert mutableConfig.timing == False
         # Mutate the configuration
         mutableConfig.out_directory = "test"
         mutableConfig.out_format = "xml"
         mutableConfig.concurrent_runs = 1
         # mutableConfig.devices = std::set<int>({0}) # @todo - this will need to change.
-        mutableConfig.verbosity = pyflamegpu.VERBOSE
+        mutableConfig.verbosity = pyflamegpu.Verbosity_Verbose
         mutableConfig.timing = True
         # Check via the const ref, this should show the same value as config was a reference, not a copy.
         assert mutableConfig.out_directory == "test"
         assert mutableConfig.out_format == "xml"
         assert mutableConfig.concurrent_runs == 1
         # assert mutableConfig.devices == std::set<int>({0})  # @todo - this will need to change
-        assert mutableConfig.verbosity == pyflamegpu.VERBOSE
+        assert mutableConfig.verbosity == pyflamegpu.Verbosity_Verbose
         assert mutableConfig.timing == True
 
     @pytest.mark.skip(reason="--help cannot be tested due to exit()")
@@ -172,10 +172,10 @@ class TestCUDAEnsemble(TestCase):
         # Create an ensemble
         ensemble = pyflamegpu.CUDAEnsemble(model)
         # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
-        assert ensemble.Config().verbosity == pyflamegpu.DEFAULT
+        assert ensemble.Config().verbosity == pyflamegpu.Verbosity_Default
         argv = ["ensemble.exe", "--quiet"]
         ensemble.initialise(argv)
-        assert ensemble.Config().verbosity == pyflamegpu.QUIET
+        assert ensemble.Config().verbosity == pyflamegpu.Verbosity_Quiet
     
     def test_initialise_default(self):
         # Create a model
@@ -183,7 +183,7 @@ class TestCUDAEnsemble(TestCase):
         # Create an ensemble
         ensemble = pyflamegpu.CUDAEnsemble(model)
         # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
-        assert ensemble.Config().verbosity == pyflamegpu.DEFAULT
+        assert ensemble.Config().verbosity == pyflamegpu.Verbosity_Default
 
     def test_initialise_verbose(self):
         # Create a model
@@ -191,10 +191,10 @@ class TestCUDAEnsemble(TestCase):
         # Create an ensemble
         ensemble = pyflamegpu.CUDAEnsemble(model)
         # Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
-        assert ensemble.Config().verbosity == pyflamegpu.DEFAULT
+        assert ensemble.Config().verbosity == pyflamegpu.Verbosity_Default
         argv = ["ensemble.exe", "--verbose"]
         ensemble.initialise(argv)
-        assert ensemble.Config().verbosity == pyflamegpu.VERBOSE
+        assert ensemble.Config().verbosity == pyflamegpu.Verbosity_Verbose
 
     def test_initialise_timing(self):
         # Create a model
@@ -270,7 +270,7 @@ class TestCUDAEnsemble(TestCase):
         # Create an ensemble
         ensemble = pyflamegpu.CUDAEnsemble(model)
         # Make it quiet to avoid outputting during the test suite
-        ensemble.Config().verbosity = pyflamegpu.QUIET
+        ensemble.Config().verbosity = pyflamegpu.Verbosity_Quiet
         # Simulate the ensemble,
         ensemble.simulate(plans)
 

--- a/tests/swig/python/io/test_io.py
+++ b/tests/swig/python/io/test_io.py
@@ -211,7 +211,7 @@ def io_test_fixture(IO_FILENAME):
     am_export.SimulationConfig().random_seed = 654321;
     am_export.SimulationConfig().steps = 123;
     am_export.SimulationConfig().timing = True;
-    am_export.SimulationConfig().verbosity = pyflamegpu.QUIET
+    am_export.SimulationConfig().verbosity = pyflamegpu.Verbosity_Quiet
     am_export.CUDAConfig().device_id = 0;
     am_export.exportData(IO_FILENAME)
     del am_export # Delete previous CUDASimulation as multiple models with same name cant exist
@@ -222,7 +222,7 @@ def io_test_fixture(IO_FILENAME):
     am.SimulationConfig().random_seed = 0;
     am.SimulationConfig().steps = 0;
     am.SimulationConfig().timing = False;
-    am.SimulationConfig().verbosity = pyflamegpu.DEFAULT
+    am.SimulationConfig().verbosity = pyflamegpu.Verbosity_Default
     # Perform import
     am.SimulationConfig().input_file = IO_FILENAME
     am.applyConfig()
@@ -230,7 +230,7 @@ def io_test_fixture(IO_FILENAME):
     assert am.SimulationConfig().random_seed == 654321
     assert am.SimulationConfig().steps == 123
     assert am.SimulationConfig().timing == True
-    assert am.SimulationConfig().verbosity == pyflamegpu.QUIET
+    assert am.SimulationConfig().verbosity == pyflamegpu.Verbosity_Quiet
     assert am.SimulationConfig().input_file == IO_FILENAME
     assert am.CUDAConfig().device_id == 0;
     pop_a_in = pyflamegpu.AgentVector(a)

--- a/tests/swig/python/io/test_io.py
+++ b/tests/swig/python/io/test_io.py
@@ -211,7 +211,7 @@ def io_test_fixture(IO_FILENAME):
     am_export.SimulationConfig().random_seed = 654321;
     am_export.SimulationConfig().steps = 123;
     am_export.SimulationConfig().timing = True;
-    am_export.SimulationConfig().verbose = False;
+    am_export.SimulationConfig().verbosity = pyflamegpu.QUIET
     am_export.CUDAConfig().device_id = 0;
     am_export.exportData(IO_FILENAME)
     del am_export # Delete previous CUDASimulation as multiple models with same name cant exist
@@ -222,7 +222,7 @@ def io_test_fixture(IO_FILENAME):
     am.SimulationConfig().random_seed = 0;
     am.SimulationConfig().steps = 0;
     am.SimulationConfig().timing = False;
-    am.SimulationConfig().verbose = True;
+    am.SimulationConfig().verbosity = pyflamegpu.DEFAULT
     # Perform import
     am.SimulationConfig().input_file = IO_FILENAME
     am.applyConfig()
@@ -230,7 +230,7 @@ def io_test_fixture(IO_FILENAME):
     assert am.SimulationConfig().random_seed == 654321
     assert am.SimulationConfig().steps == 123
     assert am.SimulationConfig().timing == True
-    assert am.SimulationConfig().verbose == False
+    assert am.SimulationConfig().verbosity == pyflamegpu.QUIET
     assert am.SimulationConfig().input_file == IO_FILENAME
     assert am.CUDAConfig().device_id == 0;
     pop_a_in = pyflamegpu.AgentVector(a)

--- a/tests/swig/python/pop/test_agent_vector.py
+++ b/tests/swig/python/pop/test_agent_vector.py
@@ -813,7 +813,7 @@ class AgentVectorTest(TestCase):
         pop2 = pyflamegpu.AgentVector(agent2);
         pop3 = pyflamegpu.AgentVector(agent3);
         pop4 = pyflamegpu.AgentVector(agent4);
-        assert pop.getInitialState(), pyflamegpu.DEFAULT_STATE
+        assert pop.getInitialState(), pyflamegpu.Verbosity_Default_STATE
         assert pop2.getInitialState(), "test"
         assert pop3.getInitialState(), "test"
         assert pop4.getInitialState(), "test2"

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -316,8 +316,8 @@ TEST(TestCUDAEnsemble, verbosity) {
         std::string errors = testing::internal::GetCapturedStderr();
         // Expect no warnings (stderr) but an output reporing the number of completed simulation runs
         std::ostringstream  expect_output;
-        EXPECT_TRUE(output.find("CUDAEnsemble progress") == std::string::npos);   // E.g. CUDAEnsemble progress: 1/2
-        EXPECT_TRUE(output.find("CUDAEnsemble completed"));                       // E.g. CUDAEnsemble completed 2 runs successfully!
+        EXPECT_TRUE(output.find("CUDAEnsemble progress") != std::string::npos);   // E.g. CUDAEnsemble progress: 1/2
+        EXPECT_TRUE(output.find("CUDAEnsemble completed") != std::string::npos);  // E.g. CUDAEnsemble completed 2 runs successfully!
         EXPECT_TRUE(output.find("Ensemble time elapsed") == std::string::npos);   // E.g. Ensemble time elapsed: 0.006000s
         EXPECT_TRUE(errors.empty());
     }
@@ -334,9 +334,9 @@ TEST(TestCUDAEnsemble, verbosity) {
         std::string output = testing::internal::GetCapturedStdout();
         std::string errors = testing::internal::GetCapturedStderr();
         // Expect no warnings (stderr) but outputs on progress and timing
-        EXPECT_TRUE(output.find("CUDAEnsemble progress"));   // E.g. CUDAEnsemble progress: 1/2
-        EXPECT_TRUE(output.find("CUDAEnsemble completed"));  // E.g. CUDAEnsemble completed 2 runs successfully!
-        EXPECT_TRUE(output.find("Ensemble time elapsed"));   // E.g. Ensemble time elapsed: 0.006000s
+        EXPECT_TRUE(output.find("CUDAEnsemble progress") != std::string::npos);   // E.g. CUDAEnsemble progress: 1/2
+        EXPECT_TRUE(output.find("CUDAEnsemble completed") != std::string::npos);  // E.g. CUDAEnsemble completed 2 runs successfully!
+        EXPECT_TRUE(output.find("Ensemble time elapsed") != std::string::npos);   // E.g. Ensemble time elapsed: 0.006000s
         EXPECT_TRUE(errors.empty());
     }
 }

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -48,21 +48,21 @@ TEST(TestCUDAEnsemble, EnsembleConfig) {
     EXPECT_EQ(immutableConfig.out_format, "json");
     EXPECT_EQ(immutableConfig.concurrent_runs, 4u);
     EXPECT_EQ(immutableConfig.devices, std::set<int>());  // @todo - this will need to change.
-    EXPECT_EQ(immutableConfig.verbosity, DEFAULT);
+    EXPECT_EQ(immutableConfig.verbosity, Verbosity::Default);
     EXPECT_EQ(immutableConfig.timing, false);
     // Mutate the config. Note we cannot mutate the return from getConfig, and connot test this as it is a compialtion failure (requires ctest / standalone .cpp file)
     mutableConfig.out_directory = std::string("test");
     mutableConfig.out_format = std::string("xml");
     mutableConfig.concurrent_runs = 1;
     mutableConfig.devices = std::set<int>({0});
-    mutableConfig.verbosity = VERBOSE;
+    mutableConfig.verbosity = Verbosity::Verbose;
     mutableConfig.timing = true;
     // Check via the const ref, this should show the same value as config was a reference, not a copy.
     EXPECT_EQ(immutableConfig.out_directory, "test");
     EXPECT_EQ(immutableConfig.out_format, "xml");
     EXPECT_EQ(immutableConfig.concurrent_runs, 1u);
     EXPECT_EQ(immutableConfig.devices, std::set<int>({0}));  // @todo - this will need to change.
-    EXPECT_EQ(immutableConfig.verbosity, VERBOSE);
+    EXPECT_EQ(immutableConfig.verbosity, Verbosity::Verbose);
     EXPECT_EQ(immutableConfig.timing, true);
 }
 // This test causes `exit` so cannot be used.
@@ -126,10 +126,10 @@ TEST(TestCUDAEnsemble, initialise_quiet) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
-    EXPECT_EQ(ensemble.getConfig().verbosity, DEFAULT);
+    EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Default);
     const char *argv[2] = { "prog.exe", "--quiet" };
     ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
-    EXPECT_EQ(ensemble.getConfig().verbosity, QUIET);
+    EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Quiet);
 }
 TEST(TestCUDAEnsemble, initialise_verbose) {
     // Create a model
@@ -137,10 +137,10 @@ TEST(TestCUDAEnsemble, initialise_verbose) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
-    EXPECT_EQ(ensemble.getConfig().verbosity, DEFAULT);
+    EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Default);
     const char* argv[2] = { "prog.exe", "--verbose" };
     ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
-    EXPECT_EQ(ensemble.getConfig().verbosity, VERBOSE);
+    EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Verbose);
 }
 TEST(TestCUDAEnsemble, initialise_timing) {
     // Create a model
@@ -243,7 +243,7 @@ TEST(TestCUDAEnsemble, simulate) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     // Simulate the ensemble,
     EXPECT_NO_THROW(ensemble.simulate(plans));
     // Get the sum of sums from the atomic.
@@ -286,13 +286,13 @@ TEST(TestCUDAEnsemble, verbosity) {
     }
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
-    // QUIET
+    // Verbosity::Quiet
     {
         // Capture stderr and stdout
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         // Set verbosity level
-        ensemble.Config().verbosity = QUIET;
+        ensemble.Config().verbosity = Verbosity::Quiet;
         // Simulate the ensemble
         EXPECT_NO_THROW(ensemble.simulate(plans));
         // Get stderr and stdout
@@ -302,13 +302,13 @@ TEST(TestCUDAEnsemble, verbosity) {
         EXPECT_TRUE(output.empty());
         EXPECT_TRUE(errors.empty());
     }
-    // DEFAULT
+    // Verbosity::Default
     {
         // Capture stderr and stdout
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         // Set verbosity level
-        ensemble.Config().verbosity = DEFAULT;
+        ensemble.Config().verbosity = Verbosity::Default;
         // Simulate the ensemble
         EXPECT_NO_THROW(ensemble.simulate(plans));
         // Get stderr and stdout
@@ -321,13 +321,13 @@ TEST(TestCUDAEnsemble, verbosity) {
         EXPECT_TRUE(output.find("Ensemble time elapsed") == std::string::npos);   // E.g. Ensemble time elapsed: 0.006000s
         EXPECT_TRUE(errors.empty());
     }
-    // VERBOSE
+    // Verbosity::Verbose
     {
         // Capture stderr and stdout
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         // Set verbosity level
-        ensemble.Config().verbosity = VERBOSE;
+        ensemble.Config().verbosity = Verbosity::Verbose;
         // Simulate the ensemble
         EXPECT_NO_THROW(ensemble.simulate(plans));
         // Get stderr and stdout
@@ -360,7 +360,7 @@ TEST(TestCUDAEnsemble, setStepLog) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     // Set the StepLog config.
     EXPECT_NO_THROW(ensemble.setStepLog(slcfg));
     // Run the ensemble, generating logs
@@ -403,7 +403,7 @@ TEST(TestCUDAEnsemble, setExitLog) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     // Set the StepLog config.
     EXPECT_NO_THROW(ensemble.setExitLog(lcfg));
     // Run the ensemble, generating logs
@@ -473,7 +473,7 @@ TEST(TestCUDAEnsemble, getEnsembleElapsedTime) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     // Get the elapsed seconds before the sim has been executed
     EXPECT_NO_THROW(ensemble.getEnsembleElapsedTime());
     // Assert that it is LE zero.
@@ -517,7 +517,7 @@ TEST(TestCUDAEnsemble, ErrorOff) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     ensemble.Config().error_level = CUDAEnsemble::EnsembleConfig::Off;
     ensemble.Config().concurrent_runs = 1;  // Single device/no concurrency to ensure we get consistent data
     ensemble.Config().devices = {0};
@@ -549,7 +549,7 @@ TEST(TestCUDAEnsemble, ErrorSlow) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     ensemble.Config().error_level = CUDAEnsemble::EnsembleConfig::Slow;
     ensemble.Config().concurrent_runs = 1;  // Single device/no concurrency to ensure we get consistent data
     ensemble.Config().devices = { 0 };
@@ -579,7 +579,7 @@ TEST(TestCUDAEnsemble, ErrorFast) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     ensemble.Config().error_level = CUDAEnsemble::EnsembleConfig::Fast;
     ensemble.Config().concurrent_runs = 1;  // Single device/no concurrency to ensure we get consistent data
     ensemble.Config().devices = { 0 };
@@ -629,7 +629,7 @@ TEST(TestCUDAEnsemble, SimualteWithExistingCUDASimulation) {
     // Create an ensemble
     flamegpu::CUDAEnsemble ensemble(model);
     // Make it quiet to avoid outputting during the test suite
-    ensemble.Config().verbosity = QUIET;
+    ensemble.Config().verbosity = Verbosity::Quiet;
     ensemble.Config().out_format = "";  // Suppress warning
     // Simulate the ensemble,
     EXPECT_NO_THROW(ensemble.simulate(plans));
@@ -680,7 +680,7 @@ TEST(TestCUDAEnsemble, SimualteWithExistingCUDAMalloc) {
         // Create an ensemble
         flamegpu::CUDAEnsemble ensemble(model);
         // Make it quiet to avoid outputting during the test suite
-        ensemble.Config().verbosity = QUIET;
+        ensemble.Config().verbosity = Verbosity::Quiet;
         ensemble.Config().out_format = "";  // Suppress warning
         // Simulate the ensemble,
         EXPECT_NO_THROW(ensemble.simulate(plans));

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -131,6 +131,17 @@ TEST(TestCUDAEnsemble, initialise_quiet) {
     ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
     EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Quiet);
 }
+TEST(TestCUDAEnsemble, initialise_default) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Default);
+    const char* argv[1] = { "prog.exe" };
+    ensemble.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(ensemble.getConfig().verbosity, Verbosity::Default);
+}
 TEST(TestCUDAEnsemble, initialise_verbose) {
     // Create a model
     flamegpu::ModelDescription model("test");

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -180,6 +180,30 @@ TEST(TestCUDASimulation, ArgParse_device_short) {
     EXPECT_EQ(c.getCUDAConfig().device_id, 1200);
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
 }
+TEST(TestSimulation, initialise_quiet) {
+    ModelDescription m(MODEL_NAME);
+    CUDASimulation c(m);
+    EXPECT_EQ(c.getSimulationConfig().verbosity, Verbosity::Default);
+    const char* argv[2] = { "prog.exe", "--quiet" };
+    c.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(c.getSimulationConfig().verbosity, Verbosity::Quiet);
+}
+TEST(TestSimulation, initialise_default) {
+    ModelDescription m(MODEL_NAME);
+    CUDASimulation c(m);
+    EXPECT_EQ(c.getSimulationConfig().verbosity, Verbosity::Default);
+    const char* argv[1] = { "prog.exe" };
+    c.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(c.getSimulationConfig().verbosity, Verbosity::Default);
+}
+TEST(TestSimulation, initialise_verbose) {
+    ModelDescription m(MODEL_NAME);
+    CUDASimulation c(m);
+    EXPECT_EQ(c.getSimulationConfig().verbosity, Verbosity::Default);
+    const char* argv[2] = { "prog.exe", "--verbose" };
+    c.initialise(sizeof(argv) / sizeof(char*), argv);
+    EXPECT_EQ(c.getSimulationConfig().verbosity, Verbosity::Verbose);
+}
 FLAMEGPU_AGENT_FUNCTION(SetGetFn, MessageNone, MessageNone) {
     int i = FLAMEGPU->getVariable<int>(dVARIABLE_NAME);
     FLAMEGPU->setVariable<int>(dVARIABLE_NAME, i * dMULTIPLIER);

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -821,13 +821,13 @@ TEST(TestCUDASimulation, simulationVerbosity) {
     CUDASimulation c(m);
     c.setPopulationData(pop);
     c.SimulationConfig().steps = 1;
-    // QUIET
+    // Verbosity::Quiet
     {
         // Capture stderr and stdout
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         // Set verbosity level
-        c.SimulationConfig().verbosity = QUIET;
+        c.SimulationConfig().verbosity = Verbosity::Quiet;
         // Simulate
         EXPECT_NO_THROW(c.simulate());
         // Get stderr and stdout
@@ -843,7 +843,7 @@ TEST(TestCUDASimulation, simulationVerbosity) {
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         // Set verbosity level
-        c.SimulationConfig().verbosity = DEFAULT;
+        c.SimulationConfig().verbosity = Verbosity::Default;
         // Simulate
         c.resetStepCounter();
         EXPECT_NO_THROW(c.simulate());
@@ -854,13 +854,13 @@ TEST(TestCUDASimulation, simulationVerbosity) {
         EXPECT_TRUE(output.empty());
         EXPECT_TRUE(errors.empty());
     }
-    // VERBOSE
+    // Verbosity::Verbose
     {
         // Capture stderr and stdout
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         // Set verbosity level
-        c.SimulationConfig().verbosity = VERBOSE;
+        c.SimulationConfig().verbosity = Verbosity::Verbose;
         // Simulate
         c.resetStepCounter();
         EXPECT_NO_THROW(c.simulate());

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -867,12 +867,12 @@ TEST(TestCUDASimulation, simulationVerbosity) {
         // Get stderr and stdout
         std::string output = testing::internal::GetCapturedStdout();
         std::string errors = testing::internal::GetCapturedStderr();
-        // Expect no warnings (stderr) but ...
-        EXPECT_TRUE(output.find("Init Function Processing time"));
-        EXPECT_TRUE(output.find("Processing Simulation Step 1"));
-        EXPECT_TRUE(output.find("Step 1 Processing time"));
-        EXPECT_TRUE(output.find("Exit Function Processing time"));
-        EXPECT_TRUE(output.find("Total Processing time"));
+        // Expect no warnings (stderr) but updates on progress and timing
+        EXPECT_TRUE(output.find("Init Function Processing time") != std::string::npos);
+        EXPECT_TRUE(output.find("Processing Simulation Step 0") != std::string::npos);
+        EXPECT_TRUE(output.find("Step 0 Processing time") != std::string::npos);
+        EXPECT_TRUE(output.find("Exit Function Processing time") != std::string::npos);
+        EXPECT_TRUE(output.find("Total Processing time") != std::string::npos);
         EXPECT_TRUE(errors.empty());
     }
 }

--- a/tests/test_cases/io/test_io.cu
+++ b/tests/test_cases/io/test_io.cu
@@ -165,7 +165,7 @@ class MiniSim {
             am.SimulationConfig().truncate_log_files = false;
             am.SimulationConfig().random_seed = 654321;
             am.SimulationConfig().steps = 123;
-            am.SimulationConfig().verbosity = QUIET;
+            am.SimulationConfig().verbosity = Verbosity::Quiet;
             am.SimulationConfig().timing = true;
 #ifdef VISUALISATION
             am.SimulationConfig().console_mode = true;
@@ -183,7 +183,7 @@ class MiniSim {
             am.SimulationConfig().truncate_log_files = true;
             am.SimulationConfig().random_seed = 0;
             am.SimulationConfig().steps = 0;
-            am.SimulationConfig().verbosity = VERBOSE;
+            am.SimulationConfig().verbosity = Verbosity::Verbose;
             am.SimulationConfig().timing = false;
 #ifdef VISUALISATION
             am.SimulationConfig().console_mode = false;
@@ -201,7 +201,7 @@ class MiniSim {
             EXPECT_EQ(am.getSimulationConfig().truncate_log_files, false);
             EXPECT_EQ(am.getSimulationConfig().random_seed, 654321u);
             EXPECT_EQ(am.getSimulationConfig().steps, 123u);
-            EXPECT_EQ(am.getSimulationConfig().verbosity, QUIET);
+            EXPECT_EQ(am.getSimulationConfig().verbosity, Verbosity::Quiet);
             EXPECT_EQ(am.getSimulationConfig().timing, true);
 #ifdef VISUALISATION
             EXPECT_EQ(am.getSimulationConfig().console_mode, true);

--- a/tests/test_cases/io/test_io.cu
+++ b/tests/test_cases/io/test_io.cu
@@ -165,7 +165,7 @@ class MiniSim {
             am.SimulationConfig().truncate_log_files = false;
             am.SimulationConfig().random_seed = 654321;
             am.SimulationConfig().steps = 123;
-            am.SimulationConfig().verbose = false;
+            am.SimulationConfig().verbosity = QUIET;
             am.SimulationConfig().timing = true;
 #ifdef VISUALISATION
             am.SimulationConfig().console_mode = true;
@@ -183,7 +183,7 @@ class MiniSim {
             am.SimulationConfig().truncate_log_files = true;
             am.SimulationConfig().random_seed = 0;
             am.SimulationConfig().steps = 0;
-            am.SimulationConfig().verbose = true;
+            am.SimulationConfig().verbosity = VERBOSE;
             am.SimulationConfig().timing = false;
 #ifdef VISUALISATION
             am.SimulationConfig().console_mode = false;
@@ -201,7 +201,7 @@ class MiniSim {
             EXPECT_EQ(am.getSimulationConfig().truncate_log_files, false);
             EXPECT_EQ(am.getSimulationConfig().random_seed, 654321u);
             EXPECT_EQ(am.getSimulationConfig().steps, 123u);
-            EXPECT_EQ(am.getSimulationConfig().verbose, false);
+            EXPECT_EQ(am.getSimulationConfig().verbosity, QUIET);
             EXPECT_EQ(am.getSimulationConfig().timing, true);
 #ifdef VISUALISATION
             EXPECT_EQ(am.getSimulationConfig().console_mode, true);

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -422,7 +422,7 @@ TEST(LoggingTest, CUDAEnsembleSimulate) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().quiet = true;
+    sim.Config().verbosity = QUIET;
     sim.Config().timing = false;
     // sim.Config().out_directory = "ensemble_out";
     // sim.Config().out_format = "json";
@@ -828,7 +828,7 @@ TEST(TestLogging, Ensemble_ToFile_Step) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().quiet = true;
+    sim.Config().verbosity = QUIET;
     sim.Config().timing = false;
     sim.Config().out_directory = "out";
     sim.Config().out_format = "json";
@@ -889,7 +889,7 @@ TEST(TestLogging, Ensemble_ToFile_Exit) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().quiet = true;
+    sim.Config().verbosity = QUIET;
     sim.Config().timing = false;
     sim.Config().out_directory = "out";
     sim.Config().out_format = "json";
@@ -956,7 +956,7 @@ TEST(TestLogging, Ensemble_ToFile_All) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().quiet = true;
+    sim.Config().verbosity = QUIET;
     sim.Config().timing = false;
     sim.Config().out_directory = "out";
     sim.Config().out_format = "json";

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -422,7 +422,7 @@ TEST(LoggingTest, CUDAEnsembleSimulate) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().verbosity = QUIET;
+    sim.Config().verbosity = Verbosity::Quiet;
     sim.Config().timing = false;
     // sim.Config().out_directory = "ensemble_out";
     // sim.Config().out_format = "json";
@@ -828,7 +828,7 @@ TEST(TestLogging, Ensemble_ToFile_Step) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().verbosity = QUIET;
+    sim.Config().verbosity = Verbosity::Quiet;
     sim.Config().timing = false;
     sim.Config().out_directory = "out";
     sim.Config().out_format = "json";
@@ -889,7 +889,7 @@ TEST(TestLogging, Ensemble_ToFile_Exit) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().verbosity = QUIET;
+    sim.Config().verbosity = Verbosity::Quiet;
     sim.Config().timing = false;
     sim.Config().out_directory = "out";
     sim.Config().out_format = "json";
@@ -956,7 +956,7 @@ TEST(TestLogging, Ensemble_ToFile_All) {
     // Run model
     CUDAEnsemble sim(m);
     sim.Config().concurrent_runs = 5;
-    sim.Config().verbosity = QUIET;
+    sim.Config().verbosity = Verbosity::Quiet;
     sim.Config().timing = false;
     sim.Config().out_directory = "out";
     sim.Config().out_format = "json";

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -373,6 +373,8 @@ TEST(TestRunPlan, noOutputWarning) {
     testing::internal::CaptureStderr();
     // Construct the ensemble
     flamegpu::CUDAEnsemble cuda_ensemble(model);
+    // Disable warnings
+    cuda_ensemble.Config().verbosity = QUIET;
     // Simulate (nothing)
     EXPECT_THROW(cuda_ensemble.simulate(runs), flamegpu::exception::EnsembleError);  // No agents so expect exception
     std::string output = testing::internal::GetCapturedStderr();

--- a/tests/test_cases/sim/test_RunPlan.cu
+++ b/tests/test_cases/sim/test_RunPlan.cu
@@ -365,21 +365,6 @@ TEST(TestRunPlan, operatorMultiplication) {
         // @todo - compare more than one part? Operator== might be easier / cleaner
     }
 }
-TEST(TestRunPlan, noOutputWarning) {
-    // Create a model
-    flamegpu::ModelDescription model("test");
-    // Create an individual run plan vector
-    flamegpu::RunPlanVector runs(model, 10);
-    testing::internal::CaptureStderr();
-    // Construct the ensemble
-    flamegpu::CUDAEnsemble cuda_ensemble(model);
-    // Disable warnings
-    cuda_ensemble.Config().verbosity = QUIET;
-    // Simulate (nothing)
-    EXPECT_THROW(cuda_ensemble.simulate(runs), flamegpu::exception::EnsembleError);  // No agents so expect exception
-    std::string output = testing::internal::GetCapturedStderr();
-    EXPECT_TRUE(output.find("Warning: ") == std::string::npos);  // No warnings should be output
-}
 /*
 getPropertyArray/setPropertyArray are only declared if SWIG is defined.
 // This is not currently the case when building the test suite, so these cannot be tested here.


### PR DESCRIPTION
Fixes #677 by adding verbosity levels and consistency between Simulation and Ensembles.

Notes for doc update ate that

 - Timeing (e.g. `-t`) data is also displayed if using `-v`
 - `-q` suppresses any warnings
 - `-q` respected by ensembles
 - `-v` individual sims will not print verbose output and will use default levels unless quiet

All warnings are now to `stderr` as there was inconsisteny with this.

Also closes #892 outputting of sim seed. Does this under verbose output. Verbose output for ensembles outputs the number of concurrent runs.

From the Ensemble example (note: the final two lines are part of the example not simulation outputs):

-q (quiet verbosity)
```
Ensemble init: 450, calculated init 450
Ensemble result: 40244135200, calculated result 40244135200
```

no args (default vebosity)
```
CUDAEnsemble completed 100 runs successfully!
Ensemble init: 450, calculated init 450
Ensemble result: 40244135200, calculated result 40244135200
```

-v (verbose output)
```
FLAME GPU 2.0.0-alpha.3+c524a128 Ensemble configuration
        Concurrent runs 4
CUDAEnsemble completed 100 runs successfully!
Ensemble time elapsed: 0.327000s
Ensemble init: 450, calculated init 450
Ensemble result: 40244135200, calculated result 40244135200
```

Tests have been added in C++ to test expected outputs of Simulate and Ensemble runs. Various other tests and Python tests have been updated. Python doesn't have duplicate tests which explicitly check outputs to stderr and stdout.
