### PR TITLE
Bump version to 2.0.0-rc.1 for post rc.0 development

### DIFF
--- a/include/flamegpu/version.h
+++ b/include/flamegpu/version.h
@@ -39,7 +39,7 @@ static constexpr unsigned int VERSION_PATCH = flamegpu::VERSION % 1000;
  * Namespaced FLAME GPU version Prerelease component
  * A set of . separated pre-release components as a string, following the semver rules for comparison.
  */
-static constexpr char VERSION_PRERELEASE[] = "rc";
+static constexpr char VERSION_PRERELEASE[] = "rc.1";
 
 /**
  * Namespaced FLAME GPU version build metadata component


### PR DESCRIPTION
Bumping the version number to `2.0.0-rc.1` immeadiately after the tagged commit allows version comparison to report it as newer and install over the top.