### PR TITLE
Install python dependencies in windows draft-release CI

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -236,6 +236,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON }}
+    
+    - name: Install python dependencies
+      if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
+      run: |
+        python3 -m pip install --upgrade wheel build setuptools
+
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
 
     # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
     - name: Configure cmake
@@ -500,6 +508,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON }}
+
+    - name: Install python dependencies
+      if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
+      run: |
+        python3 -m pip install --upgrade wheel build setuptools
+
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
 
     # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
     - name: Configure cmake

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  # Or on pull_requests which mutate this CI workflow, using pr rather than push:branch to ensure that the merged state will be OK, as that is what is important here.
+  pull_request:
+    paths:
+      - ".github/workflows/Draft-Release.yml"
   # Or trigger on manual dispatch. This will not produce a release, but will perform the thorough build. 
   workflow_dispatch:
 
@@ -22,9 +26,9 @@ defaults:
 # + Thorough Windows builds
 #   + Oldest and newest cuda, lots of arch, vis off, tests on
 # + Wheel producing manylinux builds
-#   + CUDA 11.0 and 11.2, py 3.7-10, vis on/off, py only.
+#   + CUDA 11.0 and 11.2, py 3.7-11, vis on/off, py only.
 # + Wheel producing Windows builds
-#   + CUDA 11.0 and 11.2, py 3.7-10, vis on/off, py only.
+#   + CUDA 11.0 and 11.2, py 3.7-11, vis on/off, py only.
 # + Draft github release workflow.
 
 jobs:
@@ -98,7 +102,6 @@ jobs:
       with:
         python-version: ${{ env.PYTHON }}
 
-    # @todo - is some/all of this still required when using select Python?
     - name: Install python dependencies
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
       run: |
@@ -557,7 +560,7 @@ jobs:
       - build-windows
       - wheel-manylinux2014
       - wheel-windows
-    if: ${{ success() && startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
+    if: ${{ success() && startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -42,11 +42,11 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           - cuda: "11.8"
-            cuda_arch: "35;60;90"
+            cuda_arch: "35;90"
             hostcxx: gcc-9
             os: ubuntu-20.04
           - cuda: "11.0"
-            cuda_arch: "35;60;80"
+            cuda_arch: "35;80"
             hostcxx: gcc-8
             os: ubuntu-20.04
         python:
@@ -187,11 +187,11 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           - cuda: "11.8.0"
-            cuda_arch: "35;60;90"
+            cuda_arch: "35;90"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
           - cuda: "11.0.3"
-            cuda_arch: "35;60;80"
+            cuda_arch: "35;80"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 

--- a/cmake/dependencies/Thrust.cmake
+++ b/cmake/dependencies/Thrust.cmake
@@ -8,11 +8,10 @@ include(FetchContent)
 cmake_policy(SET CMP0079 NEW)
 
 # Set the minimum supported cub/thrust version, and the version to fetch
-# Thrust version must be >= 1.9.10 for good cmake integration. 
-# Thrust 1.9.8 is a miniumum as it includes a bugfix that was causing issues.
-set(MIN_REQUIRED_THRUST_VERSION 1.11.0)
+# Thrust version must be >= 1.9.10 for good cmake integration, and >= 1.16.0 to avoid windows.h related issues and CMake Thrust version handling logic.
+set(MIN_REQUIRED_THRUST_VERSION 1.16.0)
 set(MIN_REQUIRED_CUB_VERSION ${MIN_REQUIRED_THRUST_VERSION})
-set(THRUST_DOWNLOAD_VERSION 1.14.0)
+set(THRUST_DOWNLOAD_VERSION 1.17.2)
 
 # Use the FindCUDATooklit package (CMake > 3.17) to get the CUDA version and CUDA include directories for cub/thrust location hints
 find_package(CUDAToolkit REQUIRED)


### PR DESCRIPTION
These were missed previously, but automatically installed if missing until a recent-ish change, and as this CI job doesn't run too often it was overlooked.