### PR TITLE
CMake: Escape user-provided regex patterns.

### DIFF
--- a/cmake/EscapeRegex.cmake
+++ b/cmake/EscapeRegex.cmake
@@ -1,0 +1,7 @@
+# Define a function for escaping regex chars from strings
+# This prevents regex failures when user provided paths contain regex special chars
+function(escape_regex IN_STRING OUT_VAR)
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/18580#note_483128
+    string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" OUT_STRING "${IN_STRING}")
+    set(${OUT_VAR} "${OUT_VAR}" PARENT_SCOPE)
+endfunction()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -304,24 +304,25 @@ function(flamegpu_add_executable NAME SRC FLAMEGPU_ROOT PROJECT_ROOT IS_EXAMPLE)
     flamegpu_new_linter_target(${NAME} "${SRC}" EXCLUDE_FILTERS "${FLAMEGPU_ADD_EXECUTABLE_LINT_EXCLUDE_FILTERS}")
     
     # Setup Visual Studio (and eclipse) filters
-    #src/.h
+    #src/.h    
+    escape_regex("${CMAKE_CURRENT_SOURCE_DIR}" CURRENT_SOURCE_DIR_ESCAPE)
     set(T_SRC "${SRC}")
-    list(FILTER T_SRC INCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC INCLUDE REGEX "^${CURRENT_SOURCE_DIR_ESCAPE}/src")
     list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
     source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX headers FILES ${T_SRC})
     #src/.cpp
     set(T_SRC "${SRC}")
-    list(FILTER T_SRC INCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC INCLUDE REGEX "^${CURRENT_SOURCE_DIR_ESCAPE}/src")
     list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh)$")
     source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX src FILES ${T_SRC})
     #./.h
     set(T_SRC "${SRC}")
-    list(FILTER T_SRC EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC EXCLUDE REGEX "^${CURRENT_SOURCE_DIR_ESCAPE}/src")
     list(FILTER T_SRC INCLUDE REGEX ".*\.(h|hpp|cuh)$")
     source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX headers FILES ${T_SRC})
     #./.cpp
     set(T_SRC "${SRC}")
-    list(FILTER T_SRC EXCLUDE REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/src")
+    list(FILTER T_SRC EXCLUDE REGEX "^${CURRENT_SOURCE_DIR_ESCAPE}/src")
     list(FILTER T_SRC EXCLUDE REGEX ".*\.(h|hpp|cuh|rc)$")
     source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX src FILES ${T_SRC})
 

--- a/cmake/cpplint.cmake
+++ b/cmake/cpplint.cmake
@@ -2,6 +2,7 @@
 include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/SetTargetFolder.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/EscapeRegex.cmake)
 
 # Find CPPLINT, storing in a variable CPPLINT_EXECUTABLE
 find_file(CPPLINT_EXECUTABLE NAMES cpplint cpplint.exe)
@@ -49,7 +50,8 @@ function(flamegpu_new_linter_target NAME SRC)
         "EXCLUDE_FILTERS"
         ${ARGN})
     # Don't lint external files
-    list(FILTER SRC EXCLUDE REGEX "^${FLAMEGPU_ROOT}/externals/.*")
+    escape_regex("${FLAMEGPU_ROOT}" FLAMEGPU_ROOT_ESCAPE)
+    list(FILTER SRC EXCLUDE REGEX "^${FLAMEGPU_ROOT_ESCAPE}/externals/.*")
     # Don't lint user provided list of regular expressions.
     foreach(EXCLUDE_FILTER ${NEW_LINTER_TARGET_EXCLUDE_FILTERS})
         list(FILTER SRC EXCLUDE REGEX "${EXCLUDE_FILTER}")


### PR DESCRIPTION
Closes #1071 (See issue for fix commentary)