### PR TITLE
BugFix: Curl would write to stdout/err if old

### DIFF
--- a/src/flamegpu/detail/TestSuiteTelemetry.cpp
+++ b/src/flamegpu/detail/TestSuiteTelemetry.cpp
@@ -17,11 +17,15 @@ bool TestSuiteTelemetry::sendResults(std::string reportName, std::string outcome
     // generate telemetry data
     std::string telemetry_data = flamegpu::io::Telemetry::generateData(reportName, telemetry_payload);
     // send telemetry
-    flamegpu::io::Telemetry::sendData(telemetry_data);
+    bool telemetrySuccess = flamegpu::io::Telemetry::sendData(telemetry_data);
     // print telemetry payload to the user if requested
     if (verbose) {
-        fprintf(stdout, "Telemetry packet sent to '%s' json was: %s\n", flamegpu::io::Telemetry::TELEMETRY_ENDPOINT, telemetry_data.c_str());
-        fflush(stdout);
+        if (telemetrySuccess) {
+            fprintf(stdout, "Telemetry packet sent to '%s' json was: %s\n", flamegpu::io::Telemetry::TELEMETRY_ENDPOINT, telemetry_data.c_str());
+            fflush(stdout);
+        } else {
+            fprintf(stderr, "Warning: Usage statistics for Test suite failed to send.\n");
+        }
     }
     return true;
 }

--- a/src/flamegpu/io/Telemetry.cpp
+++ b/src/flamegpu/io/Telemetry.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <cstdio>
 #include <cctype>
+#include <sstream>
 
 #include "flamegpu/version.h"
 
@@ -255,9 +256,18 @@ bool Telemetry::sendData(std::string telemetry_data) {
 #else
     null = "/dev/null";
 #endif
-    std::string curl_command = "curl -s -o " + null + " --connect-timeout " + std::to_string(CURL_CONNECT_TIMEOUT) + " --max-time " + std::to_string(CURL_MAX_TIME) +  " -X POST \"" + std::string(TELEMETRY_ENDPOINT) + "\" -H \"Content-Type: application/json; charset=utf-8\" --data-raw \"" + telemetry_data + "\"";
+    std::stringstream curl_command;
+    curl_command << "curl";
+    curl_command << " -s";
+    curl_command << " -o " << null;
+    curl_command << " --connect-timeout " << std::to_string(CURL_CONNECT_TIMEOUT);
+    curl_command << " --max-time " << std::to_string(CURL_MAX_TIME);
+    curl_command << " -X POST \"" << std::string(TELEMETRY_ENDPOINT) << "\"";
+    curl_command << " -H \"Content-Type: application/json; charset=utf-8\"";
+    curl_command << " --data-raw \"" << telemetry_data + "\"";
+    curl_command << " > " << null << " 2>&1";
     // capture the return value
-    if (std::system(curl_command.c_str()) != EXIT_SUCCESS) {
+    if (std::system(curl_command.str().c_str()) != EXIT_SUCCESS) {
         return false;
     }
 

--- a/src/flamegpu/simulation/CUDAEnsemble.cu
+++ b/src/flamegpu/simulation/CUDAEnsemble.cu
@@ -240,15 +240,15 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
         #endif
         // generate telemetry data
         std::string telemetry_data = flamegpu::io::Telemetry::generateData("ensemble-run", payload_items);
-        // send
-        if (!flamegpu::io::Telemetry::sendData(telemetry_data)) {
-            if ((config.verbosity > Verbosity::Verbose)) {
+        // send the telemetry packet
+        bool telemetrySuccess = flamegpu::io::Telemetry::sendData(telemetry_data);
+        // If verbose, print either a successful send, or a misc warning.
+        if (config.verbosity >= Verbosity::Verbose) {
+            if (telemetrySuccess) {
+                fprintf(stdout, "Telemetry packet sent to '%s' json was: %s\n", flamegpu::io::Telemetry::TELEMETRY_ENDPOINT, telemetry_data.c_str());
+            } else {
                 fprintf(stderr, "Warning: Usage statistics for CUDAEnsemble failed to send.\n");
             }
-        }
-        // print
-        if ((config.verbosity >= Verbosity::Verbose)) {
-            fprintf(stdout, "Telemetry packet sent to '%s' json was: %s\n", flamegpu::io::Telemetry::TELEMETRY_ENDPOINT, telemetry_data.c_str());
         }
     } else {
         // Encourage users who have opted out to opt back in, unless suppressed.

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -1253,17 +1253,17 @@ void CUDASimulation::simulate() {
         #endif
         // generate telemtry data
         std::string telemetry_data = flamegpu::io::Telemetry::generateData("simulation-run", payload_items);
-        // send
-        if (!flamegpu::io::Telemetry::sendData(telemetry_data)) {
-            if ((getSimulationConfig().verbosity > Verbosity::Verbose))
+        bool telemetrySuccess = flamegpu::io::Telemetry::sendData(telemetry_data);
+        // If verbose, print either a successful send, or a misc warning.
+        if (getSimulationConfig().verbosity >= Verbosity::Verbose) {
+            if (telemetrySuccess) {
+                fprintf(stdout, "Telemetry packet sent to '%s' json was: %s\n", flamegpu::io::Telemetry::TELEMETRY_ENDPOINT, telemetry_data.c_str());
+            } else {
                 fprintf(stderr, "Warning: Usage statistics for CUDASimulation failed to send.\n");
-        }
-        // print
-        if ((getSimulationConfig().verbosity >= Verbosity::Verbose)) {
-            fprintf(stdout, "Telemetry packet sent to '%s' json was: %s\n", flamegpu::io::Telemetry::TELEMETRY_ENDPOINT, telemetry_data.c_str());
+            }
         }
     } else {
-        // Occasional hinting of telemetry if not in use (and not Quiet and not testing mode)
+        // Encourage users who have opted out to opt back in, unless suppressed.
         if ((getSimulationConfig().verbosity > Verbosity::Quiet))
             flamegpu::io::Telemetry::encourageUsage();
     }

--- a/tests/helpers/main.cu
+++ b/tests/helpers/main.cu
@@ -43,7 +43,7 @@ GTEST_API_ int main(int argc, char **argv) {
         // re-enable telemetry so this will actually send.
         flamegpu::io::Telemetry::enable();
         // Submit the test results, do not handle the result and silently fail if needed
-        std::string outcome = rtn ? "Passed" : "Failed";
+        std::string outcome = rtn == EXIT_SUCCESS ? "Passed" : "Failed";
         flamegpu::detail::TestSuiteTelemetry::sendResults("googletest-run"
             , outcome
             , ::testing::UnitTest::GetInstance()->total_test_count()


### PR DESCRIPTION
@ptheywood Had this on HPC with Curl 7.29.0 (circa Feb 2013)
```
curl: option --connect-timeout: expected a proper numerical parameter
curl: try 'curl --help' or 'curl --manual' for more information
```

This attempts to pipe output of the system call to `/dev/null`, haven't tested it though.

Closes #1027