### PR TITLE
Handling NaN/Inf in JSON Output

### DIFF
--- a/src/flamegpu/io/JSONLogger.cu
+++ b/src/flamegpu/io/JSONLogger.cu
@@ -277,12 +277,12 @@ void JSONLogger::logCommon(const RunLog &log, const RunPlan *plan, bool doLogCon
     rapidjson::StringBuffer s;
     if (prettyPrint) {
         // rapidjson::Writer doesn't have virtual methods, so can't pass rapidjson::PrettyWriter around as ptr to rapidjson::writer
-        rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer = new rapidjson::PrettyWriter<rapidjson::StringBuffer>(s);
+        auto writer = new rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>(s);
         writer->SetIndent('\t', 1);
         logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit, doLogStepTime, doLogExitTime);
         delete writer;
     } else {
-        rapidjson::Writer<rapidjson::StringBuffer> *writer = new rapidjson::Writer<rapidjson::StringBuffer>(s);
+        auto *writer = new rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>(s);
         logCommon(writer, log, plan, doLogConfig, doLogSteps, doLogExit, doLogStepTime, doLogExitTime);
         delete writer;
     }

--- a/src/flamegpu/io/JSONStateReader.cpp
+++ b/src/flamegpu/io/JSONStateReader.cpp
@@ -442,7 +442,7 @@ int JSONStateReader::parse() {
     rapidjson::StringStream filess(filestring.c_str());
     rapidjson::Reader reader;
     // First parse the file and simply count the size of agent list
-    rapidjson::ParseResult pr1 = reader.Parse(filess, agentcounter);
+    rapidjson::ParseResult pr1 = reader.Parse<rapidjson::kParseNanAndInfFlag, rapidjson::StringStream, flamegpu::io::JSONStateReader_agentsize_counter>(filess, agentcounter);
     if (pr1.Code() != rapidjson::ParseErrorCode::kParseErrorNone) {
         THROW exception::RapidJSONError("Whilst parsing input file '%s', RapidJSON returned error: %s\n", inputFile.c_str(), rapidjson::GetParseError_En(pr1.Code()));
     }
@@ -456,7 +456,7 @@ int JSONStateReader::parse() {
     // Reset the string stream
     filess = rapidjson::StringStream(filestring.c_str());
     // Read in the file data
-    rapidjson::ParseResult pr2 = reader.Parse(filess, handler);
+    rapidjson::ParseResult pr2 = reader.Parse<rapidjson::kParseNanAndInfFlag, rapidjson::StringStream, flamegpu::io::JSONStateReader_impl>(filess, handler);
     if (pr2.Code() != rapidjson::ParseErrorCode::kParseErrorNone) {
         THROW exception::RapidJSONError("Whilst parsing input file '%s', RapidJSON returned error: %s\n", inputFile.c_str(), rapidjson::GetParseError_En(pr1.Code()));
     }

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -229,11 +229,11 @@ void JSONStateWriter::doWrite(T &writer) {
 int JSONStateWriter::writeStates(bool prettyPrint) {
     rapidjson::StringBuffer s;
     if (prettyPrint) {
-        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer = rapidjson::PrettyWriter<rapidjson::StringBuffer>(s);
+        auto writer = rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>(s);
         writer.SetIndent('\t', 1);
         doWrite(writer);
     } else {
-        rapidjson::Writer<rapidjson::StringBuffer> writer = rapidjson::Writer<rapidjson::StringBuffer>(s);
+        auto writer = rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>(s);
         doWrite(writer);
     }
 


### PR DESCRIPTION
Closes #762 

Uses RapidJSONs write and parse flags to relax the JSON standard and output `nan` and `inf` type values. Not technically part of the JSON spec but this is the way in which RapidJSON deals with it. Alternative would be two write `nan` and `inf` as 0 but this would prevent fully serializing and loading a model. 

Requires changes to and test for;

- [x] State agent variables
- [x] State Environment Variables
- [ ] Logging: Wont implement (see below)
 
NOTE: Testing json log outputs is very involved and requires writing a new JSON parser so it wont be done as part of this fix. Currently non out of logging tests test the actual file contents. A new issue (#970 ) for loading logs from JSON in log objects has been opened as a future feature than would then permit this to be tested.

