### PR TITLE
Add declare/define versions of agent/host function shims

### DIFF
--- a/include/flamegpu/runtime/AgentFunctionCondition_shim.cuh
+++ b/include/flamegpu/runtime/AgentFunctionCondition_shim.cuh
@@ -24,7 +24,6 @@ namespace flamegpu {
  * SomeAgentFunctionCondition_cdn_impl SomeAgentFunctionCondition;
  * @endcode
  */
-
 #define FLAMEGPU_AGENT_FUNCTION_CONDITION(funcName)\
 struct funcName ## _cdn_impl {\
     __device__ __forceinline__ bool operator()(flamegpu::ReadOnlyDeviceAPI *FLAMEGPU) const;\
@@ -32,6 +31,21 @@ struct funcName ## _cdn_impl {\
 };\
 funcName ## _cdn_impl funcName;\
 __device__ __forceinline__ bool funcName ## _cdn_impl::operator()(flamegpu::ReadOnlyDeviceAPI *FLAMEGPU) const
+
+/**
+ * Separate Declaration (DECL), Definition (DEF) version
+ * @note This version prevents inlining, hence should be used sparingly as it may impact performance
+ */
+#define FLAMEGPU_AGENT_FUNCTION_CONDITION_DECL(funcName)\
+struct funcName ## _cdn_impl {\
+    __device__ bool operator()(flamegpu::ReadOnlyDeviceAPI *FLAMEGPU) const;\
+    static constexpr flamegpu::AgentFunctionConditionWrapper *fnPtr() { return &flamegpu::agent_function_condition_wrapper<funcName ## _cdn_impl>; }\
+};\
+extern funcName ## _cdn_impl funcName;
+
+#define FLAMEGPU_AGENT_FUNCTION_CONDITION_DEF(funcName)\
+funcName ## _cdn_impl funcName;\
+__device__ bool funcName ## _cdn_impl::operator()(flamegpu::ReadOnlyDeviceAPI *FLAMEGPU) const
 
 }  // namespace flamegpu
 

--- a/include/flamegpu/runtime/HostAPI_macros.h
+++ b/include/flamegpu/runtime/HostAPI_macros.h
@@ -45,10 +45,15 @@ typedef FLAMEGPU_HOST_FUNCTION_POINTER FLAMEGPU_EXIT_FUNCTION_POINTER;
  * flamegpu::FLAMEGPU_HOST_FUNCTION_POINTER SomeHostFunction = SomeHostFunction_impl;
  * @endcode
  */
-#define FLAMEGPU_HOST_FUNCTION(funcName) \
+#define FLAMEGPU_HOST_FUNCTION_DECL(funcName) \
+extern flamegpu::FLAMEGPU_HOST_FUNCTION_POINTER funcName;
+
+#define FLAMEGPU_HOST_FUNCTION_DEF(funcName) \
 void funcName ## _impl(flamegpu::HostAPI* FLAMEGPU); \
-flamegpu::FLAMEGPU_HOST_FUNCTION_POINTER funcName = funcName ## _impl;\
+flamegpu::FLAMEGPU_HOST_FUNCTION_POINTER funcName = funcName ## _impl; \
 void funcName ## _impl(flamegpu::HostAPI* FLAMEGPU)
+
+#define FLAMEGPU_HOST_FUNCTION(funcName) FLAMEGPU_HOST_FUNCTION_DEF(funcName)
 
 /**
  * Return type for FLAMEGPU conditions


### PR DESCRIPTION
This makes it easier to split models across multiple compilation units.

Useful to Fujitsu model, I manually did host function declarations in Primage too but never required agent function declarations until now.

This is a relatively advanced feature (and we don't have any documentation on splitting large models), so I feel it requires documentation.

I build and ran the test suite for sanity reasons, so it should be fine.