### PR TITLE
Replace NVTX macros with constexpr + namespaced methods

### DIFF
--- a/examples/circles_bruteforce/src/main.cu
+++ b/examples/circles_bruteforce/src/main.cu
@@ -65,8 +65,8 @@ FLAMEGPU_STEP_FUNCTION(Validation) {
     printf("%.2f%% Drift correct\n", 100 * driftDropped / static_cast<float>(driftDropped + driftIncreased));
 }
 int main(int argc, const char ** argv) {
-    NVTX_RANGE("main");
-    NVTX_PUSH("ModelDescription");
+    flamegpu::util::nvtx::Range range{"main"};
+    flamegpu::util::nvtx::push("ModelDescription");
     flamegpu::ModelDescription model("Circles BruteForce");
 
     const unsigned int AGENT_COUNT = 16384;
@@ -114,14 +114,14 @@ int main(int argc, const char ** argv) {
         layer.addAgentFunction(move);
     }
 
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Create Model Runner
      */
-    NVTX_PUSH("CUDASimulation creation");
+    flamegpu::util::nvtx::push("CUDASimulation creation");
     flamegpu::CUDASimulation  cudaSimulation(model, argc, argv);
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Create visualisation

--- a/examples/diffusion/src/main.cu
+++ b/examples/diffusion/src/main.cu
@@ -44,8 +44,8 @@ FLAMEGPU_EXIT_CONDITION(stable_temperature) {
 int main(int argc, const char ** argv) {
     const unsigned int SQRT_AGENT_COUNT = 200;
     const unsigned int AGENT_COUNT = SQRT_AGENT_COUNT * SQRT_AGENT_COUNT;
-    NVTX_RANGE("main");
-    NVTX_PUSH("ModelDescription");
+    flamegpu::util::nvtx::Range range{"main"};
+    flamegpu::util::nvtx::push("ModelDescription");
     flamegpu::ModelDescription model("Heat Equation");
 
     {   // Message
@@ -101,14 +101,14 @@ int main(int argc, const char ** argv) {
         layer.addAgentFunction(update);
     }
     model.addExitCondition(stable_temperature);
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Create Model Runner
      */
-    NVTX_PUSH("CUDASimulation creation");
+    flamegpu::util::nvtx::push("CUDASimulation creation");
     flamegpu::CUDASimulation cudaSimulation(model, argc, argv);
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Initialisation

--- a/examples/game_of_life/src/main.cu
+++ b/examples/game_of_life/src/main.cu
@@ -33,8 +33,8 @@ FLAMEGPU_AGENT_FUNCTION(update, flamegpu::MessageArray2D, flamegpu::MessageNone)
 int main(int argc, const char ** argv) {
     const unsigned int SQRT_AGENT_COUNT = 1000;
     const unsigned int AGENT_COUNT = SQRT_AGENT_COUNT * SQRT_AGENT_COUNT;
-    NVTX_RANGE("main");
-    NVTX_PUSH("ModelDescription");
+    flamegpu::util::nvtx::Range range{"main"};
+    flamegpu::util::nvtx::push("ModelDescription");
     flamegpu::ModelDescription model("Game of Life");
 
     {   // Location message
@@ -75,14 +75,14 @@ int main(int argc, const char ** argv) {
         flamegpu::LayerDescription layer = model.newLayer();
         layer.addAgentFunction(update);
     }
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Create Model Runner
      */
-    NVTX_PUSH("CUDASimulation creation");
+    flamegpu::util::nvtx::push("CUDASimulation creation");
     flamegpu::CUDASimulation  cudaSimulation(model, argc, argv);
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Initialisation

--- a/examples/sugarscape/src/main.cu
+++ b/examples/sugarscape/src/main.cu
@@ -230,8 +230,8 @@ flamegpu::AgentDescription makeCoreAgent(flamegpu::ModelDescription &model) {
     return agent;
 }
 int main(int argc, const char ** argv) {
-    NVTX_RANGE("main");
-    NVTX_PUSH("ModelDescription");
+    flamegpu::util::nvtx::Range range{"main"};
+    flamegpu::util::nvtx::push("ModelDescription");
     flamegpu::ModelDescription submodel("Movement_model");
     {  // Define sub model for conflict resolution
         /**
@@ -349,14 +349,14 @@ int main(int argc, const char ** argv) {
         flamegpu::LayerDescription layer = model.newLayer();
         layer.addSubModel(movement_sub);
     }
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Create Model Runner
      */
-    NVTX_PUSH("CUDASimulation creation");
+    flamegpu::util::nvtx::push("CUDASimulation creation");
     flamegpu::CUDASimulation  cudaSimulation(model);
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Create visualisation
@@ -392,7 +392,7 @@ int main(int argc, const char ** argv) {
     /**
      * Initialisation
      */
-    NVTX_PUSH("CUDASimulation initialisation");
+    flamegpu::util::nvtx::push("CUDASimulation initialisation");
     cudaSimulation.initialise(argc, argv);
     if (cudaSimulation.getSimulationConfig().input_file.empty()) {
         std::mt19937_64 rng;
@@ -472,7 +472,7 @@ int main(int argc, const char ** argv) {
         }
         cudaSimulation.setPopulationData(init_pop);
     }
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
 
     /**
      * Execution

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -462,7 +462,7 @@ if(USE_NVTX AND TARGET NVTX::nvtx)
         # fallback to the old cmake var.
         set(nvtxversion ${NVTX_VERSION})
     endif()
-    target_compile_definitions(${PROJECT_NAME} PUBLIC "$<$<COMPILE_LANGUAGE:C,CXX,CUDA>:USE_NVTX=${nvtxversion}>")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "$<$<COMPILE_LANGUAGE:C,CXX,CUDA>:FLAMEGPU_USE_NVTX=${nvtxversion}>")
     unset(nvtxversion)
 endif()
 

--- a/src/flamegpu/gpu/CUDAAgent.cu
+++ b/src/flamegpu/gpu/CUDAAgent.cu
@@ -164,7 +164,7 @@ __global__ void generateCollisionFlags(const id_t* d_sortedKeys, id_t* d_flagsOu
     }
 }
 void CUDAAgent::validateIDCollisions(cudaStream_t stream) const {
-    NVTX_RANGE("CUDAAgent::validateIDCollisions");
+    flamegpu::util::nvtx::Range range{"CUDAAgent::validateIDCollisions"};
     // All data is on device, so use a device technique to check for collisions
     // Sort agent IDs, have a simple kernel check for neighbouring ID collisions to set a flag
     // Scan that flag

--- a/src/flamegpu/gpu/CUDAFatAgent.cu
+++ b/src/flamegpu/gpu/CUDAFatAgent.cu
@@ -328,7 +328,7 @@ void CUDAFatAgent::notifyDeviceBirths(unsigned int newCount) {
 #endif
 }
 void CUDAFatAgent::assignIDs(HostAPI& hostapi, CUDAScatter &scatter, cudaStream_t stream, const unsigned int streamId) {
-    NVTX_RANGE("CUDAFatAgent::assignIDs");
+    flamegpu::util::nvtx::Range range{"CUDAFatAgent::assignIDs"};
     if (agent_ids_have_init) return;
     id_t h_max = ID_NOT_SET;
     // Find the max ID within the current agents

--- a/src/flamegpu/gpu/detail/CubTemporaryMemory.cu
+++ b/src/flamegpu/gpu/detail/CubTemporaryMemory.cu
@@ -22,7 +22,7 @@ CubTemporaryMemory::~CubTemporaryMemory() {
 }
 void CubTemporaryMemory::resize(const size_t newSize) {
     if (newSize > d_cub_temp_size) {
-        NVTX_RANGE("CubTemporaryMemory::resizeTempStorage");
+        flamegpu::util::nvtx::Range range{"CubTemporaryMemory::resizeTempStorage"};
         if (d_cub_temp) {
             gpuErrchk(flamegpu::util::detail::cuda::cudaFree(d_cub_temp));
         }

--- a/src/flamegpu/runtime/detail/curve/HostCurve.cu
+++ b/src/flamegpu/runtime/detail/curve/HostCurve.cu
@@ -142,7 +142,7 @@ int HostCurve::size() const {
     return rtn;
 }
 void HostCurve::updateDevice_async(const cudaStream_t stream) {
-    NVTX_RANGE("HostCurve::updateDevice_async()");
+    flamegpu::util::nvtx::Range range{"HostCurve::updateDevice_async()"};
     // Initialise the device (if required)
     assert(d_curve_table);  // No reason for this to ever fail.
     // Copy

--- a/src/flamegpu/runtime/messaging/MessageBucket.cu
+++ b/src/flamegpu/runtime/messaging/MessageBucket.cu
@@ -22,7 +22,7 @@ namespace flamegpu {
 MessageBucket::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
     : MessageSpecialisationHandler()
     , sim_message(a) {
-    NVTX_RANGE("MessageBucket::CUDAModelHandler::CUDAModelHandler");
+    flamegpu::util::nvtx::Range range{"MessageBucket::CUDAModelHandler::CUDAModelHandler"};
     const Data &d = (const Data &)a.getMessageDescription();
     hd_data.min = d.lowerBound;
     // Here we convert it so that upperBound is one greater than the final valid index
@@ -88,7 +88,7 @@ void MessageBucket::CUDAModelHandler::freeMetaDataDevicePtr() {
 }
 
 void MessageBucket::CUDAModelHandler::buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
-    NVTX_RANGE("MessageBucket::CUDAModelHandler::buildIndex");
+    flamegpu::util::nvtx::Range range{"MessageBucket::CUDAModelHandler::buildIndex"};
     // Cuda operations all occur within the stream, so only a final sync is required.s
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -21,7 +21,7 @@ namespace flamegpu {
 MessageSpatial2D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
     : MessageSpecialisationHandler()
     , sim_message(a) {
-    NVTX_RANGE("MessageSpatial2D::CUDAModelHandler::CUDAModelHandler");
+    flamegpu::util::nvtx::Range range{"MessageSpatial2D::CUDAModelHandler::CUDAModelHandler"};
     const Data &d = (const Data &)a.getMessageDescription();
     hd_data.radius = d.radius;
     hd_data.min[0] = d.minX;
@@ -95,7 +95,7 @@ void MessageSpatial2D::CUDAModelHandler::freeMetaDataDevicePtr() {
 }
 
 void MessageSpatial2D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
-    NVTX_RANGE("MessageSpatial2D::CUDAModelHandler::buildIndex");
+    flamegpu::util::nvtx::Range range{"MessageSpatial2D::CUDAModelHandler::buildIndex"};
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram

--- a/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
@@ -16,7 +16,7 @@ namespace flamegpu {
 MessageSpatial3D::CUDAModelHandler::CUDAModelHandler(CUDAMessage &a)
   : MessageSpecialisationHandler()
   , sim_message(a) {
-    NVTX_RANGE("Spatial3D::CUDAModelHandler");
+    flamegpu::util::nvtx::Range range{"Spatial3D::CUDAModelHandler"};
     const Data &d = (const Data &)a.getMessageDescription();
     hd_data.radius = d.radius;
     hd_data.min[0] = d.minX;
@@ -94,7 +94,7 @@ void MessageSpatial3D::CUDAModelHandler::freeMetaDataDevicePtr() {
 }
 
 void MessageSpatial3D::CUDAModelHandler::buildIndex(CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
-    NVTX_RANGE("MessageSpatial3D::CUDAModelHandler::buildIndex");
+    flamegpu::util::nvtx::Range range{"MessageSpatial3D::CUDAModelHandler::buildIndex"};
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -37,7 +37,7 @@ Simulation::Simulation(const std::shared_ptr<SubModelData> &submodel_desc, CUDAS
     , maxLayerWidth(submodel_desc->submodel->getMaxLayerWidth()) { }
 
 void Simulation::initialise(int argc, const char** argv) {
-    NVTX_RANGE("Simulation::initialise");
+    flamegpu::util::nvtx::Range range{"Simulation::initialise"};
     // check input args
     if (argc)
         if (!checkArgs(argc, argv))

--- a/src/flamegpu/util/detail/JitifyCache.cu
+++ b/src/flamegpu/util/detail/JitifyCache.cu
@@ -268,7 +268,7 @@ bool confirmFLAMEGPUHeaderVersion(const std::string flamegpuIncludeDir, const st
 
 std::mutex JitifyCache::instance_mutex;
 std::unique_ptr<KernelInstantiation> JitifyCache::compileKernel(const std::string &func_name, const std::vector<std::string> &template_args, const std::string &kernel_src, const std::string &dynamic_header) {
-    NVTX_RANGE("JitifyCache::compileKernel");
+    flamegpu::util::nvtx::Range range{"JitifyCache::compileKernel"};
     // find and validate the cuda include directory via CUDA_PATH or CUDA_HOME.
     static const std::string cuda_include_dir = getCUDAIncludeDir();
     // find and validate the the flamegpu include directory
@@ -457,7 +457,7 @@ void JitifyCache::getKnownHeaders(std::vector<std::string>& headers) {
 }
 
 std::unique_ptr<KernelInstantiation> JitifyCache::loadKernel(const std::string &func_name, const std::vector<std::string> &template_args, const std::string &kernel_src, const std::string &dynamic_header) {
-    NVTX_RANGE("JitifyCache::loadKernel");
+    flamegpu::util::nvtx::Range range{"JitifyCache::loadKernel"};
     std::lock_guard<std::mutex> lock(cache_mutex);
     // Detect current compute capability=
     int currentDeviceIdx = 0;

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -463,6 +463,11 @@ class FLAMEGPURuntimeException : public std::exception {
     %rename (CUDAEnsembleConfig) flamegpu::CUDAEnsemble::EnsembleConfig;
 %feature("flatnested", ""); // flat nested off
 
+// Renames required for nvtx as it is a namespace not a class.
+%rename (nvtx_push) flamegpu::util::nvtx::push;
+%rename (nvtx_pop) flamegpu::util::nvtx::pop;
+%rename (NVTX_ENABLED) flamegpu::util::nvtx::ENABLED;
+
 // Director features. These go before the %includes.
 // -----------------
 /* Enable callback functions for step, exit and init through the use of "director" which allows Python -> C and C-> Python in callback.
@@ -631,8 +636,11 @@ class ModelVis;
 %include "flamegpu/sim/RunPlan.h"
 %include "flamegpu/sim/RunPlanVector.h"
 
-// Include  cleanup utility method
+// Include public utility headers
 %include "flamegpu/util/cleanup.h"
+// Don't flatnest this, range is explicitly not included incase of GC related issues.
+%include "flamegpu/util/nvtx.h"
+
 
 // %extend classes go after %includes, but before tempalates (that use them)
 // -----------------
@@ -974,6 +982,8 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
 
     // Ignore directives. These go before any %includes. 
     // -----------------
+    // Disable nvtx::range class, we don't trust swig+GC to dtor at the right time for it to be reliable
+    %ignore flamegpu::util::nvtx::range;
     // Disable internal vis structs
     %ignore flamegpu::visualiser::ModelVisData;
     %ignore flamegpu::visualiser::AgentVisData;

--- a/tests/swig/python/util/test_nvtx.py
+++ b/tests/swig/python/util/test_nvtx.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest import TestCase
+from pyflamegpu import *
+
+class NVTXTest(TestCase):
+
+    def test_nvtx(self):
+
+        # Assert that the Enabled flag can be accessed, and that it is a bool.
+        is_enabled = pyflamegpu.NVTX_ENABLED
+        assert type(is_enabled) is bool 
+        print(is_enabled)
+
+        # Call each public method, but they do not have any side effects that make them observable (which would also require it to be enabled). They should not thorw however?
+        try:
+            pyflamegpu.nvtx_push("test")
+        except Exception as e:
+            assert False, f"NVTX Push raised an exception {e}"
+
+        try:
+            pyflamegpu.nvtx_pop()
+        except Exception as e:
+            assert False, f"NVTX pop raised an exception {e}"
+
+        # Python doesn't have nvtx ranges in case of GC related delays in dtoring. push/pop must be used.
+        with pytest.raises(AttributeError):
+            pyflamegpu.nvtx_range("test_range")
+        with pytest.raises(AttributeError):
+            pyflamegpu.nvtx_Range("test_range")

--- a/tests/test_cases/util/test_nvtx.cu
+++ b/tests/test_cases/util/test_nvtx.cu
@@ -5,22 +5,29 @@
 
 namespace flamegpu {
 
-
 // Test nvtx versions, and whether or not use causes any potential issues.
 TEST(TestUtilNVTX, nvtx) {
-    // NVTX PUSH, POP and RANGE have no measurable side effects whether USE_NVTX is enabled or not, so use alone shouldn't cause any issues. This is effectively a compile time/linker test. This should probably be resolved (but has a cost).
+    // NVTX push, pop and range are no ops when disabled, and would need to query cupti or similar to detect if they actually pushed markers or not.
+
+    // Check the namepsaced constexpr is set or not, we can only compare it to the macro
+    const bool is_enabled = flamegpu::util::nvtx::ENABLED;
+    #if defined(FLAMEGPU_USE_NVTX)
+        EXPECT_EQ(is_enabled, true);
+    #else
+        EXPECT_EQ(is_enabled, false);
+    #endif
 
     // Push a marker
-    NVTX_PUSH("Test_RANGE");
+    flamegpu::util::nvtx::push("Test_RANGE");
     // Pop the marker
-    NVTX_POP();
+    flamegpu::util::nvtx::pop();
     // Make a scoped range (push, pop)
     {
-        NVTX_RANGE("Test_NVTX_RANGE");
+        flamegpu::util::nvtx::Range r{"Test_NVTX_RANGE"};
     }
 
     // If NVTX is enabled, we can check macros to determine which version was loaded.
-    #if defined(USE_NVTX) && defined(__CUDACC_VER_MAJOR__) && defined(NVTX_VERSION)
+    #if defined(FLAMEGPU_USE_NVTX) && defined(__CUDACC_VER_MAJOR__) && defined(NVTX_VERSION)
         int cuda_major = __CUDACC_VER_MAJOR__;
         int nvtx_version = NVTX_VERSION;
         if (cuda_major >= 10) {


### PR DESCRIPTION
+ Replaces NVTX_PUSH(label) with flamegpu::util::nvtx::push(label)
+ Replaces NVTX_POP() with flamegpu::util::nvtx::pop()
+ Replaces NVTX_RANGE(label) with flamegpu::nvtx::Range r(label)
+ Adds cosntexpr bool flamegpu::nvtx::ENABLED
+ Wraps flamegpu::util::nvtx with swig, exluding range
  + pyflamegpu.NVTX_ENABLED, pyflamegpu.nvtx_push(label), pyflamegpu.nvtx_pop()

Should have the same (C++) runtime cost in optimisaed builds

Closes #984