### PR TITLE
CUDA 12.0

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -2,23 +2,23 @@
 ## Constants
 ## -------------------
 
-# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
-# From 11.0, the download URLs have changed as verisoning within CUDA has changed. 
-# The toolkit verison is separate from the individual versions of tools, i.e. toolkit 11.1.0 contains cudart 11.1.74, but CUPTI 11.1.69  
+# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern
+# From 11.0, the download url/toolkit version is separate from the cudart version.
+# Releases since 11.5.1 (including 11.4.4) use `windows` rather than `win10` in the uri, due to windows 11 inclusion
 $CUDA_KNOWN_URLS = @{
-    "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
-    "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
-    "9.0.176" = "http://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
-    "9.1.85" = "http://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
-    "9.2.148" = "http://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
-    "10.0.130" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
-    "10.1.105" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
-    "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
-    "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
-    "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-    "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
-    "11.0.2" = "http://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
-    "11.0.3" = "http://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
+    "8.0.44"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
+    "8.0.61"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
+    "9.0.176"  = "https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
+    "9.1.85"   = "https://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
+    "9.2.148"  = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
+    "10.0.130" = "https://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
+    "10.1.105" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
+    "10.1.168" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
+    "10.1.243" = "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
+    "10.2.89"  = "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
+    "11.0.1" = "https://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
+    "11.0.2" = "https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
+    "11.0.3" = "https://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
     "11.1.0" = "https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe";
     "11.1.1" = "https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe";
     "11.2.0" = "https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe";
@@ -30,7 +30,7 @@ $CUDA_KNOWN_URLS = @{
     "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe";
     "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.2/network_installers/cuda_11.4.2_win10_network.exe";
     "11.4.3" = "https://developer.download.nvidia.com/compute/cuda/11.4.3/network_installers/cuda_11.4.3_win10_network.exe";
-    "11.4.4" = "https://developer.download.nvidia.com/compute/cuda/11.4.4/network_installers/cuda_11.4.4_win10_network.exe";
+    "11.4.4" = "https://developer.download.nvidia.com/compute/cuda/11.4.4/network_installers/cuda_11.4.4_windows_network.exe";
     "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe";
     "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe";
     "11.5.2" = "https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe";
@@ -40,14 +40,15 @@ $CUDA_KNOWN_URLS = @{
     "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe";
     "11.7.1" = "https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe";
     "11.8.0" = "https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe";
+    "12.0.0" = "https://developer.download.nvidia.com/compute/cuda/12.0.0/network_installers/cuda_12.0.0_windows_network.exe"
 }
 
-# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
+# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead
 $VISUAL_STUDIO_MIN_CUDA = @{
     "2022" = "11.6.0";
     "2019" = "10.1";
-    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
-    "2015" = "8.0"; # might support older, unsure. Depracated as of 11.1, unsupported in 11.2
+    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on version
+    "2015" = "8.0";  # Might support older, unsure. Depracated as of 11.1, unsupported in 11.2
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
@@ -60,7 +61,6 @@ $CUDA_PACKAGES_IN = @(
     "cudart";
     "thrust";
 )
-
 
 ## -------------------
 ## Select CUDA version
@@ -112,7 +112,7 @@ Foreach ($package in $CUDA_PACKAGES_IN) {
     } elseif($package -eq "thrust" -and [version]$CUDA_VERSION_FULL -lt [version]"11.3") {
         # Thrust is a package from CUDA 11.3, otherwise it should be skipped.
         continue
-    } 
+    }
     $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
 }
 echo "$($CUDA_PACKAGES)"
@@ -129,9 +129,9 @@ if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
     # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
     Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
     if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
-        $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
+        $CUDA_REPO_PKG_REMOTE="https://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
     } else {
-        $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+        $CUDA_REPO_PKG_REMOTE="https://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
     }
 }
 if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
@@ -144,7 +144,7 @@ if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
 ## Install CUDA
 ## ------------
 
-# Get CUDA network installer
+# Get CUDA network installer, retrying upto N times.
 Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
 
 $downloaded = $false
@@ -180,12 +180,12 @@ Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($C
 # Check the return status of the CUDA installer.
 if (!$?) {
     Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
-    exit 1 
+    exit 1
 }
 
 # Store the CUDA_PATH in the environment for the current session, to be forwarded in the action.
 $CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
-$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)" 
+$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)"
 # Set environmental variables in this session
 $env:CUDA_PATH = "$($CUDA_PATH)"
 $env:CUDA_PATH_VX_Y = "$($CUDA_PATH_VX_Y)"
@@ -197,7 +197,7 @@ Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
 # Set CUDA_PATH as an environmental variable
 
 # If executing on github actions, emit the appropriate echo statements to update environment variables
-if (Test-Path "env:GITHUB_ACTIONS") { 
+if (Test-Path "env:GITHUB_ACTIONS") {
     # Set paths for subsequent steps, using $env:CUDA_PATH
     echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
     echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -26,9 +26,9 @@ defaults:
 # + Thorough Windows builds
 #   + Oldest and newest cuda, lots of arch, vis off, tests on
 # + Wheel producing manylinux builds
-#   + CUDA 11.0 and 11.2, py 3.7-11, vis on/off, py only.
+#   + CUDA 11.2 and 12.0, py 3.7-11, vis on/off, py only.
 # + Wheel producing Windows builds
-#   + CUDA 11.0 and 11.2, py 3.7-11, vis on/off, py only.
+#   + CUDA 11.2 and 12.0, py 3.7-11, vis on/off, py only.
 # + Draft github release workflow.
 
 jobs:
@@ -41,12 +41,16 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
+          - cuda: "12.0"
+            cuda_arch: "50-real;90-real;90-virtual;"
+            hostcxx: gcc-11
+            os: ubuntu-22.04
           - cuda: "11.8"
-            cuda_arch: "35;90"
+            cuda_arch: "35-real;90-real;90-virtual"
             hostcxx: gcc-9
             os: ubuntu-20.04
           - cuda: "11.0"
-            cuda_arch: "35;80"
+            cuda_arch: "35-real;80-real;80-virtual"
             hostcxx: gcc-8
             os: ubuntu-20.04
         python:
@@ -186,12 +190,16 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
+          - cuda: "12.0.0"
+            cuda_arch: "50-real;90-real;90-virtual"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "11.8.0"
-            cuda_arch: "35;90"
+            cuda_arch: "35-real;90-real;90-virtual"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
           - cuda: "11.0.3"
-            cuda_arch: "35;80"
+            cuda_arch: "35-real;80-real;80-virtual"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
@@ -294,13 +302,13 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.2"
-            cuda_arch: "35;52;60;70;80"
-            hostcxx: devtoolset-9
+          - cuda: "12.0"
+            cuda_arch: "50-real;60-real;70-real;80-real;90-real;90-virtual"
+            hostcxx: devtoolset-10
             os: ubuntu-20.04
-          - cuda: "11.0"
-            cuda_arch: "35;52;60;70;80"
-            hostcxx: devtoolset-8
+          - cuda: "11.2"
+            cuda_arch: "35-real;50-real;60-real;70-real;80-real;80-virtual"
+            hostcxx: devtoolset-9
             os: ubuntu-20.04
         python: 
           - "3.11"
@@ -450,12 +458,12 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.2.2"
-            cuda_arch: "35;52;60;70;80"
+          - cuda: "12.0.0"
+            cuda_arch: "50-real;60-real;70-real;80-real;90-real;90-virtual"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
-          - cuda: "11.0.3"
-            cuda_arch: "35;52;60;70;80"
+          - cuda: "11.2.2"
+            cuda_arch: "35-real;50-real;60-real;70-real;80-real;80-virtual"
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -33,6 +33,10 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
+          - cuda: "12.0"
+            cuda_arch: "50"
+            hostcxx: devtoolset-10
+            os: ubuntu-20.04
           - cuda: "11.2"
             cuda_arch: "35"
             hostcxx: devtoolset-9

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -29,6 +29,10 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
+          - cuda: "12.0"
+            cuda_arch: "50"
+            hostcxx: gcc-12
+            os: ubuntu-22.04
           - cuda: "11.8"
             cuda_arch: "35"
             hostcxx: gcc-11

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -23,6 +23,10 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
+          - cuda: "12.0.0"
+            cuda_arch: "50"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "11.8.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,6 +29,10 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
+          - cuda: "12.0.0"
+            cuda_arch: "50"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "11.8.0"
             cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FLAME GPU 2
 
-[![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/FLAMEGPU/FLAMEGPU2/blob/master/LICENSE.MD)
+[![MIT License](https://img.shields.io/github/license/FLAMEGPU/FLAMEGPU2)](https://github.com/FLAMEGPU/FLAMEGPU2/blob/master/LICENSE.md)
 [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/FLAMEGPU/FLAMEGPU2?include_prereleases)](https://github.com/FLAMEGPU/FLAMEGPU2/releases/latest)
 [![GitHub issues](https://img.shields.io/github/issues/FLAMEGPU/FLAMEGPU2)](https://github.com/FLAMEGPU/FLAMEGPU2/issues)
 [![DOI](https://zenodo.org/badge/34064755.svg)](https://zenodo.org/badge/latestdoi/34064755)

--- a/cmake/CUDAArchitectures.cmake
+++ b/cmake/CUDAArchitectures.cmake
@@ -205,10 +205,13 @@ function(flamegpu_set_cuda_architectures)
                     endif()
                 endforeach()
             else()
-                # If nvcc help output parsing failed, just use an informed guess option from CUDA 11.8
+                # If nvcc help output parsing failed, just use an informed guess option from CUDA 12.0
                 set(default_archs "35;50;60;70;80")
                 if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.8)
                     list(APPEND default_archs "90")
+                endif()
+                if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+                    list(REMOVE_ITEM default_archs "35")
                 endif()
                 message(AUTHOR_WARNING
                     "  ${CMAKE_CURRENT_FUNCTION} failed to parse NVCC --help output for default architecture generation\n"

--- a/cmake/dependencies/rapidjson.cmake
+++ b/cmake/dependencies/rapidjson.cmake
@@ -25,7 +25,13 @@ if(NOT rapidjson_POPULATED)
     OUTPUT_QUIET
     )
     set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${rapidjson_SOURCE_DIR}")
-    find_package(RapidJSON REQUIRED)
+    find_package(RapidJSON REQUIRED
+        PATHS ${rapidjson_SOURCE_DIR}
+            NO_CMAKE_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_SYSTEM_ENVIRONMENT_PATH
+            NO_CMAKE_PACKAGE_REGISTRY
+            NO_CMAKE_SYSTEM_PATH)
     # Include path is ${RapidJSON_INCLUDE_DIRS}
 
     # Create a namespaced alias target

--- a/include/flamegpu/runtime/agent/HostAgentAPI.cuh
+++ b/include/flamegpu/runtime/agent/HostAgentAPI.cuh
@@ -4,11 +4,21 @@
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
 #endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
+#else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
 #include <thrust/execution_policy.h>
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // _MSC_VER

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
@@ -282,7 +282,8 @@ class MessageSpatial2D::In {
              * @note Does not compare _parent
              */
             __device__ bool operator==(const Message& rhs) const {
-                return this->relative_cell == rhs.relative_cell
+                return this->relative_cell[0] == rhs.relative_cell[0]
+                    && this->relative_cell[1] == rhs.relative_cell[1]
                     && this->cell_index_max == rhs.cell_index_max
                     && this->cell_index == rhs.cell_index;
             }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -540,27 +540,8 @@ set_property(TARGET ${PROJECT_NAME}  PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
 # Link against dependency targets / directories.
 
-# SYSTEM includes prevent warnings from 3rd party includes where possible. This is implied by target_link_libraries if it is an imported target.
-if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # CUB (and thrust) cause many compiler warnings at high levels, including Wreorder. 
-    # CUB:CUB does not use -isystem to prevent the automatic -I<cuda_path>/include  from being more important, and the CUDA disributed CUB being used. 
-    # Instead, if possible we pass the include directory directly rather than using the imported target.
-    # And also pass {CUDAToolkit_INCLUDE_DIRS}/../include" as isystem so the include order is correct for isystem to work (a workaround for a workaround). The `../` is required to prevent cmake from removing the duplicate path.
-
-    # Include CUB via isystem if possible (via _CUB_INCLUDE_DIR which may be subject to change), otherwise use it via target_link_libraries.
-    # If we used the system CUB, via find_package (CUDA 11.3+ package the config) then this convoluted approach could be avoided. 
-    if(DEFINED _CUB_INCLUDE_DIR)
-        target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "${_CUB_INCLUDE_DIR}")
-    else()
-        target_link_libraries(${PROJECT_NAME} PUBLIC CUB::CUB)
-    endif()
-    target_include_directories(${PROJECT_NAME}  SYSTEM PUBLIC "${CUDAToolkit_INCLUDE_DIRS}/../include")  
-else()
-    # MSVC just includes cub via the CUB::CUB target as no isystem to worry about.
-    target_link_libraries(${PROJECT_NAME} PUBLIC CUB::CUB)
-endif()
-
-# Thrust uses isystem if available
+# Cub and thrust targets are not imported targets, so they do not use -isystem, so warnings must be suppressed as pragmas as requied. This is due to nvcc magic preventing isystem from being reliable with them. 
+target_link_libraries(${PROJECT_NAME} PUBLIC CUB::CUB)
 target_link_libraries(${PROJECT_NAME} PUBLIC Thrust::Thrust)
 
 # tinyxml2 static library

--- a/src/flamegpu/runtime/messaging/MessageBucket.cu
+++ b/src/flamegpu/runtime/messaging/MessageBucket.cu
@@ -3,11 +3,21 @@
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/simulation/detail/CUDAMessage.h"

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -3,11 +3,21 @@
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 #include "flamegpu/runtime/messaging.h"
 #include "flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DHost.h"

--- a/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
@@ -2,15 +2,25 @@
 #include "flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh"
 #include "flamegpu/detail/cuda.cuh"
 #include "flamegpu/simulation/detail/CUDAScatter.cuh"
+
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
-
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 namespace flamegpu {
 MessageSpatial3D::CUDAModelHandler::CUDAModelHandler(detail::CUDAMessage &a)

--- a/src/flamegpu/simulation/detail/CUDAAgent.cu
+++ b/src/flamegpu/simulation/detail/CUDAAgent.cu
@@ -10,11 +10,21 @@
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 #include "flamegpu/version.h"
 #include "flamegpu/simulation/detail/CUDAFatAgent.h"

--- a/src/flamegpu/simulation/detail/CUDAAgentStateList.cu
+++ b/src/flamegpu/simulation/detail/CUDAAgentStateList.cu
@@ -15,7 +15,17 @@
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
 #endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
+#else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // _MSC_VER

--- a/src/flamegpu/simulation/detail/CUDAFatAgent.cu
+++ b/src/flamegpu/simulation/detail/CUDAFatAgent.cu
@@ -8,11 +8,21 @@
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 namespace flamegpu {
 namespace detail {

--- a/src/flamegpu/simulation/detail/CUDAMessage.cu
+++ b/src/flamegpu/simulation/detail/CUDAMessage.cu
@@ -16,11 +16,21 @@
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 namespace flamegpu {
 namespace detail {

--- a/src/flamegpu/simulation/detail/CUDAScatter.cu
+++ b/src/flamegpu/simulation/detail/CUDAScatter.cu
@@ -11,11 +11,21 @@
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)
-#include <cub/cub.cuh>
-#pragma warning(pop)
+#endif  // _MSC_VER
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 1719
 #else
+#pragma diag_suppress 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
 #include <cub/cub.cuh>
-#endif
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 1719
+#else
+#pragma diag_default 1719
+#endif  // __NVCC_DIAG_PRAGMA_SUPPORT__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 namespace flamegpu {
 namespace detail {

--- a/tests/test_cases/runtime/agent/test_device_agent_creation.cu
+++ b/tests/test_cases/runtime/agent/test_device_agent_creation.cu
@@ -753,7 +753,7 @@ TEST(DeviceAgentCreationTest, Optional_Output_SameState_WithAgentFunctionConditi
     EXPECT_EQ(population_b.size(), AGENT_COUNT / 2 + AGENT_COUNT / 4);
     unsigned int is_1 = 0;
     for (AgentVector::Agent ai : population_a) {
-        if (ai.getVariable<float>("x") - ai.getVariable<unsigned int>("id"), 1.0f) {
+        if (ai.getVariable<float>("x") - ai.getVariable<unsigned int>("id") == 1.0f) {
             is_1++;
             ASSERT_EQ(ai.getVariable<unsigned int>("id") % 2, 1u);
         }

--- a/tests/test_cases/runtime/messaging/test_spatial_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_3d.cu
@@ -953,7 +953,6 @@ void wrapped_3d_test(const float x_offset, const float y_offset, const float z_o
     // Recover the results and check they match what was expected
     cudaSimulation.getPopulationData(population);
     // Validate each agent has same result
-    const unsigned int badCount = population[0].getVariable<unsigned int>("badCount");
     for (AgentVector::Agent ai : population) {
         EXPECT_EQ(0.0f, ai.getVariable<float>("result_x"));
         EXPECT_EQ(0.0f, ai.getVariable<float>("result_y"));


### PR DESCRIPTION
CUDA 12 has been released, this PR:

+ Adds CI builds of CUDA 12, using SM 50 as the minimum arch
+ Updates the fallback arch detection to remove SM35 if CUDA >= 12.0
+ Updates release wheels to be 11.2 and 12.0. 
  + 11.0 is not strictly required anymore, as 11.2 has much wider compatibility and 11.0 was only produced for google colab, which is now 11.2.
+ Updates CUB/Thrust finding logic to be more robust
+ Enables Wreorder on linux for CUDA 11.3+, and on windows for CUDA 11.5+, as these versions have usable suppressions for CUB/Thrust <= 2.1.0

Includes not directly related fixes, highlighted by new warnings:

+ Incorrect if statement in test_device_agent_creation.cu
+ Fix array comparison in MessageSpatial2DDevice.cuh
+ Fix licence badge in README.md
+ Makes finding rapidjson after fetching more specific.

Tested by: 

+ [x] C++ and python tests on linux using CUDA 12.0
+ [x] C++ and python tests on windows using CUDA 12.0
+ [x] CI demonstration of thrust / cub suppression changes: 
  + [Windows - 8 builds](https://github.com/FLAMEGPU/FLAMEGPU2/actions/runs/3714572192)
  + [Ubuntu - 10 builds](https://github.com/FLAMEGPU/FLAMEGPU2/actions/runs/3714572197)


Closes #1009 
Closes #1019
