### PR TITLE
Fix compilation on Bessemer (GCC11?)

### DIFF
--- a/include/flamegpu/gpu/CUDAAgent.h
+++ b/include/flamegpu/gpu/CUDAAgent.h
@@ -16,9 +16,10 @@
 #include "flamegpu/model/SubAgentData.h"
 #include "flamegpu/runtime/detail/curve/curve_rtc.cuh"
 #include "flamegpu/sim/AgentInterface.h"
+#include "flamegpu/runtime/utility/EnvironmentManager.cuh"
 
 namespace flamegpu {
-
+class CUDAMacroEnvironment;
 class CUDAScatter;
 class CUDAFatAgent;
 struct VarOffsetStruct;

--- a/include/flamegpu/io/StateReader.h
+++ b/include/flamegpu/io/StateReader.h
@@ -6,9 +6,9 @@
 #include <unordered_map>
 #include <utility>
 
-#include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/util/StringPair.h"
 #include "flamegpu/model/EnvironmentData.h"
+#include "flamegpu/sim/Simulation.h"
 
 namespace flamegpu {
 

--- a/include/flamegpu/io/StateWriter.h
+++ b/include/flamegpu/io/StateWriter.h
@@ -12,6 +12,8 @@
 namespace flamegpu {
 
 class AgentVector;
+class EnvironmentManager;
+class Simulation;
 
 namespace io {
 

--- a/include/flamegpu/model/ModelDescription.h
+++ b/include/flamegpu/model/ModelDescription.h
@@ -7,9 +7,7 @@
 #include <string>
 
 
-#include "flamegpu/gpu/CUDAEnsemble.h"
 #include "flamegpu/model/ModelData.h"
-#include "flamegpu/gpu/CUDASimulation.h"
 #include "flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h"
 
 namespace flamegpu {
@@ -34,8 +32,8 @@ class ModelDescription {
     /**
      * Simulation accesses the classes internals to convert it to a constant ModelData
      */
-    friend CUDASimulation::CUDASimulation(const ModelDescription& _model, int argc, const char** argv);
-    friend CUDAEnsemble::CUDAEnsemble(const ModelDescription& model, int argc, const char** argv);
+    friend class CUDASimulation;
+    friend class CUDAEnsemble;
     friend class RunPlanVector;
     friend class RunPlan;
     friend class LoggingConfig;

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -12,6 +12,7 @@
 #include "flamegpu/pop/AgentVector.h"
 #include "flamegpu/gpu/CUDASimulation.h"
 #include "flamegpu/util/StringPair.h"
+#include "flamegpu/runtime/utility/EnvironmentManager.cuh"
 
 namespace flamegpu {
 namespace io {

--- a/src/flamegpu/io/XMLStateWriter.cpp
+++ b/src/flamegpu/io/XMLStateWriter.cpp
@@ -14,6 +14,7 @@
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/gpu/CUDASimulation.h"
 #include "flamegpu/pop/AgentVector.h"
+#include "flamegpu/runtime/utility/EnvironmentManager.cuh"
 
 namespace flamegpu {
 namespace io {

--- a/src/flamegpu/pop/AgentVector.cpp
+++ b/src/flamegpu/pop/AgentVector.cpp
@@ -1,4 +1,7 @@
 #include "flamegpu/pop/AgentVector.h"
+
+#include <limits>
+
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/pop/AgentVector_Agent.h"
 

--- a/src/flamegpu/pop/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/pop/DeviceAgentVector_impl.cu
@@ -1,5 +1,6 @@
 #include "flamegpu/pop/DeviceAgentVector_impl.h"
 #include "flamegpu/gpu/CUDAAgent.h"
+#include "flamegpu/runtime/HostNewAgentAPI.h"
 
 namespace flamegpu {
 

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -7,6 +7,7 @@
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/visualiser/color/ColorFunction.h"
 #include "flamegpu/visualiser/color/StaticColor.h"
+#include "flamegpu/visualiser/color/AutoPalette.h"
 #include "flamegpu/visualiser/FLAMEGPU_Visualisation.h"
 
 namespace flamegpu {


### PR DESCRIPTION
The crux of the issue was that `ModelDescription.h` includes `CUDASimulation.cuh` and `CUDAEnsemble.cuh`. This has the knock-on effect of causing cuda headers to get included in a wide number of places unnecessarily, and for some reason Bessmer/GCC11 causes curand to include cuda headers as C rather than C++.

Many other files were relying on the `ModelDescription.h` include hierarchy, so some additional includes had to be added elsewhere.