### PR TITLE
Visualisation: Add support for configuring orthographic projection.

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
-set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "flamegpu-2.0.0-rc")
+set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "79e913be8c9c65011ee7d6b5c793e1940a696ce8")
 set(DEFAULT_FLAMEGPU_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # Set a VISUSLAITION_ROOT cache entry so it is available in the GUI to override the location if required

--- a/examples/cpp/game_of_life/src/main.cu
+++ b/examples/cpp/game_of_life/src/main.cu
@@ -122,6 +122,8 @@ int main(int argc, const char ** argv) {
         visualisation.setInitialCameraLocation(SQRT_AGENT_COUNT / 2.0f, SQRT_AGENT_COUNT / 2.0f, 450.0f);
         visualisation.setInitialCameraTarget(SQRT_AGENT_COUNT / 2.0f, SQRT_AGENT_COUNT / 2.0f, 0.0f);
         visualisation.setCameraSpeed(0.001f * SQRT_AGENT_COUNT);
+        visualisation.setOrthographic(true);
+        visualisation.setOrthographicZoomModifier(1.409f);
         visualisation.setViewClips(0.01f, 2500);
         visualisation.setClearColor(0.6f, 0.6f, 0.6f);
         auto agt = visualisation.addAgent("cell");

--- a/examples/cpp/sugarscape/src/main.cu
+++ b/examples/cpp/sugarscape/src/main.cu
@@ -369,7 +369,10 @@ int main(int argc, const char ** argv) {
         visualisation.setInitialCameraLocation(GRID_WIDTH / 2.0f, GRID_HEIGHT / 2.0f, 225.0f);
         visualisation.setInitialCameraTarget(GRID_WIDTH / 2.0f, GRID_HEIGHT /2.0f, 0.0f);
         visualisation.setCameraSpeed(0.001f * GRID_WIDTH);
+        visualisation.setOrthographic(true);
+        visualisation.setOrthographicZoomModifier(0.365f);
         visualisation.setViewClips(0.1f, 5000);
+
         auto agt = visualisation.addAgent("agent");
         // Position vars are named x, y, z; so they are used by default
         agt.setModel(flamegpu::visualiser::Stock::Models::CUBE);  // 5 unwanted faces!

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -181,6 +181,23 @@ class ModelVis {
      */
     void setViewClips(const float &nearClip, const float &farClip);
     /**
+     * Sets whether the visualisation should use an orthographic (or perspective) projection
+     * This value defaults to false
+     *
+     * Orthographic projection can be toggled during the visualisation by pressing 'F9'
+     * Orthographic projection is used for 2D models, whereby depth should not affect scale
+     * @param isOrtho True if the visualisation should use an orthographic projection
+     */
+    void setOrthographic(const bool& isOrtho);
+    /**
+     * Sets initial zoom modifier for the orthographic projection
+     * This value defaults to 1.0
+     * This setting has no impact on perspective projection mode
+     * This value must be greater than 0.001, which is the maximum/closest zoom supported.
+     * @param zoomMod The initial zoom modifier
+     */
+    void setOrthographicZoomModifier(const float& zoomMod);
+    /**
 	 * Sets the Step count overlay as visible or not
 	 * This value defaults to true
 	 * @param showStep True if the count should be shown

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -197,6 +197,13 @@ void ModelVis::setViewClips(const float &nearClip, const float &farClip) {
     data->modelCfg.nearFarClip[1] = farClip;
 }
 
+void ModelVis::setOrthographic(const bool& isOrtho) {
+    data->modelCfg.isOrtho = isOrtho;
+}
+void ModelVis::setOrthographicZoomModifier(const float& zoomMod) {
+    data->modelCfg.orthoZoom = zoomMod;
+}
+
 void ModelVis::setStepVisible(const bool& showStep) {
     data->modelCfg.stepVisible = showStep;
 }


### PR DESCRIPTION
Update SugarScape/GameOfLife examples to use orthographic projection.

This will also fold in the `Draw::resize()` bugfix that was recently applied to the visualiser: https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/118
