### PR TITLE
Address pyflamegpu setuptools package would be ignored warnings

### DIFF
--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 from setuptools.dist import Distribution
 
 class BinaryDistribution(Distribution):
@@ -21,7 +21,7 @@ setup(
   url='https://github.com/FLAMEGPU/FLAMEGPU2',
   distclass=BinaryDistribution,
   cmdclass={'install': InstallPlatlib},
-  packages=find_packages(),
+  packages=find_namespace_packages(),
   include_package_data=True,
   classifiers=[
   'Development Status :: 3 - Alpha',

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -25,7 +25,7 @@ setup(
   include_package_data=True,
   classifiers=[
   'Development Status :: 3 - Alpha',
-  'Environment :: GPU :: NVIDIA CUDA :: @CUDAToolkit_VERSION_MAJOR@.@CUDAToolkit_VERSION_MINOR@'
+  'Environment :: GPU :: NVIDIA CUDA :: @CUDAToolkit_VERSION_MAJOR@.@CUDAToolkit_VERSION_MINOR@',
   'Intended Audience :: Developers',
   'License :: OSI Approved :: MIT License',
   'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
Replaces use of `setuptools.find_packages` with `setuptools.find_namespaced_packages` to fix `Package would be ignored` warnings generated by the `include` directory tree being embedded in the wheel.

(setuptools docs)[https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files]

Closes #955
