### PR TITLE
Fix va_list compilation issue on arm/tegra in FLAMEGPUException

### DIFF
--- a/src/flamegpu/exception/FLAMEGPUException.cpp
+++ b/src/flamegpu/exception/FLAMEGPUException.cpp
@@ -32,8 +32,6 @@ void FLAMEGPUException::setLocation(const char *_file, const unsigned int _line)
 
 
 std::string FLAMEGPUException::parseArgs(const char * format, va_list argp) {
-    if (!argp)
-        return format;
     std::string rtn = format;
     // Create a copy of the va_list, as vsnprintf can invalidate elements of argp and find the required buffer length
     va_list argpCopy;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/detail/test_SteadyClockTimer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/detail/test_cxxname.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/detail/test_rtc_multi_thread_device.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_flamegpu_exception.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_device_exception.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/exception/test_rtc_device_exception.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cases/io/test_io.cu

--- a/tests/test_cases/exception/test_flamegpu_exception.cpp
+++ b/tests/test_cases/exception/test_flamegpu_exception.cpp
@@ -1,0 +1,62 @@
+
+#include "gtest/gtest.h"
+
+#include "flamegpu/exception/FLAMEGPUException.h"
+
+namespace flamegpu {
+namespace test_flamegpu_exception {
+
+// Test the public methods on FLAMEGPUException objects, to ensure that va_args behaviour works as intended etc.
+// FLAMEGPUException is an abstract type, so must use one of the  derived classes.
+
+
+TEST(FLAMEGPUExceptionTest, message) {
+    // Check that the default message of a derived exception behaves correctly.
+    flamegpu::exception::CUDAError defaultExceptionMessage;
+    EXPECT_STREQ(defaultExceptionMessage.what(), "CUDA returned an error code!");
+
+    // Check that an empty message works.
+    flamegpu::exception::CUDAError emptyExceptionMessage("");
+    EXPECT_STREQ(emptyExceptionMessage.what(), "");
+
+    // Check that a manual message is set correctly
+    flamegpu::exception::CUDAError manualExceptionMessage("test");
+    EXPECT_STREQ(manualExceptionMessage.what(), "test");
+
+    // Check printf like behaviour for integers.
+    flamegpu::exception::CUDAError intFormat("%d", 12);
+    EXPECT_STREQ(intFormat.what(), "12");
+
+    // Check printf like behaviour for strings.
+    flamegpu::exception::CUDAError strFormat("%s", "test");
+    EXPECT_STREQ(strFormat.what(), "test");
+
+    // Check printf like behaviour for multiformat.
+    flamegpu::exception::CUDAError sdFormat("%s %d", "test", 12);
+    EXPECT_STREQ(sdFormat.what(), "test 12");
+}
+
+TEST(FLAMEGPUExceptionTest, exception_type) {
+    // Test that the exception type behaves as intended
+    flamegpu::exception::CUDAError ce;
+    EXPECT_STREQ(ce.exception_type(), "CUDAError");
+
+    flamegpu::exception::ReservedName rn;
+    EXPECT_STREQ(rn.exception_type(), "ReservedName");
+}
+
+TEST(FLAMEGPUExceptionTest, setLocation) {
+    // Test setting line and file mutates .waht
+    const char* f = __FILE__;
+    unsigned int l = __LINE__;
+    const char * m = "test";
+    flamegpu::exception::FLAMEGPUException::setLocation(f, l);
+    flamegpu::exception::CUDAError ce(m);
+    std::string expected_what = std::string(f) + "(" + std::to_string(l) + "): " + m;
+    EXPECT_STREQ(ce.what(), expected_what.c_str());
+}
+
+// Define a new class extending FALMEGPUException which does not take a default_message in the constructor.
+
+}  // namespace test_flamegpu_exception
+}  // namespace flamegpu

--- a/tests/test_cases/model/test_environment_description.cu
+++ b/tests/test_cases/model/test_environment_description.cu
@@ -431,7 +431,8 @@ TEST(EnvironmentDescriptionTest, ExceptionPropertyRange_uint64_t) {
 }
 #ifdef FLAMEGPU_USE_GLM
 TEST(EnvironmentDescriptionTest, Exception_array_glm) {
-    EnvironmentDescription ed;
+    ModelDescription model("test");
+    EnvironmentDescription ed = model.Environment();
     std::array<float, 15> b;
     ed.newProperty<float, 15>("a", b);
     {


### PR DESCRIPTION
Remove casting of va_list to bool which does not appear to be present in gcc/glibc on ubuntu 20.04 for nvidia tegra's with GCC 9 (issue #1038)

Adds some tests for FLAMEGPUException to ensure that the removal does not cause errors.

```
./bin/Release/tests --gtest_filter="FLAMEGPUExceptionTest.*"
Running main() from /home/ptheywood/code/flamegpu/FLAMEGPU2/tests/helpers/main.cu
Note: Google Test filter = FLAMEGPUExceptionTest.*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from FLAMEGPUExceptionTest
[ RUN      ] FLAMEGPUExceptionTest.message
[       OK ] FLAMEGPUExceptionTest.message (0 ms)
[ RUN      ] FLAMEGPUExceptionTest.exception_type
[       OK ] FLAMEGPUExceptionTest.exception_type (0 ms)
[ RUN      ] FLAMEGPUExceptionTest.setLocation
[       OK ] FLAMEGPUExceptionTest.setLocation (0 ms)
[----------] 3 tests from FLAMEGPUExceptionTest (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.
```