### PR TITLE
BugFix: Remove redundant code from CUDAFatAgent::addSubAgent()

### DIFF
--- a/src/flamegpu/gpu/CUDAFatAgent.cu
+++ b/src/flamegpu/gpu/CUDAFatAgent.cu
@@ -72,9 +72,6 @@ void CUDAFatAgent::addSubAgent(
             states.emplace(sub_state, cloned_state);
             states_unique.insert(cloned_state);
         }
-        // allocate memory for each state list by creating a new Agent State List
-        AgentState state = {mappedAgentCount, s};
-        states.emplace(state, std::make_shared<CUDAFatAgentStateList>(description));
     }
     // Handle agent variables
     for (auto &state : states_unique) {


### PR DESCRIPTION
The only effect this code had was creation and deletion of CUDAFatAgentStateList objects, when mapping subagents. (std::map::emplace() return value includes a bool which denotes whether the insertion suceeded, in this case the two branches above ensure it will always fail.)

This had the secondary effect of potentially initialising a CUDA context on the wrong CUDA device.

Closes #820

Windows, Debug, Seatbelt=On
```

[----------] Global test environment tear-down
[==========] 1022 tests from 79 test suites ran. (369557 ms total)
[  PASSED  ] 1022 tests.

  YOU HAVE 53 DISABLED TESTS
```

*I haven't actually checked whether it solves the bug on a multi-device PC, however my understanding of @ptheywood's nsys check and my use of debugger suggest it does.*