### PR TITLE
Add Poisson distribution support to Host/Agent random API.

### DIFF
--- a/include/flamegpu/runtime/random/AgentRandom.cuh
+++ b/include/flamegpu/runtime/random/AgentRandom.cuh
@@ -43,6 +43,12 @@ class AgentRandom {
     template<typename T>
     __forceinline__ __device__ T logNormal(T mean, T stddev) const;
     /**
+     * Returns a poisson distributed unsigned int according to the provided mean (default 1.0).
+     * @param mean The mean of the distribution
+     * @note This implementation uses CURAND's "simple Device API" which is considered the least robust but is more efficient when generating Poisson-distributed random numbers for many different lambdas.
+     */
+    __forceinline__ __device__ unsigned int poisson(double mean = 1.0f) const;
+    /**
      * Returns an integer uniformly distributed in the inclusive range [min, max]
      * or
      * Returns a floating point value uniformly distributed in the exclusive-inclusive range (min, max]
@@ -109,6 +115,12 @@ __forceinline__ __device__ float AgentRandom::logNormal(const float mean, const 
 template<>
 __forceinline__ __device__ double AgentRandom::logNormal(const double mean, const double stddev) const {
     return curand_log_normal_double(d_random_state, mean, stddev);
+}
+/**
+ * Poisson
+ */
+__forceinline__ __device__ unsigned int AgentRandom::poisson(const double mean) const {
+    return curand_poisson(d_random_state, mean);
 }
 /**
 * Uniform Range

--- a/include/flamegpu/runtime/random/HostRandom.cuh
+++ b/include/flamegpu/runtime/random/HostRandom.cuh
@@ -40,6 +40,13 @@ class HostRandom {
     template<typename T>
     inline T logNormal(T mean, T stddev) const;
     /**
+     * Returns a poisson distributed unsigned int according to the provided mean (default 1.0).
+     * @param mean The mean of the distribution
+     * @note Available as signed and unsigned: char, short, int, long long (default unsigned int)
+     */
+    template<typename T = unsigned int>
+    inline unsigned int poisson(double mean = 1.0f) const;
+    /**
      * Returns an integer uniformly distributed in the inclusive range [min, max]
      * or
      * Returns a floating point value uniformly distributed in the inclusive-exclusive range [min, max)
@@ -90,6 +97,13 @@ template<typename T>
 inline T HostRandom::uniform(const T min, const T max) const {
     static_assert(detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for HostRandom::uniform(T lowerBound, T max)");
     std::uniform_int_distribution<T> dist(min, max);
+    return rng.getDistribution<T>(dist);
+}
+
+template<typename T>
+inline unsigned int HostRandom::poisson(const double mean) const {
+    static_assert(detail::StaticAssert::_Is_IntType<T>::value, "Invalid template argument for HostRandom::poisson(double mean)");
+    std::poisson_distribution<T> dist(mean);
     return rng.getDistribution<T>(dist);
 }
 

--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -967,6 +967,9 @@ TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(uniform, flamegpu::HostRandom::uniformNoRan
 TEMPLATE_VARIABLE_INSTANTIATE_INTS(uniform, flamegpu::HostRandom::uniformRange)
 TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(normal, flamegpu::HostRandom::normal)
 TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(logNormal, flamegpu::HostRandom::logNormal)
+TEMPLATE_VARIABLE_INSTANTIATE_INTS(poisson, flamegpu::HostRandom::poisson)
+// Default typeless should be unsigned int
+%template(poisson) flamegpu::HostRandom::poisson<uint32_t>;
 
 // Extend the python to add the pure python class decorators
 %pythoncode %{


### PR DESCRIPTION
Note: Only the least robust curand version is supported (others require extra data/host operations).

Max said this would be useful.

Docs needs updating too:
* https://docs.flamegpu.com/guide/agent-functions/random-numbers.html
* https://docs.flamegpu.com/guide/host-functions/random-numbers.html