### PR TITLE
CUDA 12 stream destruction fix for multi-gpu systems

### DIFF
--- a/include/flamegpu/simulation/CUDASimulation.h
+++ b/include/flamegpu/simulation/CUDASimulation.h
@@ -1,5 +1,8 @@
 #ifndef INCLUDE_FLAMEGPU_SIMULATION_CUDASIMULATION_H_
 #define INCLUDE_FLAMEGPU_SIMULATION_CUDASIMULATION_H_
+
+#include <cuda.h>
+
 #include <atomic>
 #include <memory>
 #include <vector>
@@ -618,6 +621,16 @@ class CUDASimulation : public Simulation {
      * @param _model The agent model hierarchy to check
      */
     static bool detectPureRTC(const std::shared_ptr<const ModelData>& _model);
+
+#if __CUDACC_VER_MAJOR__ >= 12
+    /**
+     * The unique ID for the CUDA context used for stream creation for this instance. This is only available in CUDA 12+.
+     * This is used to ensure that streams can safely be destroyed in CUDA 12, even if the device has been reset.
+     * Cannot just use the CUcontext itself, as the handle is the same for the primary context after a reset, and the existing CUDA 11 check on the context being the active primary context no longer prevents issues in CUDA 12 for multi-gpu machines. 
+     * Cannot use cuStream querying methods, as it is UB to specify an invalid stream to these methods, resulting in segfaults
+     */
+    std::uint64_t cudaContextID;
+#endif  // __CUDACC_VER_MAJOR__ >= 12
 
  protected:
     /**

--- a/src/flamegpu/util/cleanup.cu
+++ b/src/flamegpu/util/cleanup.cu
@@ -8,13 +8,18 @@ namespace flamegpu {
 namespace util {
 
 void cleanup() {
+    int originalDevice = 0;
+    gpuErrchk(cudaGetDevice(&originalDevice));
     // Reset all cuda devices for memcheck / profiling purposes.
     int devices = 0;
     gpuErrchk(cudaGetDeviceCount(&devices));
+    // @todo - this would be better to be only devices touched by flamegpu since the last call to cleanup.
     for (int device = 0; device < devices; ++device) {
         gpuErrchk(cudaSetDevice(device));
         gpuErrchk(cudaDeviceReset());
     }
+    // resume the old device, but do not create a new context via reset or memsets
+    gpuErrchk(cudaSetDevice(originalDevice));
 }
 
 void clearRTCDiskCache() {


### PR DESCRIPTION
When using CUDA 12.x in a multi-gpu system, an interaction between `flamegpu::cleanup()` and `cudaDestroyStreams` during `~CUDASimulation()` was casuing exceptions to be thrown.

+ CUDA streams are only valid in the context which was used to create them
+ CUDA runtime and driver API methods to query a streams context / status all include UB when passing an invalid stream handle, leading to segfaults
+ A CUDA 11.x detection for the context no longer being valid by checking the primary context with the driver API does not successfully prevent the UB being triggered in CUDA 12.x in a multi-gpu system.
+ `CUcontext` can/will return the same handle after a reset, so we cannot "remember" the context that way, but CUDA 12 introduces a method which allows us to compare a unique `unsigned long long int` which can be used to check the context is a match.
+ Also ensures cleanup re-selects the original device at the time of the call, just in case (even though any existing contexts would no longer be valid). 

No new tests are required, the existing cleanup tests triggered the issue with multi-gpu + CUDA 12.

Closes #1053 

Tested in a multi-gpu linux system with CUDA 11.0, 11.8 and 12.0 with different `CUDA_VISIBLE_DEVICES` values and on a single GPU system with CUDA 12.0. 