### PR TITLE
BugFix: PyNative would fail to translate math fns inside message loops.

### DIFF
--- a/swig/python/codegen/codegen.py
+++ b/swig/python/codegen/codegen.py
@@ -477,8 +477,7 @@ class CodeGenerator:
                     self.RaiseError(t, f"Message input variable '{self._input_message_var}' does not have a supported function '{t.attr}'") 
 
             # message input iterator arg
-            elif self._message_iterator_var:
-                if t.value.id == self._message_iterator_var:
+            elif self._message_iterator_var and t.value.id == self._message_iterator_var:
                     self.write(f"{self._message_iterator_var}.")
                     # check for legit FGPU function calls and translate
                     if t.attr in self.fgpu_input_msg_iter_var_funcs:     

--- a/tests/python/codegen/test_codegen.py
+++ b/tests/python/codegen/test_codegen.py
@@ -300,6 +300,16 @@ for m in message_in:
     i = m.unsupported()
 """
 
+py_fgpu_for_msg_input_math_func = """\
+for m in message_in:
+    i = math.sqrt()
+"""
+cpp_fgpu_for_msg_input_math_func = """\
+for (const auto& m : FLAMEGPU->message_in){
+    auto i = sqrt();
+}
+"""
+
 py_fgpu_for_msg_input_args = """\
 for m in message_in(x, y, z) : 
     pass
@@ -742,6 +752,8 @@ class CodeGenTest(unittest.TestCase):
         self._checkExpected(py_fgpu_for_msg_input_funcs, cpp_fgpu_for_msg_input_funcs)    
         # Test message input with unknown function
         self._checkException(py_fgpu_for_msg_input_func_unknown, "Function 'unsupported' does not exist") 
+        # Test math function inside message loop (Previously bug #1077)
+        self._checkExpected(py_fgpu_for_msg_input_math_func, cpp_fgpu_for_msg_input_math_func) 
         # Test message input where message input requires arguments (e.g. spatial messaging)
         self._checkExpected(py_fgpu_for_msg_input_args, cpp_fgpu_for_msg_input_args)
         # Test to ensure that arguments are processed as local variables 


### PR DESCRIPTION
This affected the pynative tutorial from the documentation.

The prior code

```py
            # message input iterator arg
            elif self._message_iterator_var:
                if t.value.id == self._message_iterator_var:
```
Would cause the branch to be taken if inside a message loop, but then if the message iterator var was not being used, it would break from that branch and fail to check the other conditions. Hence math and other functions inside message loops would not be translated.

Related: https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/150