### PR TITLE
BugFix: ManyLinux CI was not setting BuildNumber inside generated bin

### DIFF
--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -142,6 +142,10 @@ jobs:
         make
         sudo make install
 
+    # This pre-emptively patches a bug from ManyLinux where git dir is owned by diff user, blocking buildnumber generation
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
     - name: Configure cmake
       run: >
         cmake . -B "${{ env.BUILD_DIR }}"

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -147,6 +147,10 @@ jobs:
         make
         sudo make install
 
+    # This pre-emptively patches a bug where ManyLinux didn't generate buildnumber as git dir was owned by diff user
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
     - name: Configure cmake
       run: >
         cmake . -B "${{ env.BUILD_DIR }}"
@@ -256,6 +260,10 @@ jobs:
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 
+    # This pre-emptively patches a bug where ManyLinux didn't generate buildnumber as git dir was owned by diff user
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      
     # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
     - name: Configure cmake
       run: >
@@ -403,6 +411,10 @@ jobs:
         make
         make install
 
+    # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
     # Unlike other builds manylinux, uses static glew as it has been built and installed.
     - name: Configure cmake
       run: >
@@ -527,6 +539,10 @@ jobs:
 
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
+
+    # This pre-emptively patches a bug where ManyLinux didn't generate buildnumber as git dir was owned by diff user
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
     # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
     - name: Configure cmake

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -133,6 +133,10 @@ jobs:
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 
+    # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
     - name: Configure cmake
       run: >
         cmake . -B "${{ env.BUILD_DIR }}"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -152,6 +152,9 @@ jobs:
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 
+    # This pre-emptively patches a bug from ManyLinux where git dir is owned by diff user, blocking buildnumber generation
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
     - name: Configure cmake
       run: >

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -74,6 +74,10 @@ jobs:
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 
+    # This pre-emptively patches a bug from ManyLinux where git dir is owned by diff user, blocking buildnumber generation
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
     # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
     - name: Configure cmake
       run: >

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -109,6 +109,10 @@ jobs:
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 
+    # This pre-emptively patches a bug from ManyLinux where git dir is owned by diff user, blocking buildnumber generation
+    - name: Enable git safe-directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
     # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
     - name: Configure cmake
       run: >


### PR DESCRIPTION
Fix the build number issue inside ManyLinux CI.

Also pre-emptively apply the fix to most of the other CI jobs (those which do compilation/CMake test)

Relates #1035

Error:
![image](https://user-images.githubusercontent.com/742154/214655789-a291b243-ce42-4e08-81b5-12deff0ed901.png)

Fixed version: (albeit the `FLAMEGPU_VERSION_BUILDMETADATA:` statement has been removed that was for debugging.)

![image](https://user-images.githubusercontent.com/742154/214656014-d76a05dd-5eec-4f69-ae86-67d0b7d88a6d.png)
![image](https://user-images.githubusercontent.com/742154/214656029-c1d25cb4-5151-450f-a929-9b735beb5977.png)

