### PR TITLE
Add swig wrapper dependencies on flamegpu header files

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -68,11 +68,15 @@ SET(SWIG_INPUT_FILE_NAME flamegpu)
 set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY SWIG_MODULE_NAME ${PYTHON_MODULE_NAME})
 set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY SWIG_FLAGS "-threads")
-
+# Get the list of FLAMEGPU2 headers from the flamegpu target
+get_target_property(FLAMEGPU_HEADERS flamegpu SOURCES)
+list(FILTER FLAMEGPU_HEADERS INCLUDE REGEX ".*\.(h|hpp|cuh)$")
+# Specify the dependency for swig file processing on all known headers manually.
+set_property(SOURCE ${SWIG_INPUT_FILE_NAME}.i PROPERTY DEPENDS ${FLAMEGPU_HEADERS})
+unset (FLAMEGPU_HEADERS)
 # Add swig module via the native CMake integration integraiton.
 swig_add_library(${PYTHON_SWIG_TARGET_NAME}
 	TYPE SHARED
-	#TYPE STATIC
 	LANGUAGE python
 	OUTPUT_DIR ${PYTHON_LIB_TEMP_DIRECTORY}/${PYTHON_MODULE_NAME}
 	SOURCES ${SWIG_INPUT_FILE_NAME}.i


### PR DESCRIPTION
Generation of the swig wrapper file was not dependent on flamegpu header files, so changes to header files might not cause a regeneration of the wrapper.

CMake 3.22+ would be required for automatic dependency generation via Swigs -M option, but we want to maintain 3.18 minimum.

Fortunately as we have an explciit list of our header files anyway its easy enough to explicitly list these via teh DEPENDS swig source property

Closes #979