### PR TITLE
BugFix: ModelVis::setBeginPaused() now ensures pause is on step 0.

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
-set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "35b428cfa2d380c516a14648484da24720350407")
+set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "02097b5ca1bf38a52693e926d0d750d972a2ae80")
 set(DEFAULT_FLAMEGPU_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # Set a VISUSLAITION_ROOT cache entry so it is available in the GUI to override the location if required

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -40,7 +40,7 @@ void ModelVisData::updateBuffers(const unsigned int& sc) {
         }
         // Block the sim when we first get agents, until vis has resized buffers, incase vis is being slow to init
         if (has_agents && (sc == 0 || sc == UINT_MAX)) {
-            while (!visualiser->isReady()) {
+            while (!visualiser->buffersReady()) {
                 // Do nothing, just spin until ready
                 std::this_thread::yield();
             }
@@ -55,6 +55,13 @@ void ModelVisData::updateBuffers(const unsigned int& sc) {
             a.second->updateBuffers(visualiser);
         }
         visualiser->releaseMutex();
+        // Block the sim again, until vis is fully ready
+        if (has_agents && (sc == 0 || sc == UINT_MAX)) {
+            while (!visualiser->isReady()) {
+                // Do nothing, just spin until ready
+                std::this_thread::yield();
+            }
+        }
     }
 }
 void ModelVisData::updateRandomSeed() {


### PR DESCRIPTION
This PR will need updating to match the merged vis PR hash.