### PR TITLE
BugFix: Message buildIndex() before buffer init.

### DIFF
--- a/src/flamegpu/runtime/messaging/MessageBucket.cu
+++ b/src/flamegpu/runtime/messaging/MessageBucket.cu
@@ -101,6 +101,11 @@ void MessageBucket::CUDAModelHandler::buildIndex(detail::CUDAScatter &scatter, u
     flamegpu::util::nvtx::Range range{"MessageBucket::CUDAModelHandler::buildIndex"};
     // Cuda operations all occur within the stream, so only a final sync is required.s
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    if (!MESSAGE_COUNT) {
+        gpuErrchk(cudaMemsetAsync(hd_data.PBM, 0x00000000, (bucketCount + 1) * sizeof(unsigned int), stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+        return;
+    }
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram
         gpuErrchk(cudaMemsetAsync(d_histogram, 0x00000000, (bucketCount + 1) * sizeof(unsigned int), stream));

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -107,6 +107,11 @@ void MessageSpatial2D::CUDAModelHandler::freeMetaDataDevicePtr() {
 void MessageSpatial2D::CUDAModelHandler::buildIndex(detail::CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
     flamegpu::util::nvtx::Range range{"MessageSpatial2D::CUDAModelHandler::buildIndex"};
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    if (!MESSAGE_COUNT) {
+        gpuErrchk(cudaMemsetAsync(hd_data.PBM, 0x00000000, (binCount + 1) * sizeof(unsigned int), stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+        return;
+    }
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram
         gpuErrchk(cudaMemsetAsync(d_histogram, 0x00000000, (binCount + 1) * sizeof(unsigned int), stream));

--- a/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
@@ -106,6 +106,11 @@ void MessageSpatial3D::CUDAModelHandler::freeMetaDataDevicePtr() {
 void MessageSpatial3D::CUDAModelHandler::buildIndex(detail::CUDAScatter &scatter, unsigned int streamId, cudaStream_t stream) {
     flamegpu::util::nvtx::Range range{"MessageSpatial3D::CUDAModelHandler::buildIndex"};
     const unsigned int MESSAGE_COUNT = this->sim_message.getMessageCount();
+    if (!MESSAGE_COUNT) {
+        gpuErrchk(cudaMemsetAsync(hd_data.PBM, 0x00000000, (binCount + 1) * sizeof(unsigned int), stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+        return;
+    }
     resizeKeysVals(this->sim_message.getMaximumListSize());  // Resize based on allocated amount rather than message count
     {  // Build atomic histogram
         gpuErrchk(cudaMemsetAsync(d_histogram, 0x00000000, (binCount + 1) * sizeof(unsigned int), stream));

--- a/tests/test_cases/runtime/environment/test_device_environment.cu
+++ b/tests/test_cases/runtime/environment/test_device_environment.cu
@@ -503,7 +503,7 @@ FLAMEGPU_AGENT_FUNCTION(get_array_glm, MessageNone, MessageNone) {
 TEST_F(DeviceEnvironmentTest, Get_array_glm) {
     // Setup agent fn
     ms->agent.newVariable<glm::vec3>("k");
-    AgentFunctionDescription& deviceFn = ms->agent.newFunction("device_function", get_array_glm);
+    AgentFunctionDescription deviceFn = ms->agent.newFunction("device_function", get_array_glm);
     LayerDescription devicefn_layer = ms->model.newLayer("devicefn_layer");
     devicefn_layer.addAgentFunction(deviceFn);
     // Setup environment

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -911,6 +911,58 @@ TEST(Spatial2DMessageTest, Wrapped_OutOfBounds) {
 #else
 TEST(Spatial2DMessageTest, DISABLED_Wrapped_OutOfBounds) { }
 #endif
+FLAMEGPU_AGENT_FUNCTION(out_mandatory2D_OddStep, MessageNone, MessageSpatial2D) {
+    if (FLAMEGPU->getStepCounter() % 2 == 0) {
+        FLAMEGPU->message_out.setLocation(
+            FLAMEGPU->getVariable<float>("x"),
+            FLAMEGPU->getVariable<float>("y"));
+    }
+    return ALIVE;
+}
+FLAMEGPU_HOST_FUNCTION(create_agents_step_zero) {
+    if (FLAMEGPU->getStepCounter() == 1) {
+        auto agent = FLAMEGPU->agent("agent");
+        std::mt19937_64 rng;
+        std::uniform_real_distribution<float> dist(0.0f, 5.0f);
+        for (unsigned int i = 0; i < 2049; ++i) {
+            auto instance = agent.newAgent();
+            float pos[2] = { dist(rng), dist(rng) };
+            instance.setVariable<float>("x", pos[0]);
+            instance.setVariable<float>("y", pos[1]);
+        }
+    }
+}
+TEST(Spatial2DMessageTest, buffer_not_init) {
+    // This tests that a bug is fixed
+    // The bug occurred when a message list, yet to have messages output to it was used as a message input
+    // This requires no agents at the first message output function during the second iteration
+    // It does 4 iterations to ensure PBM is reset too.
+    ModelDescription m("model");
+    MessageSpatial2D::Description message = m.newMessage<MessageSpatial2D>("location");
+    message.setMin(0, 0);
+    message.setMax(5, 5);
+    message.setRadius(1);
+    AgentDescription agent = m.newAgent("agent");
+    agent.newVariable<float>("x");
+    agent.newVariable<float>("y");
+    agent.newVariable<unsigned int>("count");  // Store the distance moved here, for validation
+    agent.newVariable<unsigned int>("badCount");  // Store how many messages are out of range
+    AgentFunctionDescription fo = agent.newFunction("out", out_mandatory2D_OddStep);
+    fo.setMessageOutput(message);
+    fo.setMessageOutputOptional(true);
+    AgentFunctionDescription fi = agent.newFunction("in", in2D);
+    fi.setMessageInput(message);
+    LayerDescription lo = m.newLayer();
+    lo.addAgentFunction(fo);
+    LayerDescription la = m.newLayer();
+    la.addHostFunction(create_agents_step_zero);
+    LayerDescription li = m.newLayer();
+    li.addAgentFunction(fi);
+    // Set pop in model
+    CUDASimulation c(m);
+    c.SimulationConfig().steps = 4;
+    EXPECT_NO_THROW(c.simulate());
+}
 
 }  // namespace test_message_spatial2d
 }  // namespace flamegpu


### PR DESCRIPTION
I don't think it impacts array messages (they have fixed allocation) or brute force (doesn't use `buildIndex()`).

I added tests because it's quite the edge-case to hit this bug.

Closes #1054