### PR TITLE
Visualiser: Allow agent states to be hidden.

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
-set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "79e913be8c9c65011ee7d6b5c793e1940a696ce8")
+set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "35b428cfa2d380c516a14648484da24720350407")
 set(DEFAULT_FLAMEGPU_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # Set a VISUSLAITION_ROOT cache entry so it is available in the GUI to override the location if required

--- a/include/flamegpu/visualiser/AgentStateVis.h
+++ b/include/flamegpu/visualiser/AgentStateVis.h
@@ -39,6 +39,10 @@ struct AgentStateVisData {
      * Holds a boolean for each option (or group of options), to decide whether they should be updated if the default is changed
      */
     AgentStateConfigFlags configFlags;
+    /**
+     * If false, rendering of the agent state will be skipped
+     */
+    bool visible = true;
 };
 
 /**
@@ -99,6 +103,12 @@ class AgentStateVis {
      * largest
      */
     void setModelScale(float maxLen);
+    /**
+     * Set whether this agent state is visible
+     * Defaults to true
+     * @param isVisible If false the agent state will not be included in the visualisation
+     */
+    void setVisible(bool isVisible);
     /**
      * Set a custom colour function
      */

--- a/src/flamegpu/visualiser/AgentStateVis.cpp
+++ b/src/flamegpu/visualiser/AgentStateVis.cpp
@@ -87,6 +87,9 @@ void AgentStateVis::clearColor() {
     data->config.tex_buffers.erase(TexBufferConfig::Color);
     data->config.color_shader_src = "";
 }
+void AgentStateVis::setVisible(bool isVisible) {
+    data->visible = isVisible;
+}
 
 }  // namespace visualiser
 }  // namespace flamegpu

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -43,8 +43,13 @@ void AgentVisData::initBindings(std::unique_ptr<FLAMEGPU_Visualisation>& vis) {
         // For each agent state, give the visualiser
         // vis config
         AgentStateConfig& vc = defaultConfig;  // Default to parent if child hasn't been configured
-        if (states.find(state) != states.end()) {
-            vc = states.at(state)->config;
+        const auto state_it = states.find(state);
+        if (state_it != states.end()) {
+            if (!state_it->second->visible) {
+                // Skip agent states marked hidden
+                continue;
+            }
+            vc = state_it->second->config;
         }
         vis->addAgentState(agentData->name, state, vc, core_tex_buffers, vc.tex_buffers);
     }
@@ -52,6 +57,13 @@ void AgentVisData::initBindings(std::unique_ptr<FLAMEGPU_Visualisation>& vis) {
 bool AgentVisData::requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation>& vis, bool force) {
     unsigned int agents_requested = 0;
     for (auto& state : agentData->states) {
+        const auto state_it = states.find(state);
+        if (state_it != states.end()) {
+            if (!state_it->second->visible) {
+                // Skip agent states marked hidden
+                continue;
+            }
+        }
         auto& state_map = agent.state_map.at(state);
         vis->requestBufferResizes(agentData->name, state, state_map->getSize(), force);
         agents_requested += state_map->getSize();
@@ -61,8 +73,13 @@ bool AgentVisData::requestBufferResizes(std::unique_ptr<FLAMEGPU_Visualisation>&
 void AgentVisData::updateBuffers(std::unique_ptr<FLAMEGPU_Visualisation>& vis) {
     for (auto& state : agentData->states) {
         AgentStateConfig& state_config = defaultConfig;  // Default to parent if child hasn't been configured
-        if (states.find(state) != states.end()) {
-            state_config = states.at(state)->config;
+        const auto state_it = states.find(state);
+        if (state_it != states.end()) {
+            if (!state_it->second->visible) {
+                // Skip agent states marked hidden
+                continue;
+            }
+            state_config = state_it->second->config;
         }
         auto& state_data_map = agent.state_map.at(state);
         // Update buffer pointers inside the map


### PR DESCRIPTION
This solution is confined to the fgpu2 main library, the visualiser is not aware of the existence of hidden agent states.

Based on Jack A's suggestion. May want to add a note in the docs too.