### PR TITLE
Fix CMake message when telemetry is disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -479,12 +479,12 @@ if (FLAMEGPU_SHARE_USAGE_STATISTICS)
     # If on, then set pre-processor
     target_compile_definitions(${PROJECT_NAME} PRIVATE FLAMEGPU_SHARE_USAGE_STATISTICS=1)
 else()
-    message(STATUS, "FLAMEGPU_SHARE_USAGE_STATISTICS is not selected! \n\n"
-    "Support for academic software is dependant on evidence of impact. \n"
-    "Enabling this option sends minimal anonymous usage statistics so \n"
-    "that we can continue to develop the software under a FOSS licence.\n"
-    "See our documentation for more information of what we collect and \n"
-    "why: https://docs.flamegpu.com/guide/telemetry.html")
+    message(STATUS "FLAMEGPU_SHARE_USAGE_STATISTICS is not selected. \n\n"
+    "   Support for academic software is dependant on evidence of impact. \n"
+    "   Enabling this option sends minimal anonymous usage statistics so \n"
+    "   that we can continue to develop the software under a FOSS licence.\n"
+    "   See our documentation for more information of what we collect and \n"
+    "   why: https://docs.flamegpu.com/guide/telemetry")
 endif()
 
 # If telemetry notice suppression is enabled, forward it to the compiler. 

--- a/src/flamegpu/io/Telemetry.cpp
+++ b/src/flamegpu/io/Telemetry.cpp
@@ -273,7 +273,7 @@ void Telemetry::encourageUsage() {
             "setting FLAMEGPU_SHARE_USAGE_STATISTICS to true as an environment variable, "
             "or setting the Simulation/Ensemble config telemetry property to true.\n"
             "This message can be silenced by suppressing all output (--quiet), "
-            "calling flamegpu::io::suppressNotice, or defining a system environment variable FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE\n");
+            "calling flamegpu::io::Telemetry::suppressNotice, or defining a system environment variable FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE\n");
         // Set the flag that this has already been emitted once during execution of the current binary file, so it doesn't happen again.
         haveNotified = true;
     }


### PR DESCRIPTION
Fix CMake message when telemetry is disabled

Minor syntax fix, some indentation and a correct URI. 

Fixes method namespacing suggested by the `Telemetry::encourageUsage`

Closes #1029