### PR TITLE
CUDAEnsemble truncate log files.

### DIFF
--- a/include/flamegpu/exception/FLAMEGPUException.h
+++ b/include/flamegpu/exception/FLAMEGPUException.h
@@ -399,6 +399,10 @@ DERIVED_FLAMEGPUException(VersionMismatch, "Versions do not match");
  */
 DERIVED_FLAMEGPUException(InvalidFilePath, "File does not exist.");
 /**
+ * Defines an error reported when an output file already exists, so would be overwritten
+ */
+DERIVED_FLAMEGPUException(FileAlreadyExists, "File already existst.");
+/**
  * Defines an exception indicating that the flamegpu::util::detail::Timer has been used incorrectly.
  */
 DERIVED_FLAMEGPUException(TimerException, "Invalid use of Timer");

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -73,6 +73,11 @@ class CUDAEnsemble {
          */
         ErrorLevel error_level = Slow;
         /**
+         * If true, all log files created will truncate any existing files with the same name
+         * If false, an exception will be raised when a log file already exists
+         */
+        bool truncate_output_files = false;
+        /**
          * Prevents the computer from entering standby whilst the ensemble is running
          * @note This feature is currently only supported by Windows builds.
          */

--- a/include/flamegpu/gpu/CUDAEnsemble.h
+++ b/include/flamegpu/gpu/CUDAEnsemble.h
@@ -76,7 +76,7 @@ class CUDAEnsemble {
          * If true, all log files created will truncate any existing files with the same name
          * If false, an exception will be raised when a log file already exists
          */
-        bool truncate_output_files = false;
+        bool truncate_log_files = false;
         /**
          * Prevents the computer from entering standby whilst the ensemble is running
          * @note This feature is currently only supported by Windows builds.

--- a/include/flamegpu/sim/Simulation.h
+++ b/include/flamegpu/sim/Simulation.h
@@ -54,7 +54,7 @@ class Simulation {
         std::string step_log_file;
         std::string exit_log_file;
         std::string common_log_file;
-        bool truncate_log_files = true;
+        bool truncate_log_files = false;
         uint64_t random_seed;
         unsigned int steps = 1;
         flamegpu::Verbosity verbosity = Verbosity::Default;

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -63,13 +63,13 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
         // Check that output files don't already exist
         if (std::filesystem::exists(config.out_directory)) {
             std::set<std::filesystem::path> exit_files;
-            for (int p = 0; p < plans.size(); ++p) {
+            for (unsigned int p = 0; p < plans.size(); ++p) {
                 const std::filesystem::path exit_path = config.out_directory / std::filesystem::path(plans[p].getOutputSubdirectory()) / std::filesystem::path(std::to_string(p) + "." + config.out_format);
                 exit_files.insert(exit_path);
             }
             if (!config.truncate_log_files) {
                 // Step
-                for (int p = 0; p < plans.size(); ++p) {
+                for (unsigned int p = 0; p < plans.size(); ++p) {
                     const std::filesystem::path step_path = config.out_directory / std::filesystem::path(plans[p].getOutputSubdirectory()) / std::filesystem::path("exit." + config.out_format);
                     if (std::filesystem::exists(step_path)) {
                         THROW exception::FileAlreadyExists("Step log file '%s' already exists, in CUDAEnsemble::simulate()", step_path.c_str());
@@ -78,7 +78,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
                 // Exit
                 for (const auto &exit_path : exit_files) {
                     if (std::filesystem::exists(exit_path)) {
-                        THROW exception::FileAlreadyExists("Step log file '%s' already exists, in CUDAEnsemble::simulate()", exit_path.c_str());
+                        THROW exception::FileAlreadyExists("Exit log file '%s' already exists, in CUDAEnsemble::simulate()", exit_path.c_str());
                     }
                 }
             } else {

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -64,13 +64,19 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
         if (std::filesystem::exists(config.out_directory)) {
             std::set<std::filesystem::path> exit_files;
             for (unsigned int p = 0; p < plans.size(); ++p) {
-                const std::filesystem::path exit_path = config.out_directory / std::filesystem::path(plans[p].getOutputSubdirectory()) / std::filesystem::path(std::to_string(p) + "." + config.out_format);
+                std::filesystem::path exit_path = config.out_directory;
+                if (!plans[p].getOutputSubdirectory().empty())
+                    exit_path /= std::filesystem::path(plans[p].getOutputSubdirectory());
+                exit_path /= std::filesystem::path("exit." + config.out_format);
                 exit_files.insert(exit_path);
             }
             if (!config.truncate_log_files) {
                 // Step
                 for (unsigned int p = 0; p < plans.size(); ++p) {
-                    const std::filesystem::path step_path = config.out_directory / std::filesystem::path(plans[p].getOutputSubdirectory()) / std::filesystem::path("exit." + config.out_format);
+                    std::filesystem::path step_path = config.out_directory;
+                    if (!plans[p].getOutputSubdirectory().empty())
+                        step_path /= std::filesystem::path(plans[p].getOutputSubdirectory());
+                    step_path /= std::filesystem::path(std::to_string(p) + "." + config.out_format);
                     if (std::filesystem::exists(step_path)) {
                         THROW exception::FileAlreadyExists("Step log file '%s' already exists, in CUDAEnsemble::simulate()", step_path.c_str());
                     }

--- a/src/flamegpu/gpu/CUDAEnsemble.cu
+++ b/src/flamegpu/gpu/CUDAEnsemble.cu
@@ -67,7 +67,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
                 const std::filesystem::path exit_path = config.out_directory / std::filesystem::path(plans[p].getOutputSubdirectory()) / std::filesystem::path(std::to_string(p) + "." + config.out_format);
                 exit_files.insert(exit_path);
             }
-            if (!config.truncate_output_files) {
+            if (!config.truncate_log_files) {
                 // Step
                 for (int p = 0; p < plans.size(); ++p) {
                     const std::filesystem::path step_path = config.out_directory / std::filesystem::path(plans[p].getOutputSubdirectory()) / std::filesystem::path("exit." + config.out_format);
@@ -367,7 +367,7 @@ int CUDAEnsemble::checkArgs(int argc, const char** argv) {
         }
         // --truncate, Truncate output files
         if (arg.compare("--truncate") == 0) {
-            config.truncate_output_files = true;
+            config.truncate_log_files = true;
             continue;
         }
         // --standby Disable the blocking of standby

--- a/src/flamegpu/io/JSONStateWriter.cpp
+++ b/src/flamegpu/io/JSONStateWriter.cpp
@@ -239,7 +239,7 @@ int JSONStateWriter::writeStates(bool prettyPrint) {
     }
 
     // Perform output
-    std::ofstream out(outputFile);
+    std::ofstream out(outputFile, std::ofstream::trunc);
     out << s.GetString();
     out.close();
 

--- a/src/flamegpu/sim/SimLogger.cu
+++ b/src/flamegpu/sim/SimLogger.cu
@@ -80,7 +80,7 @@ void SimLogger::start() {
             }
             if (export_step) {
                 const std::filesystem::path step_path = p_out_directory/std::filesystem::path(run_plans[target_log].getOutputSubdirectory())/std::filesystem::path(std::to_string(target_log)+"."+out_format);
-                const auto step_logger = io::LoggerFactory::createLogger(step_path.generic_string(), false, false);
+                const auto step_logger = io::LoggerFactory::createLogger(step_path.generic_string(), false, true);
                 step_logger->log(run_logs[target_log], run_plans[target_log], true, false, export_step_time, false);
             }
             // Continue

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -282,6 +282,11 @@ int Simulation::checkArgs(int argc, const char** argv) {
             config.common_log_file = argv[++i];
             continue;
         }
+        // --truncate, Output log files will truncate (rather than throwing an exception)
+        if (arg.compare("--truncate") == 0) {
+            config.truncate_log_files = true;
+            continue;
+        }
 #ifdef VISUALISATION
         // -c/--console, Renders the visualisation inert
         if (arg.compare("--console") == 0 || arg.compare("-c") == 0) {

--- a/src/flamegpu/sim/Simulation.cu
+++ b/src/flamegpu/sim/Simulation.cu
@@ -123,6 +123,9 @@ const ModelData& Simulation::getModelDescription() const {
  * issues: only saves the last output, hardcoded, will be changed
  */
 void Simulation::exportData(const std::string &path, bool prettyPrint) {
+    if (!config.truncate_log_files && std::filesystem::exists(path)) {
+        THROW exception::FileAlreadyExists("File '%s' already exists, in Simulation::exportData()", path.c_str());
+    }
     // Build population vector
     util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> pops;
     for (auto &agent : model->agents) {
@@ -137,6 +140,9 @@ void Simulation::exportData(const std::string &path, bool prettyPrint) {
     write__->writeStates(prettyPrint);
 }
 void Simulation::exportLog(const std::string &path, bool steps, bool exit, bool stepTime, bool exitTime, bool prettyPrint) {
+    if (!config.truncate_log_files && std::filesystem::exists(path)) {
+        THROW exception::FileAlreadyExists("Log file '%s' already exists, in Simulation::exportLog()", path.c_str());
+    }
     // Create the correct type of logger
     auto logger = io::LoggerFactory::createLogger(path, prettyPrint, config.truncate_log_files);
     // Perform logging

--- a/tests/swig/python/gpu/test_cuda_ensemble.py
+++ b/tests/swig/python/gpu/test_cuda_ensemble.py
@@ -206,6 +206,14 @@ class TestCUDAEnsemble(TestCase):
         argv = ["ensemble.exe", "--timing"]
         ensemble.initialise(argv)
         assert ensemble.Config().timing == True
+
+    def test_initialise_truncate(self):
+        model = pyflamegpu.ModelDescription("test_initialise_truncate")
+        ensemble = pyflamegpu.CUDAEnsemble(model)
+        assert ensemble.Config().truncate_log_files == False
+        argv = [ "prog.exe", "--truncate"]
+        ensemble.initialise(argv)
+        assert ensemble.Config().truncate_log_files == True
         
     def test_initialise_error_level(self):
         # Create a model

--- a/tests/swig/python/gpu/test_cuda_simulation.py
+++ b/tests/swig/python/gpu/test_cuda_simulation.py
@@ -194,6 +194,14 @@ class TestSimulation(TestCase):
         c.initialise(argv)
         assert c.SimulationConfig().verbosity == pyflamegpu.Verbosity_Verbose
 
+    def test_initalise_truncate(self):
+        m = pyflamegpu.ModelDescription("test_initialise_truncate")
+        c = pyflamegpu.CUDASimulation(m)
+        assert c.SimulationConfig().truncate_log_files == False
+        argv = [ "prog.exe", "--truncate"]
+        c.initialise(argv)
+        assert c.SimulationConfig().truncate_log_files == True
+
     SetGetFn = """
     FLAMEGPU_AGENT_FUNCTION(SetGetFn, flamegpu::MessageNone, flamegpu::MessageNone) {
         int i = FLAMEGPU->getVariable<int>("test");


### PR DESCRIPTION
Ensemble and simulation now have the argument `--truncate` or config variable `truncate_log_files`.

If `true`, this causes all output files to overwrite existing files (and in the case of ensemble exit logs, it will simply delete files at the start).

If `false` a `FileAlreadyExists` exception will be raised. The existence of files is checked at the start of calls to `simulate()` in the case of ensemble runs to ensure early exit, rather than after waiting for compute. Simulation's however perform this as the time of logging (to avoid repetition, due to those methods being possible to call in isolation).

- [x] CUDAEnsemble
- [x] CUDASimulation
- [x] Tests

Closes #818