### PR TITLE
Automatically trigger __disown__() when Python hostfns are bound to models.

### DIFF
--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -472,6 +472,34 @@ class FLAMEGPURuntimeException : public std::exception {
 %feature("director") flamegpu::HostFunctionCallback;
 %feature("director") flamegpu::HostFunctionConditionCallback;
 
+
+// Automatically disown all passed host functions, to prevent them going out of scope too early
+// This still leaves a potential race condition if stateful information is stored in a host function instance
+%feature("pythonprepend") flamegpu::LayerDescription::addHostFunctionCallback(HostFunctionCallback*) %{
+    try:
+        func_callback = func_callback.__disown__()
+    except:
+        pass
+%}
+%feature("pythonprepend") flamegpu::ModelDescription::addInitFunctionCallback(HostFunctionCallback*) %{
+    try:
+        func_callback = func_callback.__disown__()
+    except:
+        pass
+%}
+%feature("pythonprepend") flamegpu::ModelDescription::addStepFunctionCallback(HostFunctionCallback*) %{
+    try:
+        func_callback = func_callback.__disown__()
+    except:
+        pass
+%}
+%feature("pythonprepend") flamegpu::ModelDescription::addExitFunctionCallback(HostFunctionCallback*) %{
+    try:
+        func_callback = func_callback.__disown__()
+    except:
+        pass
+%}
+
 // Apply type mappings go before %includes.
 // -----------------
 

--- a/tests/swig/python/gpu/test_cuda_simulation.py
+++ b/tests/swig/python/gpu/test_cuda_simulation.py
@@ -473,7 +473,7 @@ class TestSimulation(TestCase):
         m.Environment().newPropertyInt("int", 2);
         m.Environment().newPropertyArrayInt("int2", [ 12, 13 ]);
         m.Environment().newPropertyArrayInt("int3", [ 56, 57, 58 ]);
-        m.newLayer().addHostFunctionCallback(Check_setEnvironmentProperty().__disown__());
+        m.newLayer().addHostFunctionCallback(Check_setEnvironmentProperty());
         s = pyflamegpu.CUDASimulation(m);
         s.SimulationConfig().steps = 1;
         # Test the getters work

--- a/tests/swig/python/runtime/test_host_macro_property.py
+++ b/tests/swig/python/runtime/test_host_macro_property.py
@@ -439,7 +439,7 @@ class HostMacroPropertyTest(TestCase):
         agent.newVariableUInt("a");
         t = agent.newRTCFunction("agentwrite", AgentWrite);
         model.newLayer().addAgentFunction(t);
-        model.newLayer().addHostFunctionCallback(HostRead().__disown__());
+        model.newLayer().addHostFunctionCallback(HostRead());
         total_agents = TEST_DIMS[0] * TEST_DIMS[1] * TEST_DIMS[2] * TEST_DIMS[3];
         population = pyflamegpu.AgentVector(agent, total_agents);
         a = 0;
@@ -476,7 +476,7 @@ class HostMacroPropertyTest(TestCase):
         agent.newVariableUInt("w");
         agent.newVariableUInt("a");
         t = agent.newRTCFunction("agentread", AgentRead);
-        model.newLayer().addHostFunctionCallback(HostWrite().__disown__());
+        model.newLayer().addHostFunctionCallback(HostWrite());
         model.newLayer().addAgentFunction(t);
         total_agents = TEST_DIMS[0] * TEST_DIMS[1] * TEST_DIMS[2] * TEST_DIMS[3];
         population = pyflamegpu.AgentVector(agent, total_agents);
@@ -523,7 +523,7 @@ class HostMacroPropertyTest(TestCase):
         t1 = agent.newRTCFunction("agentwrite", AgentWrite);
         t2 = agent.newRTCFunction("agentread", AgentReadZero);
         model.newLayer().addAgentFunction(t1);
-        model.newLayer().addHostFunctionCallback(HostZero().__disown__());
+        model.newLayer().addHostFunctionCallback(HostZero());
         model.newLayer().addAgentFunction(t2);
         total_agents = TEST_DIMS[0] * TEST_DIMS[1] * TEST_DIMS[2] * TEST_DIMS[3];
         population = pyflamegpu.AgentVector(agent, total_agents);
@@ -569,8 +569,8 @@ class HostMacroPropertyTest(TestCase):
         model.Environment().newMacroPropertyDouble("double");
         # Setup agent fn
         model.newAgent("agent");
-        model.newLayer().addHostFunctionCallback(HostArithmeticInit().__disown__());
-        model.newLayer().addHostFunctionCallback(HostArithmetic().__disown__());
+        model.newLayer().addHostFunctionCallback(HostArithmeticInit());
+        model.newLayer().addHostFunctionCallback(HostArithmetic());
         # Do Sim
         cudaSimulation = pyflamegpu.CUDASimulation(model);
         cudaSimulation.SimulationConfig().steps = 1;


### PR DESCRIPTION
I wasn't able to trigger the exception, but added a try-catch regardless.


I think I have removed all usages of `__disown__()` from the Python tests, checked using `grep -rnw "tests/" -e "disown"`.

Closes #498