### PR TITLE
CMake Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ cmake --build . --target all
 | `FLAMEGPU_SHARE_USAGE_STATISTICS`    | `ON`/`OFF`                  | Share usage statistics ([telemetry](https://docs.flamegpu.com/guide/telemetry)) to support evidencing usage/impact of the software. Default `ON`. |
 | `FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE` | `ON`/`OFF`                  | Suppress notice encouraging telemetry to be enabled, which is emitted once per binary execution if telemetry is disabled. Defaults to `OFF`, or the value of a system environment variable of the same name. |
 | `FLAMEGPU_TELEMETRY_TEST_MODE`       | `ON`/`OFF`                  | Submit telemetry values to the test mode of TelemetryDeck. Intended for use during development of FLAMEGPU rather than use. Defaults to `OFF`, or the value of a system environment variable of the same name.|
+| `FLAMEGPU_ENABLE_LINT_FLAMEGPU`      | `ON`/`OFF`                  | Enable/Disable creation of the `lint_flamegpu` target. Default `ON` if this repository is the root CMAKE_SOURCE_DIR, otherwise `OFF` |
 
 <!-- Additional options which users can find if they need them.
 | `FLAMEGPU_BUILD_API_DOCUMENTATION` | `ON`/`OFF` | Build the documentation target. Default `ON` |

--- a/cmake/cpplint.cmake
+++ b/cmake/cpplint.cmake
@@ -81,7 +81,7 @@ function(flamegpu_new_linter_target NAME SRC)
     endif()
     # Add the lint_ target
     add_custom_target(
-        "lint_${PROJECT_NAME}"
+        "lint_${NAME}"
         COMMAND ${CPPLINT_EXECUTABLE} ${CPPLINT_ARGS}
         ${SRC}
     )
@@ -95,6 +95,6 @@ function(flamegpu_new_linter_target NAME SRC)
     # Put within Lint filter
     if (CMAKE_USE_FOLDERS)
         set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-        set_property(TARGET "lint_${PROJECT_NAME}" PROPERTY FOLDER "Lint")
+        set_property(TARGET "lint_${NAME}" PROPERTY FOLDER "Lint")
     endif ()
 endfunction()

--- a/cmake/dependencies/doxygen.cmake
+++ b/cmake/dependencies/doxygen.cmake
@@ -2,7 +2,12 @@
 find_package(Doxygen OPTIONAL_COMPONENTS mscgen dia dot)
 if(DOXYGEN_FOUND)
     include(CMakeDependentOption)
-    option(FLAMEGPU_BUILD_API_DOCUMENTATION "Enable building documentation (requires Doxygen)" ON)
+    set(FLAMEGPU_BUILD_API_DOCUMENTATION_DEFAULT OFF)
+    if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}" OR "${CMAKE_SOURCE_DIR}" STREQUAL "${FLAMEGPU_ROOT}")
+        set(FLAMEGPU_BUILD_API_DOCUMENTATION_DEFAULT ON)
+    endif()
+    option(FLAMEGPU_BUILD_API_DOCUMENTATION "Enable building documentation (requires Doxygen)" ${FLAMEGPU_BUILD_API_DOCUMENTATION_DEFAULT})
+
     # option to hide / not hide the detail namespace from the docs, developers can enable it if they want detail docs / the actual docs website might require this due to breathe/exhale not respecting doxygen exclude correctly and not having an equivalent option.
     cmake_dependent_option(FLAMEGPU_API_DOCUMENTATION_EXCLUDE_DETAIL "Exclude the detail namespace from doxygen documentation" ON "FLAMEGPU_BUILD_API_DOCUMENTATION" ON)
     mark_as_advanced(FLAMEGPU_API_DOCUMENTATION_EXCLUDE_DETAIL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -407,22 +407,17 @@ SET(ALL_SRC
 )
 SET(FLAMEGPU_INCLUDE ${SRC_INCLUDE} CACHE INTERNAL "Include files required by FLAMEGPU RTC")
 
-# Setup Visual Studio (and eclipse) filters
-source_group(TREE ${FLAMEGPU_ROOT}/include/flamegpu PREFIX include FILES ${SRC_INCLUDE})
-list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
-set(T_SRC_FLAMEGPU "${SRC_FLAMEGPU}")
-list(FILTER T_SRC_FLAMEGPU INCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${FLAMEGPU_ROOT}/src/flamegpu PREFIX headers FILES ${T_SRC_FLAMEGPU})
-set(T_SRC_FLAMEGPU "${SRC_FLAMEGPU}")
-list(FILTER T_SRC_FLAMEGPU EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${FLAMEGPU_ROOT}/src/flamegpu PREFIX src FILES ${T_SRC_FLAMEGPU})
-set(T_SRC_EXTERNAL "${SRC_EXTERNAL}")
-list(FILTER T_SRC_EXTERNAL INCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${FLAMEGPU_ROOT}/include PREFIX external FILES ${T_SRC_EXTERNAL})
-set(T_SRC_EXTERNAL "${SRC_EXTERNAL}")
-list(FILTER T_SRC_EXTERNAL EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
-source_group(TREE ${FLAMEGPU_ROOT}/include PREFIX external FILES ${T_SRC_EXTERNAL})
-
+# Setup Visual Studio (and eclipse) filters, using the TREE variant separating header and source files.
+set(SRC_GROUP_TREE_COMPATIBLE_HEADERS "${ALL_SRC}")
+list(FILTER SRC_GROUP_TREE_COMPATIBLE_HEADERS INCLUDE REGEX ".*\.(h|hpp|cuh)$")
+set(SRC_GROUP_TREE_COMPATIBLE_SOURCES "${ALL_SRC}")
+list(FILTER SRC_GROUP_TREE_COMPATIBLE_SOURCES EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
+# Apply source group filters with TREE, using CMake's default "Header Files" and "Source Files" for consistency
+source_group(TREE ${FLAMEGPU_ROOT} PREFIX "Header Files" FILES ${SRC_GROUP_TREE_COMPATIBLE_HEADERS})
+source_group(TREE ${FLAMEGPU_ROOT} PREFIX "Source Files" FILES ${SRC_GROUP_TREE_COMPATIBLE_SOURCES})
+# Clean up variables
+unset(SRC_GROUP_TREE_COMPATIBLE_HEADERS)
+unset(SRC_GROUP_TREE_COMPATIBLE_SOURCES)
 
 # Create the library target and set various properties
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,16 @@ option(FLAMEGPU_RTC_DISK_CACHE "Enable caching of RTC kernels to disk by default
 # Option to enable/disable logging of dynamic RTC files to disk
 option(FLAMEGPU_RTC_EXPORT_SOURCES "Export RTC source files to disk at runtime" OFF)
 
+# Option to enable / disable linting of the flamegpu target by default, so repos which consume this repository via add_subdir do not create the lint_flamegpu target or include it in all_lint by default.
+# Defaults to OFF unless this, or FLAMEGPU_ROOT is the top level project.
+# cmake_dependent option wouldn't cooperate.
+set(FLAMEGPU_ENABLE_LINT_FLAMEGPU_DEFAULT OFF)
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}" OR "${CMAKE_SOURCE_DIR}" STREQUAL "${FLAMEGPU_ROOT}")
+    set(FLAMEGPU_ENABLE_LINT_FLAMEGPU_DEFAULT ON)
+endif()
+option(FLAMEGPU_ENABLE_LINT_FLAMEGPU "Enable creation of the lint_flamegpu target" ${FLAMEGPU_ENABLE_LINT_FLAMEGPU_DEFAULT})
+unset(FLAMEGPU_ENABLE_LINT_FLAMEGPU_DEFAULT)
+
 # Option to make put glm on the include path
 option(FLAMEGPU_ENABLE_GLM "Experimental: Make GLM available to flamegpu2 projects on the include path" OFF)
 mark_as_advanced(FLAMEGPU_ENABLE_GLM)
@@ -588,13 +598,15 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 
-# Flag the new linter target and the files to be linted. Ensure vis sources are linted even if vis is not enabled (mostly for CI)
-if (FLAMEGPU_VISUALISATION)
-    # If vis is enabled, just use ALL_SRC
-    flamegpu_new_linter_target(${PROJECT_NAME} "${ALL_SRC}")
-else()
-    # If vis is not enabled, pass in the vis source files too.
-    flamegpu_new_linter_target(${PROJECT_NAME} "${ALL_SRC};${SRC_INCLUDE_VISUALISER};${SRC_FLAMEGPU_VISUALISER}")
+# Flag the new linter target and the files to be linted, if enabled. Ensure vis sources are linted even if vis is not enabled (mostly for CI)
+if(FLAMEGPU_ENABLE_LINT_FLAMEGPU)
+    if (FLAMEGPU_VISUALISATION)
+        # If vis is enabled, just use ALL_SRC
+        flamegpu_new_linter_target(${PROJECT_NAME} "${ALL_SRC}")
+    else()
+        # If vis is not enabled, pass in the vis source files too.
+        flamegpu_new_linter_target(${PROJECT_NAME} "${ALL_SRC};${SRC_INCLUDE_VISUALISER};${SRC_FLAMEGPU_VISUALISER}")
+    endif()
 endif()
 # Put within FLAMEGPU filter
 flamegpu_set_target_folder(${PROJECT_NAME} "FLAMEGPU")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -426,8 +426,6 @@ source_group(TREE ${FLAMEGPU_ROOT}/include PREFIX external FILES ${T_SRC_EXTERNA
 
 # Create the library target and set various properties
 
-# @todo - correctly set PUBLIC/PRIVATE/INTERFACE for the flamegpu library target
-
 # Define which source files are required for the target executable
 add_library(${PROJECT_NAME} STATIC ${ALL_SRC})
 


### PR DESCRIPTION
A number of fixes and additions to FLAMEGPU2's CMake encountered when working on a more complex tempalte model.

+ [x] `flamegpu_new_linter_target` fix. Closes #1057 
+ [x] Make the `lint_flamegpu` target OFF by default when this repo is not he primary CMake. Closes #1045 
+ [x] Make the `docs` target OFF by default when this repo is not primary
+ [x] Add `flamegpu_add_library`, for creating static libraries which are more than just linked against FLAMEGPU2 (i.e. warning levels MSVC + CUDA fixes etc. This allows the creation of unit-testable FLAMEGPU 2 simulators.
+ [x] Some Refactoring, to reduce duplication
+ [x] Demonstrate `flamegpu_add_library` in an existing example. This may not actually be desirable for merging.
+ [x] Fix `source_group` errors, Closes #1051. Tested on windows.
+ [x] Make sure that abs paths with `++` still work (I.e. check I don't break #1085 during a rebase) 