### PR TITLE
Warning for unknown args with tests

### DIFF
--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -54,6 +54,11 @@ class CUDAEnsemble {
          */
         flamegpu::Verbosity verbosity = Verbosity::Default;
         /**
+         * Suppresses warning for unknown arguments passed to the CUDAEnsemble during initialisation. Useful for when arguments are passed to user defined models but should
+         * not be considered by the FLAME GPU API.
+         */
+        bool silence_unknown_args = false;
+        /**
          * If true, the total runtime for the ensemble will be printed to stdout at completion
          * This is independent of the EnsembleConfig::quiet
          * Defaults to false

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -42,6 +42,7 @@ class Simulation {
             steps = other.steps;
             verbosity = other.verbosity;
             timing = other.timing;
+            silence_unknown_args = other.silence_unknown_args;
 #ifdef VISUALISATION
             console_mode = other.console_mode;
 #endif
@@ -55,6 +56,7 @@ class Simulation {
         unsigned int steps = 1;
         flamegpu::Verbosity verbosity = Verbosity::Default;
         bool timing = false;
+        bool silence_unknown_args = false;
 #ifdef VISUALISATION
         bool console_mode = false;
 #else

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -338,9 +338,7 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
 #endif
             continue;
         }
-        fprintf(stderr, "Unexpected argument: %s\n", arg.c_str());
-        printHelp(argv[0]);
-        return false;
+        fprintf(stderr, "Warning: Unknown argument '%s' passed to Ensemble will be ignored\n", arg.c_str());
     }
     return true;
 }

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -310,6 +310,11 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
             config.timing = true;
             continue;
         }
+        // -u/--silence-unknown-args, Silence warning for unknown arguments
+        if (arg.compare("--silence-unknown-args") == 0 || arg.compare("-u") == 0) {
+            config.silence_unknown_args = true;
+            continue;
+        }
         // -e/--error, Specify the error level
         if (arg.compare("--error") == 0 || arg.compare("-e") == 0) {
             if (i + 1 >= argc) {
@@ -338,7 +343,9 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
 #endif
             continue;
         }
-        fprintf(stderr, "Warning: Unknown argument '%s' passed to Ensemble will be ignored\n", arg.c_str());
+        // Warning if not in QUIET verbosity or if silnce-unknown-args is set
+        if (!(config.verbosity == flamegpu::Verbosity::Quiet || config.silence_unknown_args))
+            fprintf(stderr, "Warning: Unknown argument '%s' passed to Ensemble will be ignored\n", arg.c_str());
     }
     return true;
 }
@@ -357,6 +364,7 @@ void CUDAEnsemble::printHelp(const char *executable) {
     printf(line_fmt, "-v, --verbose", "Print config, progress and timing (-t) information to console");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
     printf(line_fmt, "-e, --error <error level>", "The error level 0, 1, 2, off, slow or fast");
+    printf(line_fmt, "-u, --silence-unknown-args", "Silence warnings for unknown arguments passed after this flag.");
 #ifdef _MSC_VER
     printf(line_fmt, "    --standby", "Allow the machine to enter standby during execution");
 #endif

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -250,6 +250,11 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.timing = true;
             continue;
         }
+        // -u/--silence-unknown-args, Silence unknown args
+        if (arg.compare("--silence-unknown-args") == 0 || arg.compare("-u") == 0) {
+            config.silence_unknown_args = true;
+            continue;
+        }
         // --out-step <file.xml/file.json>, Step log file path
         if (arg.compare("--out-step") == 0) {
             if (i + 1 >= argc) {
@@ -288,7 +293,9 @@ int Simulation::checkArgs(int argc, const char** argv) {
         if (checkArgs_derived(argc, argv, i)) {
             continue;
         }
-        fprintf(stderr, "Warning: Unknown argument '%s' passed to Simulation will be ignored\n", arg.c_str());
+        // Warning if not in QUIET verbosity or if silnce-unknown-args is set
+        if (!(config.verbosity == flamegpu::Verbosity::Quiet || config.silence_unknown_args))
+            fprintf(stderr, "Warning: Unknown argument '%s' passed to Simulation will be ignored\n", arg.c_str());
     }
     return true;
 }
@@ -308,6 +315,7 @@ void Simulation::printHelp(const char* executable) {
     printf(line_fmt, "-q, --quiet", "Do not print progress information to console");
     printf(line_fmt, "-v, --verbose", "Print config, progress and timing (-t) information to console.");
     printf(line_fmt, "-t, --timing", "Output timing information to stdout");
+    printf(line_fmt, "-u, --silence-unknown-args", "Silence warnings for unknown arguments passed after this flag.");
 #ifdef VISUALISATION
     printf(line_fmt, "-c, --console", "Console mode, disable the visualisation");
 #endif

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -288,9 +288,7 @@ int Simulation::checkArgs(int argc, const char** argv) {
         if (checkArgs_derived(argc, argv, i)) {
             continue;
         }
-        fprintf(stderr, "Unexpected argument: %s\n", arg.c_str());
-        printHelp(argv[0]);
-        return false;
+        fprintf(stderr, "Warning: Unknown argument '%s' passed to Simulation will be ignored\n", arg.c_str());
     }
     return true;
 }

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -131,7 +131,33 @@ TEST(TestCUDAEnsemble, initialise_unknown_arg) {
     testing::internal::CaptureStderr();
     EXPECT_NO_THROW(ensemble.initialise(sizeof(argv) / sizeof(char*), argv));  //  No exception but warning shoudl be raised
     std::string errors = testing::internal::GetCapturedStderr();
-    EXPECT_TRUE(errors.find("Warning: Unknown argument") != std::string::npos);
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") != std::string::npos);  // Should be found
+}
+TEST(TestCUDAEnsemble, initialise_unknown_arg_quiet) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().devices, std::set<int>({}));
+    const char* argv[3] = { "prog.exe", "--quiet", "--unknown" };
+    testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(ensemble.initialise(sizeof(argv) / sizeof(char*), argv));  //  No exception but warning shoudl be raised
+    std::string errors = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") == std::string::npos);  // Should NOT be found
+}
+TEST(TestCUDAEnsemble, initialise_unknown_arg_silenced) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().devices, std::set<int>({}));
+    const char* argv[3] = { "prog.exe", "--silence-unknown-args", "--unknown" };
+    testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(ensemble.initialise(sizeof(argv) / sizeof(char*), argv));  //  No exception but warning shoudl be raised
+    std::string errors = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") == std::string::npos);  // Should NOT be found
 }
 TEST(TestCUDAEnsemble, initialise_quiet) {
     // Create a model

--- a/tests/test_cases/gpu/test_cuda_ensemble.cu
+++ b/tests/test_cases/gpu/test_cuda_ensemble.cu
@@ -120,6 +120,19 @@ TEST(TestCUDAEnsemble, initialise_devices_wrong) {
     // Sim with out of bounds device ID, get exception
     EXPECT_THROW(ensemble.simulate(plan), exception::InvalidCUDAdevice);
 }
+TEST(TestCUDAEnsemble, initialise_unknown_arg) {
+    // Create a model
+    flamegpu::ModelDescription model("test");
+    // Create an ensemble
+    flamegpu::CUDAEnsemble ensemble(model);
+    // Call initialise with differnt cli arguments, which will mutate values. Check they have the new value.
+    EXPECT_EQ(ensemble.getConfig().devices, std::set<int>({}));
+    const char* argv[2] = { "prog.exe", "--unknown" };
+    testing::internal::CaptureStderr();
+    EXPECT_NO_THROW(ensemble.initialise(sizeof(argv) / sizeof(char*), argv));  //  No exception but warning shoudl be raised
+    std::string errors = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") != std::string::npos);
+}
 TEST(TestCUDAEnsemble, initialise_quiet) {
     // Create a model
     flamegpu::ModelDescription model("test");

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -180,6 +180,16 @@ TEST(TestCUDASimulation, ArgParse_device_short) {
     EXPECT_EQ(c.getCUDAConfig().device_id, 1200);
     ASSERT_EQ(cudaGetLastError(), cudaSuccess);
 }
+TEST(TestSimulation, ArgParse_unknown) {
+    ModelDescription m(MODEL_NAME);
+    CUDASimulation c(m);
+    const char* argv[2] = { "prog.exe", "--unknown" };
+    EXPECT_EQ(c.getSimulationConfig().input_file, "");
+    testing::internal::CaptureStderr();
+    c.initialise(sizeof(argv) / sizeof(char*), argv);
+    std::string errors = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") != std::string::npos);
+}
 TEST(TestSimulation, initialise_quiet) {
     ModelDescription m(MODEL_NAME);
     CUDASimulation c(m);

--- a/tests/test_cases/gpu/test_cuda_simulation.cu
+++ b/tests/test_cases/gpu/test_cuda_simulation.cu
@@ -188,7 +188,27 @@ TEST(TestSimulation, ArgParse_unknown) {
     testing::internal::CaptureStderr();
     c.initialise(sizeof(argv) / sizeof(char*), argv);
     std::string errors = testing::internal::GetCapturedStderr();
-    EXPECT_TRUE(errors.find("Warning: Unknown argument") != std::string::npos);
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") != std::string::npos);  // Should be found
+}
+TEST(TestSimulation, ArgParse_unknown_quiet) {
+    ModelDescription m(MODEL_NAME);
+    CUDASimulation c(m);
+    const char* argv[3] = { "prog.exe", "--quiet", "--unknown" };
+    EXPECT_EQ(c.getSimulationConfig().input_file, "");
+    testing::internal::CaptureStderr();
+    c.initialise(sizeof(argv) / sizeof(char*), argv);
+    std::string errors = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") == std::string::npos);  // Shoudl NOT be found
+}
+TEST(TestSimulation, ArgParse_unknown_silenced) {
+    ModelDescription m(MODEL_NAME);
+    CUDASimulation c(m);
+    const char* argv[3] = { "prog.exe", "--silence-unknown-args", "--unknown" };
+    EXPECT_EQ(c.getSimulationConfig().input_file, "");
+    testing::internal::CaptureStderr();
+    c.initialise(sizeof(argv) / sizeof(char*), argv);
+    std::string errors = testing::internal::GetCapturedStderr();
+    EXPECT_TRUE(errors.find("Warning: Unknown argument") == std::string::npos);  // Shoudl NOT be found
 }
 TEST(TestSimulation, initialise_quiet) {
     ModelDescription m(MODEL_NAME);


### PR DESCRIPTION
Fixes #931.

Testing for previous behaviour is tricky as it causes a system exit. There are exit tests available in google test but these don't support "test for no exit". It would be possible to have a friend class test the arg parsing function specifically however an exit from google test would not constitute a pass (it just wouldn't fail as the testing would exit with an error code) so this seems unnecessary.