### PR TITLE
Visualiser: Begin Paused v2

### DIFF
--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -63,6 +63,10 @@ struct ModelVisData {
      */
     bool env_registered = false;
     /**
+     * Marked true when first agent data has been passed to vis
+     */
+    bool has_first_agents = true;
+    /**
      * Updates all agent renders from corresponding
      * @param sc Step count, the step count value shown in visualisation HUD
      */

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -34,12 +34,16 @@ void ModelVisData::registerEnvProperties() {
 }
 void ModelVisData::updateBuffers(const unsigned int& sc) {
     if (visualiser) {
-        bool has_agents = false;
+        bool _has_first_agents = false;
         for (auto& a : agents) {
-            has_agents = a.second->requestBufferResizes(visualiser, sc == 0 || sc == UINT_MAX) || has_agents;
+            _has_first_agents = a.second->requestBufferResizes(visualiser, sc == 0 || sc == UINT_MAX) || _has_first_agents;
+        }
+        if (_has_first_agents) {
+            _has_first_agents = !this->has_first_agents;
+            this->has_first_agents = true;
         }
         // Block the sim when we first get agents, until vis has resized buffers, incase vis is being slow to init
-        if (has_agents && (sc == 0 || sc == UINT_MAX)) {
+        if (_has_first_agents) {
             while (!visualiser->buffersReady()) {
                 // Do nothing, just spin until ready
                 std::this_thread::yield();
@@ -56,7 +60,7 @@ void ModelVisData::updateBuffers(const unsigned int& sc) {
         }
         visualiser->releaseMutex();
         // Block the sim again, until vis is fully ready
-        if (has_agents && (sc == 0 || sc == UINT_MAX)) {
+        if (_has_first_agents) {
             while (!visualiser->isReady()) {
                 // Do nothing, just spin until ready
                 std::this_thread::yield();
@@ -135,6 +139,7 @@ void ModelVis::_activate() {
             agent.second->initBindings(data->visualiser);
         }
         data->env_registered = false;
+        data->has_first_agents = false;
         data->registerEnvProperties();
         data->visualiser->start();
     }


### PR DESCRIPTION
Tweaks visualiser begin paused behaviour, so that it begins paused on the first step with agents.

The changes so far, cause it to pause the step after agents are created (if created in a step function), need to check that agent creation can be moved so this is affected earlier.

Closes https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/issues/122