### PR TITLE
pyflamegpu: Move the visualsation wheel identifier into the local version

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -112,15 +112,27 @@ endif()
 
 # Local python version identifiers are: <public version identifier>[+<local version label>]
 # Optionally (default on) embed the cuda version in the local version number, to differentiate wheels based on python version.
+# Also mark visuasliation builds in the local build number
+# Builds a list of the local label components, prior to joining with the local label componetn separator
 set(FLAMEGPU_VERSION_PYTHON_LOCAL "${FLAMEGPU_VERSION_PYTHON_PUBLIC}")
+
 # Find and attach the `cudaXY` to the local python version number, if we know what it should be.
 if(CUDAToolkit_FOUND)
-    set(FLAMEGPU_VERSION_PYTHON_LOCAL_SUFFIX "cuda${CUDAToolkit_VERSION_MAJOR}${CUDAToolkit_VERSION_MINOR}")
+    list(APPEND FLAMEGPU_VERSION_PYTHON_LOCAL_SEGMENTS "cuda${CUDAToolkit_VERSION_MAJOR}${CUDAToolkit_VERSION_MINOR}")
 endif()
-if(NOT FLAMEGPU_VERSION_PYTHON_LOCAL_SUFFIX STREQUAL "")
-    set(FLAMEGPU_VERSION_PYTHON_LOCAL "${FLAMEGPU_VERSION_PYTHON_LOCAL}+${FLAMEGPU_VERSION_PYTHON_LOCAL_SUFFIX}")
+
+# If a vis build, also add the visualisation marker
+if(VISUALISATION)
+    list(APPEND FLAMEGPU_VERSION_PYTHON_LOCAL_SEGMENTS "vis")
 endif()
-unset(FLAMEGPU_VERSION_PYTHON_LOCAL_SUFFIX)
+
+# Join the local version segments with the local version separator
+list(JOIN FLAMEGPU_VERSION_PYTHON_LOCAL_SEGMENTS "." FLAMEGPU_VERSION_PYTHON_LOCAL_LABEL)
+
+# If there are local version 
+if(NOT FLAMEGPU_VERSION_PYTHON_LOCAL_LABEL STREQUAL "")
+    set(FLAMEGPU_VERSION_PYTHON_LOCAL "${FLAMEGPU_VERSION_PYTHON_LOCAL}+${FLAMEGPU_VERSION_PYTHON_LOCAL_LABEL}")
+endif()
 
 # Set the python version number to use, based on the local version flag.
 set(FLAMEGPU_VERSION_PYTHON ${FLAMEGPU_VERSION_PYTHON_PUBLIC})
@@ -129,5 +141,7 @@ if(BUILD_SWIG_PYTHON_LOCALVERSION)
 endif()
 
 # Unset temporary variables.
+unset(FLAMEGPU_VERSION_PYTHON_LOCAL_SEGMENTS)
+unset(FLAMEGPU_VERSION_PYTHON_LOCAL_LABEL)
 unset(FLAMEGPU_VERSION_PRERELEASE_LABEL)
 unset(FLAMEGPU_VERSION_PRERELEASE_NUMBER)

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -23,14 +23,8 @@ include(${FLAMEGPU_ROOT}/cmake/version.cmake)
 
 # Python module name (must match module name in swig input *.i file), leading to import <x>
 SET(PYTHON_MODULE_NAME pyflamegpu)
-# Set the python distribution name for uniquely naming wheels based on build config.
+# Set the python distribution name, which in practice should probably always match the module name to avoid metadata issues and duplicate installs of the same module.
 set(PYTHON_DISTRIBUTION_NAME ${PYTHON_MODULE_NAME})
-# If the vis is enabled, suffix it onto the python distribution name.
-if(VISUALISATION)
-  # Python doesn't like dashes, so use underscores.
-  # The recommendations for package / distribution names are also to keep them short and all lowercase, although _ are allowed to improve readability.
-  set(PYTHON_DISTRIBUTION_NAME "${PYTHON_DISTRIBUTION_NAME}_vis")
-endif()
 
 # Set the swig cmake target name (i.e. this needs to not be pyflamegpu)
 set(PYTHON_SWIG_TARGET_NAME "${PYTHON_MODULE_NAME}_swig")


### PR DESCRIPTION
This fixes an issue with visusalition builds running test_version.py, which uses a method call which checks metadata against the distribution name, rather than the module name.

This also prevents being able to install vis and non-vis distributions side by side, with both being installed but only the latest installed module being available. Instead only one dist can be installed, which provides the pyflamegpu module.

This will have an implication on order version precedence when attempting to install a different version over another, though cuda version will be higher precendence.

Part of #605 