### PR TITLE
Fix Python Tests

### DIFF
--- a/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
+++ b/include/flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h
@@ -225,7 +225,10 @@ class MessageBruteForce::CDescription {
      */
     bool hasVariable(const std::string& variable_name) const;
 
+#ifndef SWIG
+
  protected:
+#endif
     ///
     /// These mutable accessors will only be available via mutable subclasses
     /// This solves a multiple inheritance issue

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -877,6 +877,7 @@ TEMPLATE_VARIABLE_INSTANTIATE(getSum, flamegpu::AgentLogFrame::getSum)
 
 
 // Instantiate template versions of message functions from the API
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageBruteForce::CDescription::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageBruteForce::Description::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageSpatial2D::Description::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageSpatial3D::Description::newVariable)
@@ -884,6 +885,7 @@ TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageArray::Descriptio
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageArray2D::Description::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageArray3D::Description::newVariable)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariable, flamegpu::MessageBucket::Description::newVariable)
+TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MessageBruteForce::CDescription::newVariableArray)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MessageBruteForce::Description::newVariableArray)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MessageSpatial2D::Description::newVariableArray)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(newVariableArray, flamegpu::MessageSpatial3D::Description::newVariableArray)

--- a/tests/swig/python/model/test_dependency_graph.py
+++ b/tests/swig/python/model/test_dependency_graph.py
@@ -80,9 +80,8 @@ class DependencyGraphTest(TestCase):
     
     def test_ValidateEmptyGraph(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
-        graph = _m.getDependencyGraph()
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
-            graph.validateDependencyGraph()
+            _m.generateLayers() # Triggers validateDependencyGraph() internally
         assert e.value.type() == "InvalidDependencyGraph"
     
     def test_ValidateSingleNode(self):
@@ -90,8 +89,7 @@ class DependencyGraphTest(TestCase):
         a = _m.newAgent(AGENT_NAME)
         f = a.newRTCFunction(FUNCTION_NAME1, self.agent_fn1)
         _m.addExecutionRoot(f)
-        graph = _m.getDependencyGraph()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
     
     def test_ValidateSingleChain(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
@@ -101,9 +99,8 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
     
     def test_ValidateBranch(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
@@ -113,9 +110,8 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
     
     def test_ValidateCycle(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
@@ -126,10 +122,9 @@ class DependencyGraphTest(TestCase):
         f2.dependsOn(f)
         f2.dependsOn(f3)
         f3.dependsOn(f2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
-            graph.validateDependencyGraph()
+            _m.generateLayers() # Triggers validateDependencyGraph() internally
         assert e.value.type() == "InvalidDependencyGraph"
     
     def test_ValidateRootWithDependencies(self):
@@ -140,10 +135,9 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f2)
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
-            graph.validateDependencyGraph()
+            _m.generateLayers() # Triggers validateDependencyGraph() internally
         assert e.value.type() == "InvalidDependencyGraph"
     
     def test_ConstructLayersSingleChain(self):
@@ -154,10 +148,8 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        _m.generateLayers()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         assert _m.getLayersCount() == 3
     
     def test_ConstructLayersRootTwoChildrenConflict(self):
@@ -168,7 +160,6 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
         _m.generateLayers()
         assert _m.getLayersCount() == 3
@@ -179,10 +170,8 @@ class DependencyGraphTest(TestCase):
         f = a.newRTCFunction(FUNCTION_NAME1, self.agent_fn1)
         hf = pyflamegpu.HostFunctionDescription(HOST_FN_NAME1, self.host_fn1)
         hf.dependsOn(f)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        _m.generateLayers()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
     
     def test_AddHostFunctionAsDependency(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
@@ -190,10 +179,8 @@ class DependencyGraphTest(TestCase):
         f = a.newRTCFunction(FUNCTION_NAME1, self.agent_fn1)
         hf = pyflamegpu.HostFunctionDescription(HOST_FN_NAME1, self.host_fn1)
         f.dependsOn(hf)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(hf)
-        _m.generateLayers()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
     
     def test_AddSubmodelAsDependent(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
@@ -206,10 +193,8 @@ class DependencyGraphTest(TestCase):
         _smd = _m.newSubModel("sub", _sm)
     
         _smd.dependsOn(f)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        _m.generateLayers()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         assert _m.getLayersCount() == 2
     
     def test_AddSubmodelAsDependency(self):
@@ -223,10 +208,8 @@ class DependencyGraphTest(TestCase):
         _smd = _m.newSubModel("sub", _sm)
     
         f.dependsOn(_smd)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(_smd)
-        _m.generateLayers()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
     
     def test_DOTDiagramSingleChain(self):
         _m = pyflamegpu.ModelDescription(MODEL_NAME)
@@ -236,10 +219,8 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        _m.generateLayers()
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         _m.generateDependencyGraphDOTDiagram("singlechain.gv")
 
         # Check file contents
@@ -265,9 +246,8 @@ class DependencyGraphTest(TestCase):
         f3 = a.newRTCFunction(FUNCTION_NAME3, self.agent_fn3)
         f2.dependsOn(f)
         f3.dependsOn(f)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         _m.generateDependencyGraphDOTDiagram("twodeps.gv")
 
         # Check file contents
@@ -296,9 +276,8 @@ class DependencyGraphTest(TestCase):
         f3.dependsOn(f)
         f4.dependsOn(f2)
         f4.dependsOn(f3)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         _m.generateDependencyGraphDOTDiagram("diamond.gv")
 
         # Check file contents
@@ -334,10 +313,9 @@ class DependencyGraphTest(TestCase):
         f4.dependsOn(f2)
         f4.dependsOn(hf)
         hf2.dependsOn(f3)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
         _m.addExecutionRoot(hf)
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         _m.generateDependencyGraphDOTDiagram("host_functions.gv")
 
         # Check file contents
@@ -381,10 +359,9 @@ class DependencyGraphTest(TestCase):
         f4.dependsOn(hf)
         hf2.dependsOn(f3)
         _smd.dependsOn(hf2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
         _m.addExecutionRoot(hf)
-        assert graph.validateDependencyGraph() == True
+        _m.generateLayers() # Triggers validateDependencyGraph() internally, which throws exception on failure
         _m.generateDependencyGraphDOTDiagram("all_dependencies.gv")
 
         # Check file contents
@@ -430,7 +407,6 @@ class DependencyGraphTest(TestCase):
         f4.dependsOn(hf)
         hf2.dependsOn(f3)
         _smd.dependsOn(hf2)
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
         _m.addExecutionRoot(hf)
         _m.generateLayers()
@@ -472,7 +448,7 @@ sub
 '''
         print (expectedLayers)
         print (_m.getConstructedLayersString())
-        assert expectedLayers == graph.getConstructedLayersString()
+        assert expectedLayers == _m.getConstructedLayersString()
         assert _m.getLayersCount() == 7
 
     def test_CorrectLayersConcurrent(self):
@@ -490,8 +466,6 @@ sub
         hf2.dependsOn(f)
         hf2.dependsOn(f2)
         hf2.dependsOn(f3)
-
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f3)
         _m.addExecutionRoot(hf)
         _m.generateLayers()
@@ -543,7 +517,6 @@ HostFn2
         l = _m.newLayer(LAYER_NAME)
         l.addAgentFunction(f2)
 
-        graph = _m.getDependencyGraph()
         _m.addExecutionRoot(f)
 
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:

--- a/tests/swig/python/model/test_environment_description.py
+++ b/tests/swig/python/model/test_environment_description.py
@@ -10,7 +10,8 @@ def AddGet_SetGet_test(type: str):
     Function replicates the template version in C++ by getting type qualified add, get and set 
     functions from EnvironmentDescription
     """
-    ed = pyflamegpu.EnvironmentDescription()
+    m = pyflamegpu.ModelDescription("model")
+    ed = m.Environment()
     add_func = getattr(ed, f"newProperty{type}")
     get_func = getattr(ed, f"getProperty{type}")
     set_func = getattr(ed, f"setProperty{type}")
@@ -26,7 +27,8 @@ def AddGet_SetGet_array_test(type: str):
     Function replicates the template version in C++ by getting type and array size qualified 
     add, get and set functions from EnvironmentDescription
     """
-    ed = pyflamegpu.EnvironmentDescription()
+    m = pyflamegpu.ModelDescription("model")
+    ed = m.Environment()
     add_func = getattr(ed, f"newPropertyArray{type}")
     get_func = getattr(ed, f"getPropertyArray{type}")
     set_func = getattr(ed, f"setPropertyArray{type}")
@@ -52,7 +54,8 @@ def AddGet_SetGet_array_element_test(type: str):
     Function replicates the template version in C++ by getting type and array size qualified 
     add, get and set functions from EnvironmentDescription
     """
-    ed = pyflamegpu.EnvironmentDescription()
+    m = pyflamegpu.ModelDescription("model")
+    ed = m.Environment()
     add_func = getattr(ed, f"newPropertyArray{type}")
     get_func = getattr(ed, f"getProperty{type}")
     set_func = getattr(ed, f"setProperty{type}")
@@ -74,7 +77,8 @@ def ExceptionPropertyType_test(type1: str, type2: str):
     Function replicates the template version in C++ by getting type and array size qualified 
     add, get and set functions from EnvironmentDescription
     """
-    ed = pyflamegpu.EnvironmentDescription()
+    m = pyflamegpu.ModelDescription("model")
+    ed = m.Environment()
     add_func_t1 = getattr(ed, f"newProperty{type1}")
     add_func_array_t1 = getattr(ed, f"newPropertyArray{type1}")
     set_func_t1 = getattr(ed, f"setProperty{type1}")
@@ -107,7 +111,8 @@ def ExceptionPropertyLength_test(type: str):
     Function replicates the template version in C++ by getting type and array size qualified 
     add, get and set functions from EnvironmentDescription
     """
-    ed = pyflamegpu.EnvironmentDescription()
+    m = pyflamegpu.ModelDescription("model")
+    ed = m.Environment()
     add_func = getattr(ed, f"newPropertyArray{type}")
     set_func = getattr(ed, f"setPropertyArray{type}")
     
@@ -127,7 +132,8 @@ def ExceptionPropertyLength_test(type: str):
     set_func("a", b)
 
 def ExceptionPropertyRange_test(type:str):
-    ed = pyflamegpu.EnvironmentDescription()
+    m = pyflamegpu.ModelDescription("model")
+    ed = m.Environment()
     add_func = getattr(ed, f"newPropertyArray{type}")
     set_func = getattr(ed, f"setProperty{type}")
     get_func = getattr(ed, f"getProperty{type}")
@@ -342,7 +348,8 @@ class EnvironmentDescriptionTest(TestCase):
 
 
     def test_exception_property_doesnt_exist(self):
-        ed = pyflamegpu.EnvironmentDescription()
+        m = pyflamegpu.ModelDescription("model")
+        ed = m.Environment()
         a = 12.0
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             ed.getPropertyFloat("a")
@@ -365,7 +372,8 @@ class EnvironmentDescriptionTest(TestCase):
         assert e.value.type() == "InvalidEnvProperty"
 
     def test_reserved_name(self):
-        ed = pyflamegpu.EnvironmentDescription()
+        m = pyflamegpu.ModelDescription("model")
+        ed = m.Environment()
         with pytest.raises(pyflamegpu.FLAMEGPURuntimeException) as e:
             ed.newPropertyInt("_", 1)
         assert e.value.type() == "ReservedName"


### PR DESCRIPTION
Broken by #952

Have implemented a suitable workaround for message descriptions (https://github.com/FLAMEGPU/FLAMEGPU2/issues/982), whilst we consider our options. It should be fine to deploy the next release with this workaround in place.