### PR TITLE
Environment Macro Property IO

### DIFF
--- a/include/flamegpu/io/JSONStateReader.h
+++ b/include/flamegpu/io/JSONStateReader.h
@@ -3,13 +3,8 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <utility>
-#include <vector>
 
 #include "flamegpu/io/StateReader.h"
-#include "flamegpu/model/ModelDescription.h"
-#include "flamegpu/util/StringPair.h"
 
 namespace flamegpu {
 namespace io {
@@ -20,33 +15,12 @@ namespace io {
 class JSONStateReader : public StateReader {
  public:
     /**
-     * Constructs a reader capable of reading model state from JSON files
-     * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
-     * Agent data will be read into 'model_state'
-     * @param model_name Name from the model description hierarchy of the model to be loaded
-     * @param env_desc Environment description for validating property data on load
-     * @param env_init Dictionary of loaded values map:<name, value>
-     * @param macro_env_desc Macro environment description for validating property data on load
-     * @param macro_env_init Dictionary of loaded values map:<name, value>
-     * @param model_state Map of AgentVector to load the agent data into per agent, key should be agent name
-     * @param input_file Filename of the input file (This will be used to determine which reader to return)
-     * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
-     */
-    JSONStateReader(
-        const std::string &model_name,
-        const std::unordered_map<std::string, EnvironmentData::PropData> &env_desc,
-        std::unordered_map<std::string, detail::Any> &env_init,
-        const std::unordered_map<std::string, EnvironmentData::MacroPropData> &macro_env_desc,
-        std::unordered_map<std::string, std::vector<char>> &macro_env_init,
-        util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
-        const std::string &input_file,
-        Simulation *sim_instance);
-    /**
-     * Actual performs the XML parsing to load the model state
-     * @return Always 0
-     * @throws exception::RapidJSONError If parsing of the input file fails
-     */
-    int parse() override;
+    * Loads the specified XML file to an internal data-structure 
+    * @param input_file Path to file to be read
+    * @param model Model description to ensure file loaded is suitable
+    * @param verbosity Verbosity level to use during load
+    */
+    void parse(const std::string &input_file, const std::shared_ptr<const ModelData> &model, Verbosity verbosity) override;
 };
 }  // namespace io
 }  // namespace flamegpu

--- a/include/flamegpu/io/JSONStateReader.h
+++ b/include/flamegpu/io/JSONStateReader.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "flamegpu/io/StateReader.h"
 #include "flamegpu/model/ModelDescription.h"
@@ -24,7 +25,9 @@ class JSONStateReader : public StateReader {
      * Agent data will be read into 'model_state'
      * @param model_name Name from the model description hierarchy of the model to be loaded
      * @param env_desc Environment description for validating property data on load
-     * @param env_init Dictionary of loaded values map:<{name, index}, value>
+     * @param env_init Dictionary of loaded values map:<name, value>
+     * @param macro_env_desc Macro environment description for validating property data on load
+     * @param macro_env_init Dictionary of loaded values map:<name, value>
      * @param model_state Map of AgentVector to load the agent data into per agent, key should be agent name
      * @param input_file Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -32,7 +35,9 @@ class JSONStateReader : public StateReader {
     JSONStateReader(
         const std::string &model_name,
         const std::unordered_map<std::string, EnvironmentData::PropData> &env_desc,
-        std::unordered_map<std::string, detail::Any>&env_init,
+        std::unordered_map<std::string, detail::Any> &env_init,
+        const std::unordered_map<std::string, EnvironmentData::MacroPropData> &macro_env_desc,
+        std::unordered_map<std::string, std::vector<char>> &macro_env_init,
         util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
         const std::string &input_file,
         Simulation *sim_instance);

--- a/include/flamegpu/io/JSONStateWriter.h
+++ b/include/flamegpu/io/JSONStateWriter.h
@@ -52,7 +52,7 @@ class JSONStateWriter : public StateWriter {
     void writeConfig(const Simulation *sim_instance) override;
     void writeStats(unsigned int iterations) override;
     void writeEnvironment(const std::shared_ptr<const detail::EnvironmentManager>& env_manager) override;
-    void writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env) override;
+    void writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env, std::initializer_list<std::string> filter = {}) override;
     void writeAgents(const util::StringPairUnorderedMap<std::shared_ptr<const AgentVector>>& agents_map) override;
 
  private:

--- a/include/flamegpu/io/JSONStateWriter.h
+++ b/include/flamegpu/io/JSONStateWriter.h
@@ -10,6 +10,9 @@
 #include "flamegpu/util/StringPair.h"
 
 namespace flamegpu {
+namespace detail {
+class CUDAMacroEnvironment;
+}
 namespace io {
 /**
  * JSON format StateWriter
@@ -22,6 +25,7 @@ class JSONStateWriter : public StateWriter {
      * @param model_name Name from the model description hierarchy of the model to be exported
      * @param env_manager Environment manager containing env property data for this sim instance
      * @param model_state Map of AgentVector to read the agent data from per agent, key should be agent name
+     * @param macro_env Macro environment of the model
      * @param iterations The value from the step counter at the time of export.
      * @param output_file Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -30,6 +34,7 @@ class JSONStateWriter : public StateWriter {
         const std::string &model_name,
         const std::shared_ptr<detail::EnvironmentManager>& env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
+        std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env,
         unsigned int iterations,
         const std::string &output_file,
         const Simulation *sim_instance);

--- a/include/flamegpu/io/StateReader.h
+++ b/include/flamegpu/io/StateReader.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "flamegpu/util/StringPair.h"
 #include "flamegpu/model/EnvironmentData.h"
@@ -29,7 +30,9 @@ class StateReader {
      * Agent data will be read into 'model_state'
      * @param _model_name Name from the model description hierarchy of the model to be loaded
      * @param _env_desc Environment description for validating property data on load
-     * @param _env_init Dictionary of loaded values map:<{name, index}, value>
+     * @param _env_init Dictionary of loaded values map:<name, value>
+     * @param _macro_env_desc Macro environment description for validating property data on load
+     * @param _macro_env_init Dictionary of loaded values map:<name, value>
      * @param _model_state Map of AgentVector to load the agent data into per agent, key should be agent name
      * @param input Filename of the input file (This will be used to determine which reader to return)
      * @param _sim_instance Instance of the simulation (for configuration data IO)
@@ -38,6 +41,8 @@ class StateReader {
         const std::string& _model_name,
         const std::unordered_map<std::string, EnvironmentData::PropData>& _env_desc,
         std::unordered_map<std::string, detail::Any>& _env_init,
+        const std::unordered_map<std::string, EnvironmentData::MacroPropData>& _macro_env_desc,
+        std::unordered_map<std::string, std::vector<char>>& _macro_env_init,
         util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& _model_state,
         const std::string& input,
         Simulation* _sim_instance)
@@ -46,6 +51,8 @@ class StateReader {
     , model_name(_model_name)
     , env_desc(_env_desc)
     , env_init(_env_init)
+    , macro_env_desc(_macro_env_desc)
+    , macro_env_init(_macro_env_init)
     , sim_instance(_sim_instance) {}
     /**
      * Virtual destructor for correct inheritance behaviour
@@ -63,11 +70,13 @@ class StateReader {
     virtual int parse() = 0;
 
  protected:
-    util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& model_state;
+    util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state;
     std::string inputFile;
     const std::string model_name;
     const std::unordered_map<std::string, EnvironmentData::PropData> &env_desc;
     std::unordered_map<std::string, detail::Any>& env_init;
+    const std::unordered_map<std::string, EnvironmentData::MacroPropData> &macro_env_desc;
+    std::unordered_map<std::string, std::vector<char>>& macro_env_init;
     Simulation *sim_instance;
 };
 }  // namespace io

--- a/include/flamegpu/io/StateReaderFactory.h
+++ b/include/flamegpu/io/StateReaderFactory.h
@@ -26,33 +26,17 @@ class StateReaderFactory {
  public:
     /**
      * Returns a reader capable of reading 'input'
-     * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
-     * Agent data will be read into 'model_state'
-     * @param model_name Name from the model description hierarchy of the model to be loaded
-     * @param env_desc Environment description for validating property data on load
-     * @param env_init Dictionary of loaded values map:<name, value>
-     * @param macro_env_desc Macro environment description for validating property data on load
-     * @param macro_env_init Dictionary of loaded values map:<name, value>
-     * @param model_state Map of AgentVector to load the agent data into per agent, key should be agent name
      * @param input Filename of the input file (This will be used to determine which reader to return)
-     * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
      * @throws exception::UnsupportedFileType If the file extension does not match an appropriate reader
      */
     static StateReader* createReader(
-        const std::string& model_name,
-        const std::unordered_map<std::string, EnvironmentData::PropData>& env_desc,
-        std::unordered_map<std::string, detail::Any>& env_init,
-        const std::unordered_map<std::string, EnvironmentData::MacroPropData>& macro_env_desc,
-        std::unordered_map<std::string, std::vector<char>>& macro_env_init,
-        util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& model_state,
-        const std::string& input,
-        Simulation* sim_instance) {
+        const std::string& input) {
         const std::string extension = std::filesystem::path(input).extension().string();
 
         if (extension == ".xml") {
-            return new XMLStateReader(model_name, env_desc, env_init, macro_env_desc, macro_env_init, model_state, input, sim_instance);
+            return new XMLStateReader();
         } else if (extension == ".json") {
-            return new JSONStateReader(model_name, env_desc, env_init, macro_env_desc, macro_env_init, model_state, input, sim_instance);
+            return new JSONStateReader();
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be read "
             "by StateReaderFactory::createReader().",

--- a/include/flamegpu/io/StateReaderFactory.h
+++ b/include/flamegpu/io/StateReaderFactory.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <algorithm>
 #include <filesystem>
+#include <vector>
 
 #include "flamegpu/io/StateReader.h"
 #include "flamegpu/io/XMLStateReader.h"
@@ -29,7 +30,9 @@ class StateReaderFactory {
      * Agent data will be read into 'model_state'
      * @param model_name Name from the model description hierarchy of the model to be loaded
      * @param env_desc Environment description for validating property data on load
-     * @param env_init Dictionary of loaded values map:<{name, index}, value>
+     * @param env_init Dictionary of loaded values map:<name, value>
+     * @param macro_env_desc Macro environment description for validating property data on load
+     * @param macro_env_init Dictionary of loaded values map:<name, value>
      * @param model_state Map of AgentVector to load the agent data into per agent, key should be agent name
      * @param input Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -39,15 +42,17 @@ class StateReaderFactory {
         const std::string& model_name,
         const std::unordered_map<std::string, EnvironmentData::PropData>& env_desc,
         std::unordered_map<std::string, detail::Any>& env_init,
+        const std::unordered_map<std::string, EnvironmentData::MacroPropData>& macro_env_desc,
+        std::unordered_map<std::string, std::vector<char>>& macro_env_init,
         util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& model_state,
         const std::string& input,
         Simulation* sim_instance) {
         const std::string extension = std::filesystem::path(input).extension().string();
 
         if (extension == ".xml") {
-            return new XMLStateReader(model_name, env_desc, env_init, model_state, input, sim_instance);
+            return new XMLStateReader(model_name, env_desc, env_init, macro_env_desc, macro_env_init, model_state, input, sim_instance);
         } else if (extension == ".json") {
-            return new JSONStateReader(model_name, env_desc, env_init, model_state, input, sim_instance);
+            return new JSONStateReader(model_name, env_desc, env_init, macro_env_desc, macro_env_init, model_state, input, sim_instance);
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be read "
             "by StateReaderFactory::createReader().",

--- a/include/flamegpu/io/StateWriter.h
+++ b/include/flamegpu/io/StateWriter.h
@@ -81,7 +81,12 @@ class StateWriter {
     virtual void writeConfig(const Simulation *sim_instance) = 0;
     virtual void writeStats(unsigned int iterations) = 0;
     virtual void writeEnvironment(const std::shared_ptr<const detail::EnvironmentManager>& env_manager) = 0;
-    virtual void writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env) = 0;
+    /**
+     * Write the macro environment block
+     * @param macro_env The macro environment to pull properties from
+     * @param filter If provided, only named properties will be written. Note, if filter contains missing properties it will fail
+     */
+    virtual void writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env, std::initializer_list<std::string> filter = {}) = 0;
     virtual void writeAgents(const util::StringPairUnorderedMap<std::shared_ptr<const AgentVector>>& agents_map) = 0;
 };
 }  // namespace io

--- a/include/flamegpu/io/StateWriter.h
+++ b/include/flamegpu/io/StateWriter.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/model/ModelDescription.h"
@@ -12,6 +13,7 @@
 namespace flamegpu {
 namespace detail {
 class EnvironmentManager;
+class CUDAMacroEnvironment;
 }  // namespace detail
 class AgentVector;
 class Simulation;
@@ -31,21 +33,24 @@ class StateWriter {
      * @param _model_name Name from the model description hierarchy of the model to be exported
      * @param _env_manager Environment manager containing env property data for this sim instance
      * @param _model_state Map of AgentVector to read the agent data from per agent, key should be agent name
+     * @param _macro_env Macro environment of the model
      * @param _iterations The value from the step counter at the time of export.
      * @param output_file Filename of the input file (This will be used to determine which reader to return)
      * @param _sim_instance Instance of the simulation (for configuration data IO)
      */
-    StateWriter(const std::string &_model_name,
-        const std::shared_ptr<detail::EnvironmentManager>& _env_manager,
+    StateWriter(std::string _model_name,
+        std::shared_ptr<detail::EnvironmentManager> _env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &_model_state,
+        std::shared_ptr<const detail::CUDAMacroEnvironment> _macro_env,
         const unsigned int _iterations,
-        const std::string &output_file,
+        std::string output_file,
         const Simulation *_sim_instance)
     : model_state(_model_state)
     , iterations(_iterations)
-    , outputFile(output_file)
-    , model_name(_model_name)
-    , env_manager(_env_manager)
+    , outputFile(std::move(output_file))
+    , model_name(std::move(_model_name))
+    , env_manager(std::move(_env_manager))
+    , macro_env(std::move(_macro_env))
     , sim_instance(_sim_instance) {}
     /**
      * Virtual destructor for correct inheritance behaviour
@@ -69,6 +74,7 @@ class StateWriter {
     std::string outputFile;
     const std::string model_name;
     const std::shared_ptr<detail::EnvironmentManager> env_manager;
+    const std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env;
     const Simulation *sim_instance;
 };
 }  // namespace io

--- a/include/flamegpu/io/StateWriterFactory.h
+++ b/include/flamegpu/io/StateWriterFactory.h
@@ -1,23 +1,15 @@
 #ifndef INCLUDE_FLAMEGPU_IO_STATEWRITERFACTORY_H_
 #define INCLUDE_FLAMEGPU_IO_STATEWRITERFACTORY_H_
 
-#include <memory>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <algorithm>
+#include <filesystem>
 
 #include "flamegpu/io/StateWriter.h"
 #include "flamegpu/io/XMLStateWriter.h"
 #include "flamegpu/io/JSONStateWriter.h"
-#include "flamegpu/io/JSONLogger.h"
-#include "flamegpu/io/XMLLogger.h"
-#include "flamegpu/util/StringPair.h"
 
 namespace flamegpu {
-
-class AgentVector;
-
 namespace io {
 
 /**
@@ -29,29 +21,17 @@ class StateWriterFactory {
      * Returns a writer capable of writing model state to 'output_file'
      * Environment properties from the Simulation instance pointed to by 'sim_instance_id' will be used
      * Agent data will be read from 'model_state'
-     * @param model_name Name from the model description hierarchy of the model to be exported
-     * @param env_manager Environment manager containing env property data for this sim instance
-     * @param model_state Map of AgentVector to read the agent data from per agent, key should be agent name
-     * @param macro_env Macro environment of the model
-     * @param iterations The value from the step counter at the time of export.
      * @param output_file Filename of the input file (This will be used to determine which reader to return)
-     * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
      * @throws exception::UnsupportedFileType If the file extension does not match an appropriate reader
      */
     static StateWriter* createWriter(
-        const std::string& model_name,
-        const std::shared_ptr<detail::EnvironmentManager>& env_manager,
-        const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& model_state,
-        std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env,
-        const unsigned int iterations,
-        const std::string& output_file,
-        const Simulation* sim_instance) {
+        const std::string& output_file) {
         const std::string extension = std::filesystem::path(output_file).extension().string();
 
         if (extension == ".xml") {
-            return new XMLStateWriter(model_name, env_manager, model_state, macro_env, iterations, output_file, sim_instance);
+            return new XMLStateWriter();
         } else if (extension == ".json") {
-            return new JSONStateWriter(model_name, env_manager, model_state, macro_env, iterations, output_file, sim_instance);
+            return new JSONStateWriter();
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be written "
             "by StateWriterFactory::createWriter().",

--- a/include/flamegpu/io/StateWriterFactory.h
+++ b/include/flamegpu/io/StateWriterFactory.h
@@ -32,6 +32,7 @@ class StateWriterFactory {
      * @param model_name Name from the model description hierarchy of the model to be exported
      * @param env_manager Environment manager containing env property data for this sim instance
      * @param model_state Map of AgentVector to read the agent data from per agent, key should be agent name
+     * @param macro_env Macro environment of the model
      * @param iterations The value from the step counter at the time of export.
      * @param output_file Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -41,15 +42,16 @@ class StateWriterFactory {
         const std::string& model_name,
         const std::shared_ptr<detail::EnvironmentManager>& env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>& model_state,
+        std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env,
         const unsigned int iterations,
         const std::string& output_file,
         const Simulation* sim_instance) {
         const std::string extension = std::filesystem::path(output_file).extension().string();
 
         if (extension == ".xml") {
-            return new XMLStateWriter(model_name, env_manager, model_state, iterations, output_file, sim_instance);
+            return new XMLStateWriter(model_name, env_manager, model_state, macro_env, iterations, output_file, sim_instance);
         } else if (extension == ".json") {
-            return new JSONStateWriter(model_name, env_manager, model_state, iterations, output_file, sim_instance);
+            return new JSONStateWriter(model_name, env_manager, model_state, macro_env, iterations, output_file, sim_instance);
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be written "
             "by StateWriterFactory::createWriter().",

--- a/include/flamegpu/io/XMLStateReader.h
+++ b/include/flamegpu/io/XMLStateReader.h
@@ -3,13 +3,8 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <utility>
-#include <vector>
 
 #include "flamegpu/io/StateReader.h"
-#include "flamegpu/model/ModelDescription.h"
-#include "flamegpu/util/StringPair.h"
 
 namespace flamegpu {
 namespace io {
@@ -19,40 +14,19 @@ namespace io {
 class XMLStateReader : public StateReader {
  public:
     /**
-     * Constructs a reader capable of reading model state from XML files
-     * Environment properties will be read into the Simulation instance pointed to by 'sim_instance_id'
-     * Agent data will be read into 'model_state'
-     * @param model_name Name from the model description hierarchy of the model to be loaded
-     * @param env_desc Environment description for validating property data on load
-     * @param env_init Dictionary of loaded values map:<{name, index}, value>
-     * @param macro_env_desc Macro environment description for validating property data on load
-     * @param macro_env_init Dictionary of loaded values map:<name, value>
-     * @param model_state Map of AgentVector to load the agent data into per agent, key should be agent name
-     * @param input_file Filename of the input file (This will be used to determine which reader to return)
-     * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
+     * Loads the specified XML file to an internal data-structure 
+     * @param input_file Path to file to be read
+     * @param model Model description to ensure file loaded is suitable
+     * @param verbosity Verbosity level to use during load
      */
-    XMLStateReader(
-        const std::string &model_name,
-        const std::unordered_map<std::string, EnvironmentData::PropData> &env_desc,
-        std::unordered_map<std::string, detail::Any> &env_init,
-        const std::unordered_map<std::string, EnvironmentData::MacroPropData> &macro_env_desc,
-        std::unordered_map<std::string, std::vector<char>> &macro_env_init,
-        util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
-        const std::string &input_file,
-        Simulation *sim_instance);
-    /**
-     * Actual performs the XML parsing to load the model state
-     * @return Always tinyxml2::XML_SUCCESS
-     * @throws exception::TinyXMLError If parsing of the input file fails
-     */
-    int parse() override;
+    void parse(const std::string &input_file, const std::shared_ptr<const ModelData> &model, Verbosity verbosity) override;
 
  private:
     /**
      * Flamegpu1 xml input files are allowed to omit state
      * This function extracts the initial state for the named agent from model_state;
      */
-    std::string getInitialState(const std::string& agent_name) const;
+    static std::string getInitialState(const std::shared_ptr<const ModelData> &model, const std::string& agent_name);
 };
 }  // namespace io
 }  // namespace flamegpu

--- a/include/flamegpu/io/XMLStateReader.h
+++ b/include/flamegpu/io/XMLStateReader.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "flamegpu/io/StateReader.h"
 #include "flamegpu/model/ModelDescription.h"
@@ -24,6 +25,8 @@ class XMLStateReader : public StateReader {
      * @param model_name Name from the model description hierarchy of the model to be loaded
      * @param env_desc Environment description for validating property data on load
      * @param env_init Dictionary of loaded values map:<{name, index}, value>
+     * @param macro_env_desc Macro environment description for validating property data on load
+     * @param macro_env_init Dictionary of loaded values map:<name, value>
      * @param model_state Map of AgentVector to load the agent data into per agent, key should be agent name
      * @param input_file Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -32,6 +35,8 @@ class XMLStateReader : public StateReader {
         const std::string &model_name,
         const std::unordered_map<std::string, EnvironmentData::PropData> &env_desc,
         std::unordered_map<std::string, detail::Any> &env_init,
+        const std::unordered_map<std::string, EnvironmentData::MacroPropData> &macro_env_desc,
+        std::unordered_map<std::string, std::vector<char>> &macro_env_init,
         util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
         const std::string &input_file,
         Simulation *sim_instance);

--- a/include/flamegpu/io/XMLStateWriter.h
+++ b/include/flamegpu/io/XMLStateWriter.h
@@ -46,7 +46,7 @@ class XMLStateWriter : public StateWriter {
     void writeConfig(const Simulation *sim_instance) override;
     void writeStats(unsigned int iterations) override;
     void writeEnvironment(const std::shared_ptr<const detail::EnvironmentManager>& env_manager) override;
-    void writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env) override;
+    void writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env, std::initializer_list<std::string> filter = {}) override;
     void writeAgents(const util::StringPairUnorderedMap<std::shared_ptr<const AgentVector>>& agents_map) override;
 
  private:

--- a/include/flamegpu/io/XMLStateWriter.h
+++ b/include/flamegpu/io/XMLStateWriter.h
@@ -22,6 +22,7 @@ class XMLStateWriter : public StateWriter {
      * @param model_name Name from the model description hierarchy of the model to be exported
      * @param env_manager Environment manager containing env property data for this sim instance
      * @param model_state Map of AgentVector to read the agent data from per agent, key should be agent name
+     * @param macro_env Macro environment of the model
      * @param iterations The value from the step counter at the time of export.
      * @param output_file Filename of the input file (This will be used to determine which reader to return)
      * @param sim_instance Instance of the Simulation object (This is used for setting/getting config)
@@ -30,6 +31,7 @@ class XMLStateWriter : public StateWriter {
         const std::string &model_name,
         const std::shared_ptr<detail::EnvironmentManager>& env_manager,
         const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &model_state,
+        std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env,
         unsigned int iterations,
         const std::string &output_file,
         const Simulation *sim_instance);

--- a/include/flamegpu/model/ModelDescription.h
+++ b/include/flamegpu/model/ModelDescription.h
@@ -37,6 +37,8 @@ class ModelDescription {
     friend class RunPlanVector;
     friend class RunPlan;
     friend class LoggingConfig;
+    friend class XMLStateReader;
+    friend class JSONStateReader;
  public:
     /**
      * Constructor

--- a/include/flamegpu/runtime/HostAPI.h
+++ b/include/flamegpu/runtime/HostAPI.h
@@ -57,7 +57,7 @@ class HostAPI {
         const AgentOffsetMap &agentOffsets,
         AgentDataMap &agentData,
         const std::shared_ptr<detail::EnvironmentManager> &env,
-        detail::CUDAMacroEnvironment &macro_env,
+        const std::shared_ptr<detail::CUDAMacroEnvironment> &macro_env,
         unsigned int streamId,
         cudaStream_t stream);
     /**

--- a/include/flamegpu/runtime/environment/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/environment/HostEnvironment.cuh
@@ -36,7 +36,9 @@ class HostEnvironment {
     /**
      * Constructor, to be called by HostAPI
      */
-    explicit HostEnvironment(unsigned int instance_id, const std::shared_ptr<detail::EnvironmentManager> &env, const std::shared_ptr<detail::CUDAMacroEnvironment>& _macro_env);
+    explicit HostEnvironment(CUDASimulation &_simulation, cudaStream_t _stream,
+                             std::shared_ptr<detail::EnvironmentManager> env,
+                             std::shared_ptr<detail::CUDAMacroEnvironment> _macro_env);
     /**
      * Provides access to EnvironmentManager singleton
      */
@@ -50,6 +52,14 @@ class HostEnvironment {
      * This is used to augment all variable names
      */
     const unsigned int instance_id;
+    /**
+     * The relevant simulation, required for importing macro properties
+     */
+    CUDASimulation& simulation;
+    /**
+     * CUDAStream for memcpys
+     */
+    const cudaStream_t stream;
 
  public:
     /**
@@ -155,6 +165,21 @@ class HostEnvironment {
     template<typename T>
     HostMacroProperty_swig<T> getMacroProperty_swig(const std::string& name) const;
 #endif
+    /**
+     * Import macro property data from file
+     * @param property_name Name of the macro property to import
+     * @param file_path Path to file containing macro property data (.json, .xml, .bin)
+     * @note This method supports raw binary files (.bin)
+     */
+    void importMacroProperty(const std::string& property_name, const std::string& file_path) const;
+    /**
+     * Export macro property data to file
+     * @param property_name Name of the macro property to import
+     * @param file_path Path to file to export macro property data (.json, .xml. bin)
+     * @param pretty_print Print in readable or minified format (if available)
+     * @note This method supports raw binary files (.bin)
+     */
+    void exportMacroProperty(const std::string& property_name, const std::string& file_path, bool pretty_print = true) const;
 };
 
 /**

--- a/include/flamegpu/runtime/environment/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/environment/HostEnvironment.cuh
@@ -36,7 +36,7 @@ class HostEnvironment {
     /**
      * Constructor, to be called by HostAPI
      */
-    explicit HostEnvironment(unsigned int instance_id, const std::shared_ptr<detail::EnvironmentManager> &env, detail::CUDAMacroEnvironment &_macro_env);
+    explicit HostEnvironment(unsigned int instance_id, const std::shared_ptr<detail::EnvironmentManager> &env, const std::shared_ptr<detail::CUDAMacroEnvironment>& _macro_env);
     /**
      * Provides access to EnvironmentManager singleton
      */
@@ -44,7 +44,7 @@ class HostEnvironment {
     /**
      * Provides access to macro properties for the instance
      */
-    detail::CUDAMacroEnvironment& macro_env;
+    const std::shared_ptr<detail::CUDAMacroEnvironment> macro_env;
     /**
      * Access to instance id of the CUDASimulation
      * This is used to augment all variable names
@@ -219,13 +219,13 @@ std::vector<T> HostEnvironment::getPropertyArray(const std::string& name) const 
 
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
 HostMacroProperty<T, I, J, K, W> HostEnvironment::getMacroProperty(const std::string& name) const {
-    return macro_env.getProperty<T, I, J, K, W>(name);
+    return macro_env->getProperty<T, I, J, K, W>(name);
 }
 
 #ifdef SWIG
 template<typename T>
 HostMacroProperty_swig<T> HostEnvironment::getMacroProperty_swig(const std::string& name) const {
-    return macro_env.getProperty_swig<T>(name);
+    return macro_env->getProperty_swig<T>(name);
 }
 #endif
 }  // namespace flamegpu

--- a/include/flamegpu/runtime/environment/HostMacroProperty.cuh
+++ b/include/flamegpu/runtime/environment/HostMacroProperty.cuh
@@ -33,14 +33,26 @@ struct HostMacroProperty_MetaData {
     }
     /**
      * Download data
+     * @note Only works first time
+     * @see force_download()
      */
     void download() {
         if (!h_base_ptr) {
-            h_base_ptr = static_cast<char*>(malloc(elements * type_size));
-            gpuErrchk(cudaMemcpyAsync(h_base_ptr, d_base_ptr, elements * type_size, cudaMemcpyDeviceToHost, stream));
-            gpuErrchk(cudaStreamSynchronize(stream));
-            has_changed = false;
+            force_download();
         }
+    }
+
+    /**
+     * Downloads data from device to host (allocating host buffer if required)
+     * Sets has_changed flag to false, as host is current to device
+     */
+    void force_download() {
+        if (!h_base_ptr) {
+            h_base_ptr = static_cast<char*>(malloc(elements * type_size));
+        }
+        gpuErrchk(cudaMemcpyAsync(h_base_ptr, d_base_ptr, elements * type_size, cudaMemcpyDeviceToHost, stream));
+        gpuErrchk(cudaStreamSynchronize(stream));
+        has_changed = false;
     }
     /**
      * Upload data

--- a/include/flamegpu/simulation/CUDASimulation.h
+++ b/include/flamegpu/simulation/CUDASimulation.h
@@ -445,7 +445,7 @@ class CUDASimulation : public Simulation {
     /**
      * Macro env property storage
      */
-    detail::CUDAMacroEnvironment macro_env;
+    std::shared_ptr<detail::CUDAMacroEnvironment> macro_env;
     /**
      * Internal model config
      */
@@ -574,6 +574,10 @@ class CUDASimulation : public Simulation {
      */
     void initEnvironmentMgr();
     /**
+     * Common method for initialising macro environment properties from macro_env_init
+     */
+    void initMacroEnvironment();
+    /**
      * Flag indicating that the model has been initialsed
      */
     bool singletonsInitialised;
@@ -617,6 +621,7 @@ class CUDASimulation : public Simulation {
 
  private:
     std::shared_ptr<detail::EnvironmentManager> getEnvironment() const override;
+    std::shared_ptr<const detail::CUDAMacroEnvironment> getMacroEnvironment() const override;
     void assignAgentIDs();
     /**
      * Set to false whenever an agent population is imported from outside

--- a/include/flamegpu/simulation/Simulation.h
+++ b/include/flamegpu/simulation/Simulation.h
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <utility>
 #include <unordered_map>
+#include <vector>
 
 #include "flamegpu/defines.h"
 #include "flamegpu/simulation/detail/AgentInterface.h"
@@ -14,6 +15,7 @@
 namespace flamegpu {
 namespace detail {
 class EnvironmentManager;
+class CUDAMacroEnvironment;
 }  // namespace detail
 class AgentVector;
 class HostAPI;
@@ -150,6 +152,7 @@ class Simulation {
      * Returns the environment manager
      */
     virtual std::shared_ptr<detail::EnvironmentManager> getEnvironment() const = 0;
+    virtual std::shared_ptr<const detail::CUDAMacroEnvironment> getMacroEnvironment() const = 0;
 
     /**
      * returns the width of the widest layer in model.
@@ -182,6 +185,10 @@ class Simulation {
      * Initial environment items if they have been loaded from file, prior to device selection
      */
     std::unordered_map<std::string, detail::Any> env_init;
+    /**
+     * Initial macro environment items if they have been loaded from file, prior to device selection
+     */
+    std::unordered_map<std::string, std::vector<char>> macro_env_init;
     /**
      * the width of the widest layer in the concrete version of the model (calculated once)
      */

--- a/include/flamegpu/simulation/detail/CUDAAgent.h
+++ b/include/flamegpu/simulation/detail/CUDAAgent.h
@@ -208,7 +208,7 @@ class CUDAAgent : public AgentInterface {
      * @param function_condition If true then this function will instantiate a function condition rather than an agent function
      * @throw exception::InvalidAgentFunc thrown if the user supplied agent function has compilation errors
      */
-    void addInstantitateRTCFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager>& env, const CUDAMacroEnvironment& macro_env, bool function_condition = false);
+    void addInstantitateRTCFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager>& env, std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env, bool function_condition = false);
     /**
      * Instantiates the curve instance for an (non-RTC) Agent function (or agent function condition) from agent function data description containing the source.
      *
@@ -218,7 +218,7 @@ class CUDAAgent : public AgentInterface {
      * @param macro_env Object containing environment macro properties for the simulation instance
      * @param function_condition If true then this function will instantiate a function condition rather than an agent function
      */
-    void addInstantitateFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager>& env, const CUDAMacroEnvironment& macro_env, bool function_condition = false);
+    void addInstantitateFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager>& env, std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env, bool function_condition = false);
     /**
      * Returns the jitify kernel instantiation of the agent function.
      * Will throw an exception::InvalidAgentFunc excpetion if the function name does not have a valid instantiation

--- a/include/flamegpu/simulation/detail/CUDAMacroEnvironment.h
+++ b/include/flamegpu/simulation/detail/CUDAMacroEnvironment.h
@@ -162,6 +162,13 @@ class CUDAMacroEnvironment {
      * Used for IO
      */
     const std::map<std::string, MacroEnvProp>& getPropertiesMap() const;
+    /**
+     * Return the metadata, if setup, for the named macro property
+     *
+     * @param property_name Name of the macro property to load
+     * @return nullptr if not currently cached
+     */
+    std::shared_ptr<HostMacroProperty_MetaData> getHostPropertyMetadata(const std::string property_name);
 
  private:
     const CUDASimulation& cudaSimulation;

--- a/include/flamegpu/simulation/detail/CUDAMacroEnvironment.h
+++ b/include/flamegpu/simulation/detail/CUDAMacroEnvironment.h
@@ -167,6 +167,7 @@ class CUDAMacroEnvironment {
     const CUDASimulation& cudaSimulation;
     std::map<std::string, MacroEnvProp> properties;
     std::map<std::string, std::weak_ptr<HostMacroProperty_MetaData>> host_cache;
+    cudaStream_t stream = nullptr;
 };
 
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>
@@ -205,7 +206,7 @@ HostMacroProperty<T, I, J, K, W> CUDAMacroEnvironment::getProperty(const std::st
         }
         host_cache.erase(cache);
     }
-    auto ret = std::make_shared<HostMacroProperty_MetaData>(prop->second.d_ptr, prop->second.elements, sizeof(T), read_flag, name);
+    auto ret = std::make_shared<HostMacroProperty_MetaData>(prop->second.d_ptr, prop->second.elements, sizeof(T), read_flag, name, stream);
     host_cache.emplace(name, ret);
     return HostMacroProperty<T, I, J, K, W>(ret);
 }
@@ -243,7 +244,7 @@ HostMacroProperty_swig<T> CUDAMacroEnvironment::getProperty_swig(const std::stri
         }
         host_cache.erase(cache);
     }
-    auto ret = std::make_shared<HostMacroProperty_MetaData>(prop->second.d_ptr, prop->second.elements, sizeof(T), read_flag, name);
+    auto ret = std::make_shared<HostMacroProperty_MetaData>(prop->second.d_ptr, prop->second.elements, sizeof(T), read_flag, name, stream);
     host_cache.emplace(name, ret);
     return HostMacroProperty_swig<T>(ret);
 }

--- a/include/flamegpu/simulation/detail/CUDAMacroEnvironment.h
+++ b/include/flamegpu/simulation/detail/CUDAMacroEnvironment.h
@@ -33,6 +33,7 @@ class CurveRTCHost;
  * This class is CUDASimulation's internal handler for macro environment functionality
  */
 class CUDAMacroEnvironment {
+ public:
     /**
      * Used to group items required by properties
      */
@@ -70,11 +71,7 @@ class CUDAMacroEnvironment {
         bool is_sub;
         // ptrdiff_t rtc_offset;  // This is set by buildRTCOffsets();
     };
-    const CUDASimulation& cudaSimulation;
-    std::map<std::string, MacroEnvProp> properties;
-    std::map<std::string, std::weak_ptr<HostMacroProperty_MetaData>> host_cache;
 
- public:
     /**
      * Normal constructor
      * @param description Agent description of the agent
@@ -95,7 +92,7 @@ class CUDAMacroEnvironment {
      * @param stream The CUDAStream to use for CUDA operations
      * @note This must be called after the master model CUDAMacroEnvironment has init
      */
-    void init(const SubEnvironmentData& mapping, const CUDAMacroEnvironment& master_macro_env, cudaStream_t stream);
+    void init(const SubEnvironmentData& mapping, std::shared_ptr<const detail::CUDAMacroEnvironment> master_macro_env, cudaStream_t stream);
     /**
      * Release all CUDA allocations, and unregisters CURVE variables
      */
@@ -160,6 +157,16 @@ class CUDAMacroEnvironment {
     template<typename T>
     HostMacroProperty_swig<T> getProperty_swig(const std::string& name);
 #endif
+    /**
+     * Returns the full map of macro environment properties
+     * Used for IO
+     */
+    const std::map<std::string, MacroEnvProp>& getPropertiesMap() const;
+
+ private:
+    const CUDASimulation& cudaSimulation;
+    std::map<std::string, MacroEnvProp> properties;
+    std::map<std::string, std::weak_ptr<HostMacroProperty_MetaData>> host_cache;
 };
 
 template<typename T, unsigned int I, unsigned int J, unsigned int K, unsigned int W>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,10 +330,10 @@ SET(SRC_FLAMEGPU
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/messaging/MessageBucket.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/environment/HostEnvironment.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/random/HostRandom.cu
-    ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateReader.cpp
-    ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateWriter.cpp
-    ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateReader.cpp
-    ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateWriter.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateReader.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateWriter.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateReader.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateWriter.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLLogger.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONLogger.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/Telemetry.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -332,6 +332,7 @@ SET(SRC_FLAMEGPU
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/random/HostRandom.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateWriter.cu
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/StateReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateWriter.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLLogger.cu

--- a/src/flamegpu/io/JSONStateWriter.cu
+++ b/src/flamegpu/io/JSONStateWriter.cu
@@ -208,7 +208,7 @@ void JSONStateWriter::writeEnvironment(const std::shared_ptr<const detail::Envir
 
     environment_written = true;
 }
-void JSONStateWriter::writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env) {
+void JSONStateWriter::writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env, std::initializer_list<std::string> filter) {
     if (!writer) {
         THROW exception::UnknownInternalError("beginWrite() must be called before writeMacroEnvironment(), in JSONStateWriter::writeMacroEnvironment()");
     } else if (macro_environment_written) {
@@ -220,6 +220,12 @@ void JSONStateWriter::writeMacroEnvironment(const std::shared_ptr<const detail::
     writer->StartObject();
     if (macro_env) {
         const std::map<std::string, detail::CUDAMacroEnvironment::MacroEnvProp>& m_properties = macro_env->getPropertiesMap();
+        for (const auto &_filter : filter) {
+            if (m_properties.find(_filter) == m_properties.end()) {
+                THROW exception::InvalidEnvProperty("Macro property '%s' specified in filter does not exist, in JSONStateWriter::writeMacroEnvironment()", _filter.c_str());
+            }
+        }
+        std::set<std::string> filter_set = filter;
         // Calculate largest buffer in map
         size_t max_len = 0;
         for (const auto& [_, prop] : m_properties) {
@@ -230,6 +236,8 @@ void JSONStateWriter::writeMacroEnvironment(const std::shared_ptr<const detail::
             char* const t_buffer = static_cast<char*>(malloc(max_len));
             // Write out each array (all are written out as 1D arrays for simplicity given variable dimensions)
             for (const auto& [name, prop] : m_properties) {
+                if (!filter_set.empty() && filter_set.find(name) == filter_set.end())
+                    continue;
                 // Copy data
                 const size_t element_ct = std::accumulate(prop.elements.begin(), prop.elements.end(), 1, std::multiplies<unsigned int>());
                 gpuErrchk(cudaMemcpy(t_buffer, prop.d_ptr, element_ct * prop.type_size, cudaMemcpyDeviceToHost));

--- a/src/flamegpu/io/JSONStateWriter.cu
+++ b/src/flamegpu/io/JSONStateWriter.cu
@@ -19,148 +19,205 @@
 
 namespace flamegpu {
 namespace io {
-JSONStateWriter::JSONStateWriter(
-    const std::string &model_name,
-    const std::shared_ptr<detail::EnvironmentManager> &env_manager,
-    const util::StringPairUnorderedMap<std::shared_ptr<AgentVector>>&model,
-    std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env,
-    const unsigned int iterations,
-    const std::string &output_file,
-    const Simulation *_sim_instance)
-    : StateWriter(model_name, env_manager, model, macro_env, iterations, output_file, _sim_instance) {}
+JSONStateWriter::JSONStateWriter()
+    : StateWriter() {}
+void JSONStateWriter::beginWrite(const std::string &output_file, bool pretty_print) {
+    this->outputPath = output_file;
+    if (writer) {
+        THROW exception::UnknownInternalError("Writing already active, in JSONStateWriter::beginWrite()");
+    }
+    buffer = rapidjson::StringBuffer();
+    if (pretty_print) {
+        auto t_writer = std::make_unique<rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>>(buffer);
+        t_writer->SetIndent('\t', 1);
+        writer = std::move(t_writer);
+    } else {
+        writer = std::make_unique<rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>>(buffer);
+    }
+    // Begin Json file
+    writer->StartObject();
 
-template<typename T>
-void JSONStateWriter::doWrite(T &writer) {
-    // Begin json output object
-    writer.StartObject();
+    // Clear flags
+    this->config_written = false;
+    this->stats_written = false;
+    this->environment_written = false;
+    this->macro_environment_written = false;
+    this->agents_written = false;
+}
+void JSONStateWriter::endWrite() {
+    if (!writer) {
+        THROW exception::UnknownInternalError("Writing not active, in XMLStateWriter::endWrite()");
+    }
+
+    // End Json file
+    writer->EndObject();
+
+    std::ofstream out(outputPath, std::ofstream::trunc);
+    out << buffer.GetString();
+    out.close();
+
+    writer.reset();
+    buffer.Clear();
+}
+
+void JSONStateWriter::writeConfig(const Simulation *sim_instance) {
+    if (!writer) {
+        THROW exception::UnknownInternalError("beginWrite() must be called before writeConfig(), in JSONStateWriter::writeConfig()");
+    } else if (config_written) {
+        THROW exception::UnknownInternalError("writeConfig() can only be called once per write session, in JSONStateWriter::writeConfig()");
+    }
 
     // General simulation config/properties
-    writer.Key("config");
-    writer.StartObject();
-    {
-        // Simulation config
-        if (sim_instance) {
-            writer.Key("simulation");
-            writer.StartObject();
-            {
-                const auto &sim_cfg = sim_instance->getSimulationConfig();
-                // Input file
-                writer.Key("input_file");
-                writer.String(sim_cfg.input_file.c_str());
-                // Step log file
-                writer.Key("step_log_file");
-                writer.String(sim_cfg.step_log_file.c_str());
-                // Exit log file
-                writer.Key("exit_log_file");
-                writer.String(sim_cfg.exit_log_file.c_str());
-                // Common log file
-                writer.Key("common_log_file");
-                writer.String(sim_cfg.common_log_file.c_str());
-                // Truncate log files
-                writer.Key("truncate_log_files");
-                writer.Bool(sim_cfg.truncate_log_files);
-                // Random seed
-                writer.Key("random_seed");
-                writer.Uint64(sim_cfg.random_seed);
-                // Steps
-                writer.Key("steps");
-                writer.Uint(sim_cfg.steps);
-                // Verbose output
-                writer.Key("verbosity");
-                writer.Uint(static_cast<unsigned int>(sim_cfg.verbosity));
-                // Timing Output
-                writer.Key("timing");
-                writer.Bool(sim_cfg.timing);
+    writer->Key("config");
+    writer->StartObject();
+    // Simulation config
+    if (sim_instance) {
+        writer->Key("simulation");
+        writer->StartObject();
+        {
+            const auto& sim_cfg = sim_instance->getSimulationConfig();
+            // Input file
+            writer->Key("input_file");
+            writer->String(sim_cfg.input_file.c_str());
+            // Step log file
+            writer->Key("step_log_file");
+            writer->String(sim_cfg.step_log_file.c_str());
+            // Exit log file
+            writer->Key("exit_log_file");
+            writer->String(sim_cfg.exit_log_file.c_str());
+            // Common log file
+            writer->Key("common_log_file");
+            writer->String(sim_cfg.common_log_file.c_str());
+            // Truncate log files
+            writer->Key("truncate_log_files");
+            writer->Bool(sim_cfg.truncate_log_files);
+            // Random seed
+            writer->Key("random_seed");
+            writer->Uint64(sim_cfg.random_seed);
+            // Steps
+            writer->Key("steps");
+            writer->Uint(sim_cfg.steps);
+            // Verbose output
+            writer->Key("verbosity");
+            writer->Uint(static_cast<unsigned int>(sim_cfg.verbosity));
+            // Timing Output
+            writer->Key("timing");
+            writer->Bool(sim_cfg.timing);
 #ifdef FLAMEGPU_VISUALISATION
-                // Console mode
-                writer.Key("console_mode");
-                writer.Bool(sim_cfg.console_mode);
+            // Console mode
+            writer->Key("console_mode");
+            writer->Bool(sim_cfg.console_mode);
 #endif
-            }
-            writer.EndObject();
         }
+        writer->EndObject();
 
         // CUDA config
-        if (auto *cudamodel_instance = dynamic_cast<const CUDASimulation*>(sim_instance)) {
-            writer.Key("cuda");
-            writer.StartObject();
+        if (auto* cudamodel_instance = dynamic_cast<const CUDASimulation*>(sim_instance)) {
+            writer->Key("cuda");
+            writer->StartObject();
             {
-                const auto &cuda_cfg = cudamodel_instance->getCUDAConfig();
+                const auto& cuda_cfg = cudamodel_instance->getCUDAConfig();
                 // device_id
-                writer.Key("device_id");
-                writer.Uint(cuda_cfg.device_id);
+                writer->Key("device_id");
+                writer->Uint(cuda_cfg.device_id);
                 // inLayerConcurrency
-                writer.Key("inLayerConcurrency");
-                writer.Bool(cuda_cfg.inLayerConcurrency);
+                writer->Key("inLayerConcurrency");
+                writer->Bool(cuda_cfg.inLayerConcurrency);
             }
-            writer.EndObject();
+            writer->EndObject();
         }
     }
-    writer.EndObject();
+    writer->EndObject();
+    config_written = true;
+}
+void JSONStateWriter::writeStats(unsigned int iterations) {
+    if (!writer) {
+        THROW exception::UnknownInternalError("beginWrite() must be called before writeIterations(), in JSONStateWriter::writeIterations()");
+    } else if (stats_written) {
+        THROW exception::UnknownInternalError("writeIterations() can only be called once per write session, in JSONStateWriter::writeIterations()");
+    }
 
     // General runtime stats (e.g. we could add timing data in future)
-    writer.Key("stats");
-    writer.StartObject();
+    writer->Key("stats");
+    writer->StartObject();
     {
         // Steps
-        writer.Key("step_count");
-        writer.Uint(iterations);
+        writer->Key("step_count");
+        writer->Uint(iterations);
         // in future could also support random seed, run args etc
     }
-    writer.EndObject();
+    writer->EndObject();
+
+    stats_written = true;
+}
+void JSONStateWriter::writeEnvironment(const std::shared_ptr<const detail::EnvironmentManager>& env_manager) {
+    if (!writer) {
+        THROW exception::UnknownInternalError("beginWrite() must be called before writeEnvironment(), in JSONStateWriter::writeEnvironment()");
+    } else if (environment_written) {
+        THROW exception::UnknownInternalError("writeEnvironment() can only be called once per write session, in JSONStateWriter::writeEnvironment()");
+    }
 
     // Environment properties
-    writer.Key("environment");
-    writer.StartObject();
+    writer->Key("environment");
+    writer->StartObject();
     if (env_manager) {
         const char *env_buffer = reinterpret_cast<const char *>(env_manager->getHostBuffer());
         // for each environment property
         for (auto &a : env_manager->getPropertiesMap()) {
             // Set name
-            writer.Key(a.first.c_str());
+            writer->Key(a.first.c_str());
             // Output value
             if (a.second.elements > 1) {
                 // Value is an array
-                writer.StartArray();
+                writer->StartArray();
             }
             // Loop through elements, to construct array
             for (unsigned int el = 0; el < a.second.elements; ++el) {
                 if (a.second.type == std::type_index(typeid(float))) {
-                    writer.Double(*reinterpret_cast<const float*>(env_buffer + a.second.offset + (el * sizeof(float))));
+                    writer->Double(*reinterpret_cast<const float*>(env_buffer + a.second.offset + (el * sizeof(float))));
                 } else if (a.second.type == std::type_index(typeid(double))) {
-                    writer.Double(*reinterpret_cast<const double*>(env_buffer + a.second.offset + (el * sizeof(double))));
+                    writer->Double(*reinterpret_cast<const double*>(env_buffer + a.second.offset + (el * sizeof(double))));
                 } else if (a.second.type == std::type_index(typeid(int64_t))) {
-                    writer.Int64(*reinterpret_cast<const int64_t*>(env_buffer + a.second.offset + (el * sizeof(int64_t))));
+                    writer->Int64(*reinterpret_cast<const int64_t*>(env_buffer + a.second.offset + (el * sizeof(int64_t))));
                 } else if (a.second.type == std::type_index(typeid(uint64_t))) {
-                    writer.Uint64(*reinterpret_cast<const uint64_t*>(env_buffer + a.second.offset + (el * sizeof(uint64_t))));
+                    writer->Uint64(*reinterpret_cast<const uint64_t*>(env_buffer + a.second.offset + (el * sizeof(uint64_t))));
                 } else if (a.second.type == std::type_index(typeid(int32_t))) {
-                    writer.Int(*reinterpret_cast<const int32_t*>(env_buffer + a.second.offset + (el * sizeof(int32_t))));
+                    writer->Int(*reinterpret_cast<const int32_t*>(env_buffer + a.second.offset + (el * sizeof(int32_t))));
                 } else if (a.second.type == std::type_index(typeid(uint32_t))) {
-                    writer.Uint(*reinterpret_cast<const uint32_t*>(env_buffer + a.second.offset + (el * sizeof(uint32_t))));
+                    writer->Uint(*reinterpret_cast<const uint32_t*>(env_buffer + a.second.offset + (el * sizeof(uint32_t))));
                 } else if (a.second.type == std::type_index(typeid(int16_t))) {
-                    writer.Int(*reinterpret_cast<const int16_t*>(env_buffer + a.second.offset + (el * sizeof(int16_t))));
+                    writer->Int(*reinterpret_cast<const int16_t*>(env_buffer + a.second.offset + (el * sizeof(int16_t))));
                 } else if (a.second.type == std::type_index(typeid(uint16_t))) {
-                    writer.Uint(*reinterpret_cast<const uint16_t*>(env_buffer + a.second.offset + (el * sizeof(uint16_t))));
+                    writer->Uint(*reinterpret_cast<const uint16_t*>(env_buffer + a.second.offset + (el * sizeof(uint16_t))));
                 } else if (a.second.type == std::type_index(typeid(int8_t))) {
-                    writer.Int(static_cast<int32_t>(*reinterpret_cast<const int8_t*>(env_buffer + a.second.offset + (el * sizeof(int8_t)))));  // Char outputs weird if being used as an integer
+                    writer->Int(static_cast<int32_t>(*reinterpret_cast<const int8_t*>(env_buffer + a.second.offset + (el * sizeof(int8_t)))));  // Char outputs weird if being used as an integer
                 } else if (a.second.type == std::type_index(typeid(uint8_t))) {
-                    writer.Uint(static_cast<uint32_t>(*reinterpret_cast<const uint8_t*>(env_buffer + a.second.offset + (el * sizeof(uint8_t)))));  // Char outputs weird if being used as an integer
+                    writer->Uint(static_cast<uint32_t>(*reinterpret_cast<const uint8_t*>(env_buffer + a.second.offset + (el * sizeof(uint8_t)))));  // Char outputs weird if being used as an integer
                 } else {
                     THROW exception::RapidJSONError("Model contains environment property '%s' of unsupported type '%s', "
-                        "in JSONStateWriter::writeStates()\n", a.first.c_str(), a.second.type.name());
+                        "in JSONStateWriter::writeEnvironment()\n", a.first.c_str(), a.second.type.name());
                 }
             }
             if (a.second.elements > 1) {
                 // Value is an array
-                writer.EndArray();
+                writer->EndArray();
             }
         }
     }
-    writer.EndObject();
+    writer->EndObject();
+
+    environment_written = true;
+}
+void JSONStateWriter::writeMacroEnvironment(const std::shared_ptr<const detail::CUDAMacroEnvironment>& macro_env) {
+    if (!writer) {
+        THROW exception::UnknownInternalError("beginWrite() must be called before writeMacroEnvironment(), in JSONStateWriter::writeMacroEnvironment()");
+    } else if (macro_environment_written) {
+        THROW exception::UnknownInternalError("writeMacroEnvironment() can only be called once per write session, in JSONStateWriter::writeMacroEnvironment()");
+    }
 
     // Macro Environment
-    writer.Key("macro_environment");
-    writer.StartObject();
+    writer->Key("macro_environment");
+    writer->StartObject();
     if (macro_env) {
         const std::map<std::string, detail::CUDAMacroEnvironment::MacroEnvProp>& m_properties = macro_env->getPropertiesMap();
         // Calculate largest buffer in map
@@ -176,55 +233,64 @@ void JSONStateWriter::doWrite(T &writer) {
                 // Copy data
                 const size_t element_ct = std::accumulate(prop.elements.begin(), prop.elements.end(), 1, std::multiplies<unsigned int>());
                 gpuErrchk(cudaMemcpy(t_buffer, prop.d_ptr, element_ct * prop.type_size, cudaMemcpyDeviceToHost));
-                writer.Key(name.c_str());
-                writer.StartArray();
+                writer->Key(name.c_str());
+                writer->StartArray();
                 for (size_t i = 0; i < element_ct; ++i) {
                     if (prop.type == std::type_index(typeid(float))) {
-                        writer.Double(*reinterpret_cast<const float*>(t_buffer + i * sizeof(float)));
+                        writer->Double(*reinterpret_cast<const float*>(t_buffer + i * sizeof(float)));
                     } else if (prop.type == std::type_index(typeid(double))) {
-                        writer.Double(*reinterpret_cast<const double*>(t_buffer + i * sizeof(double)));
+                        writer->Double(*reinterpret_cast<const double*>(t_buffer + i * sizeof(double)));
                     } else if (prop.type == std::type_index(typeid(int64_t))) {
-                        writer.Int64(*reinterpret_cast<const int64_t*>(t_buffer + i * sizeof(int64_t)));
+                        writer->Int64(*reinterpret_cast<const int64_t*>(t_buffer + i * sizeof(int64_t)));
                     } else if (prop.type == std::type_index(typeid(uint64_t))) {
-                        writer.Uint64(*reinterpret_cast<const uint64_t*>(t_buffer + i * sizeof(uint64_t)));
+                        writer->Uint64(*reinterpret_cast<const uint64_t*>(t_buffer + i * sizeof(uint64_t)));
                     } else if (prop.type == std::type_index(typeid(int32_t))) {
-                        writer.Int(*reinterpret_cast<const int32_t*>(t_buffer + i * sizeof(int32_t)));
+                        writer->Int(*reinterpret_cast<const int32_t*>(t_buffer + i * sizeof(int32_t)));
                     } else if (prop.type == std::type_index(typeid(uint32_t))) {
-                        writer.Uint(*reinterpret_cast<const uint32_t*>(t_buffer + i * sizeof(uint32_t)));
+                        writer->Uint(*reinterpret_cast<const uint32_t*>(t_buffer + i * sizeof(uint32_t)));
                     } else if (prop.type == std::type_index(typeid(int16_t))) {
-                        writer.Int(*reinterpret_cast<const int16_t*>(t_buffer + i * sizeof(int16_t)));
+                        writer->Int(*reinterpret_cast<const int16_t*>(t_buffer + i * sizeof(int16_t)));
                     } else if (prop.type == std::type_index(typeid(uint16_t))) {
-                        writer.Uint(*reinterpret_cast<const uint16_t*>(t_buffer + i * sizeof(uint16_t)));
+                        writer->Uint(*reinterpret_cast<const uint16_t*>(t_buffer + i * sizeof(uint16_t)));
                     } else if (prop.type == std::type_index(typeid(int8_t))) {
-                        writer.Int(static_cast<int32_t>(*reinterpret_cast<const int8_t*>(t_buffer + i * sizeof(int8_t))));  // Char outputs weird if being used as an integer
+                        writer->Int(static_cast<int32_t>(*reinterpret_cast<const int8_t*>(t_buffer + i * sizeof(int8_t))));  // Char outputs weird if being used as an integer
                     } else if (prop.type == std::type_index(typeid(uint8_t))) {
-                        writer.Uint(static_cast<uint32_t>(*reinterpret_cast<const uint8_t*>(t_buffer + i * sizeof(uint8_t))));  // Char outputs weird if being used as an integer
+                        writer->Uint(static_cast<uint32_t>(*reinterpret_cast<const uint8_t*>(t_buffer + i * sizeof(uint8_t))));  // Char outputs weird if being used as an integer
                     } else {
                         THROW exception::RapidJSONError("Model contains macro environment property '%s' of unsupported type '%s', "
-                            "in JSONStateWriter::writeStates()\n", name.c_str(), prop.type.name());
+                            "in JSONStateWriter::writeFullModelState()\n", name.c_str(), prop.type.name());
                     }
                 }
-                writer.EndArray();
+                writer->EndArray();
             }
             // Release temp buffer
             free(t_buffer);
         }
     }
-    writer.EndObject();
+    writer->EndObject();
+
+    macro_environment_written = true;
+}
+void JSONStateWriter::writeAgents(const util::StringPairUnorderedMap<std::shared_ptr<const AgentVector>>& agents_map) {
+    if (!writer) {
+        THROW exception::UnknownInternalError("beginWrite() must be called before writeAgents(), in JSONStateWriter::writeAgents()");
+    } else if (agents_written) {
+        THROW exception::UnknownInternalError("writeAgents() can only be called once per write session, in JSONStateWriter::writeAgents()");
+    }
 
     // AgentStates
-    writer.Key("agents");
-    writer.StartObject();
+    writer->Key("agents");
+    writer->StartObject();
     // Build a set of agent names
     std::set<std::string> agent_names;
-    for (const auto& [key, _] : model_state) {
+    for (const auto& [key, _] : agents_map) {
         agent_names.emplace(key.first);
     }
     // Process agents one at a time by iterating the map once per agent type
     for (const auto &agt : agent_names) {
-        writer.Key(agt.c_str());
-        writer.StartObject();
-        for (const auto &agent : model_state) {
+        writer->Key(agt.c_str());
+        writer->StartObject();
+        for (const auto &agent : agents_map) {
             const std::string &agent_name = agent.first.first;
             if (agent_name != agt)
                 continue;
@@ -234,84 +300,63 @@ void JSONStateWriter::doWrite(T &writer) {
             const unsigned int populationSize = agent.second->size();
             // Only log states with agents
             if (populationSize) {
-                writer.Key(state_name.c_str());
-                writer.StartArray();
+                writer->Key(state_name.c_str());
+                writer->StartArray();
                 for (unsigned int i = 0; i < populationSize; ++i) {
-                    writer.StartObject();
-                    AgentVector::Agent instance = agent.second->at(i);
+                    writer->StartObject();
+                    AgentVector::CAgent instance = agent.second->at(i);
                     // for each variable
                     for (auto var : agent_vars) {
                         // Set name
                         const std::string variable_name = var.first;
-                        writer.Key(variable_name.c_str());
+                        writer->Key(variable_name.c_str());
                         // Output value
                         if (var.second.elements > 1) {
                             // Value is an array
-                            writer.StartArray();
+                            writer->StartArray();
                         }
                         // Loop through elements, to construct array
                         for (unsigned int el = 0; el < var.second.elements; ++el) {
                             if (var.second.type == std::type_index(typeid(float))) {
-                                writer.Double(instance.getVariable<float>(variable_name, el));
+                                writer->Double(instance.getVariable<float>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(double))) {
-                                writer.Double(instance.getVariable<double>(variable_name, el));
+                                writer->Double(instance.getVariable<double>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(int64_t))) {
-                                writer.Int64(instance.getVariable<int64_t>(variable_name, el));
+                                writer->Int64(instance.getVariable<int64_t>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(uint64_t))) {
-                                writer.Uint64(instance.getVariable<uint64_t>(variable_name, el));
+                                writer->Uint64(instance.getVariable<uint64_t>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(int32_t))) {
-                                writer.Int(instance.getVariable<int32_t>(variable_name, el));
+                                writer->Int(instance.getVariable<int32_t>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(uint32_t))) {
-                                writer.Uint(instance.getVariable<uint32_t>(variable_name, el));
+                                writer->Uint(instance.getVariable<uint32_t>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(int16_t))) {
-                                writer.Int(instance.getVariable<int16_t>(variable_name, el));
+                                writer->Int(instance.getVariable<int16_t>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(uint16_t))) {
-                                writer.Uint(instance.getVariable<uint16_t>(variable_name, el));
+                                writer->Uint(instance.getVariable<uint16_t>(variable_name, el));
                             } else if (var.second.type == std::type_index(typeid(int8_t))) {
-                                writer.Int(instance.getVariable<int8_t>(variable_name, el));  // Char outputs weird if being used as an integer
+                                writer->Int(instance.getVariable<int8_t>(variable_name, el));  // Char outputs weird if being used as an integer
                             } else if (var.second.type == std::type_index(typeid(uint8_t))) {
-                                writer.Uint(instance.getVariable<uint8_t>(variable_name, el));  // Char outputs weird if being used as an integer
+                                writer->Uint(instance.getVariable<uint8_t>(variable_name, el));  // Char outputs weird if being used as an integer
                             } else {
                                 THROW exception::RapidJSONError("Agent '%s' contains variable '%s' of unsupported type '%s', "
-                                    "in JSONStateWriter::writeStates()\n", agent.first.first.c_str(), variable_name.c_str(), var.second.type.name());
+                                    "in JSONStateWriter::writeAgents()\n", agent.first.first.c_str(), variable_name.c_str(), var.second.type.name());
                             }
                         }
                         if (var.second.elements > 1) {
                             // Value is an array
-                            writer.EndArray();
+                            writer->EndArray();
                         }
                     }
-                    writer.EndObject();
+                    writer->EndObject();
                 }
-                writer.EndArray();
+                writer->EndArray();
             }
         }
-        writer.EndObject();
+        writer->EndObject();
     }
-    writer.EndObject();
+    writer->EndObject();
 
-    // End Json file
-    writer.EndObject();
+    agents_written = true;
 }
-
-int JSONStateWriter::writeStates(bool prettyPrint) {
-    rapidjson::StringBuffer s;
-    if (prettyPrint) {
-        auto writer = rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>(s);
-        writer.SetIndent('\t', 1);
-        doWrite(writer);
-    } else {
-        auto writer = rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>(s);
-        doWrite(writer);
-    }
-
-    // Perform output
-    std::ofstream out(outputFile, std::ofstream::trunc);
-    out << s.GetString();
-    out.close();
-
-    return 0;
-}
-
 }  // namespace io
 }  // namespace flamegpu

--- a/src/flamegpu/io/StateReader.cu
+++ b/src/flamegpu/io/StateReader.cu
@@ -1,0 +1,96 @@
+#include "flamegpu/io/StateReader.h"
+
+namespace flamegpu {
+namespace io {
+
+void StateReader::resetCache() {
+    simulation_config.clear();
+    cuda_config.clear();
+    env_init.clear();
+    macro_env_init.clear();
+    agents_map.clear();
+}
+void StateReader::getFullModelState(
+    Simulation::Config &s_cfg,
+    std::unordered_map<std::string, detail::Any> &environment_init,
+    std::unordered_map<std::string, std::vector<char>> &macro_environment_init,
+    util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &agents_init) {
+    getSimulationConfig(s_cfg);
+    getEnvironment(environment_init);
+    getMacroEnvironment(macro_environment_init);
+    getAgents(agents_init);
+}
+
+#define MAP_GET(out, map, name, typ) out.name = map.find(#name) == map.end()?out.name:std::any_cast<typ>(map.at(#name))
+
+void StateReader::getSimulationConfig(Simulation::Config &cfg) {
+    if (input_filepath.empty()) {
+        THROW exception::InvalidOperation("Input file has not been parsed, in StateReader::getSimulationConfig()");
+    }
+    // if (!simulation_config) {
+    //     THROW exception::InvalidInputFile("Input file %s did not contain an simulation config, in StateReader::getSimulationConfig()", input_filepath.c_str());
+    // }
+    // Set all the items manually
+    MAP_GET(cfg, simulation_config, input_file, std::string);
+    MAP_GET(cfg, simulation_config, step_log_file, std::string);
+    MAP_GET(cfg, simulation_config, exit_log_file, std::string);
+    MAP_GET(cfg, simulation_config, common_log_file, std::string);
+    MAP_GET(cfg, simulation_config, truncate_log_files, bool);
+    MAP_GET(cfg, simulation_config, random_seed, uint64_t);
+    MAP_GET(cfg, simulation_config, steps, unsigned int);
+    MAP_GET(cfg, simulation_config, verbosity, Verbosity);
+    MAP_GET(cfg, simulation_config, timing, bool);
+    MAP_GET(cfg, simulation_config, silence_unknown_args, bool);
+    MAP_GET(cfg, simulation_config, telemetry, bool);
+#ifdef FLAMEGPU_VISUALISATION
+    MAP_GET(cfg, simulation_config, console_mode, bool);
+#endif
+}
+void StateReader::getCUDAConfig(CUDASimulation::Config &cfg) {
+    if (input_filepath.empty()) {
+        THROW exception::InvalidOperation("Input file has not been parsed, in StateReader::getCUDAConfig()");
+    }
+    // if (!cuda_config) {
+    //     THROW exception::InvalidInputFile("Input file %s did not contain an CUDA config, in StateReader::getCUDAConfig()", input_filepath.c_str());
+    // }
+    // Set all the items manually
+    MAP_GET(cfg, cuda_config, device_id, int);
+    MAP_GET(cfg, cuda_config, inLayerConcurrency, bool);
+}
+void StateReader::getEnvironment(std::unordered_map<std::string, detail::Any> &environment_init) {
+    if (input_filepath.empty()) {
+        THROW exception::InvalidOperation("Input file has not been parsed, in StateReader::getEnvironment()");
+    }
+    // if (env_init.empty()) {
+    //     THROW exception::InvalidInputFile("Input file %s did not contain any environment properties, in StateReader::getEnvironment()", input_filepath.c_str());
+    // }
+    for (const auto& [key, val] : env_init) {
+        environment_init.erase(key);
+        environment_init.emplace(key, val);
+    }
+}
+void StateReader::getMacroEnvironment(std::unordered_map<std::string, std::vector<char>> &macro_environment_init) {
+    if (input_filepath.empty()) {
+        THROW exception::InvalidOperation("Input file has not been parsed, in StateReader::getEnvironment()");
+    }
+    // if (macro_env_init.empty()) {
+    //     THROW exception::InvalidInputFile("Input file %s did not contain any macro environment properties, in StateReader::getMacroEnvironment()", input_filepath.c_str());
+    // }
+    for (const auto& [key, val] : macro_env_init) {
+        macro_environment_init.insert_or_assign(key, val);
+    }
+}
+void StateReader::getAgents(util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> &agents_init) {
+    if (input_filepath.empty()) {
+        THROW exception::InvalidOperation("Input file has not been parsed, in StateReader::getEnvironment()");
+    }
+    // if (agents_map.empty()) {
+    //     THROW exception::InvalidInputFile("Input file %s did not contain any agents, in StateReader::getMacroEnvironment()", input_filepath.c_str());
+    // }
+    for (const auto& [key, val] : agents_map) {
+        agents_init.insert_or_assign(key, val);
+    }
+}
+
+}  // namespace io
+}  // namespace flamegpu

--- a/src/flamegpu/runtime/HostAPI.cu
+++ b/src/flamegpu/runtime/HostAPI.cu
@@ -14,7 +14,7 @@ HostAPI::HostAPI(CUDASimulation &_agentModel,
     const AgentOffsetMap &_agentOffsets,
     AgentDataMap &_agentData,
     const std::shared_ptr<detail::EnvironmentManager>& env,
-    detail::CUDAMacroEnvironment &macro_env,
+    const std::shared_ptr<detail::CUDAMacroEnvironment>& macro_env,
     const unsigned int _streamId,
     cudaStream_t _stream)
     : random(rng)

--- a/src/flamegpu/runtime/HostAPI.cu
+++ b/src/flamegpu/runtime/HostAPI.cu
@@ -18,7 +18,7 @@ HostAPI::HostAPI(CUDASimulation &_agentModel,
     const unsigned int _streamId,
     cudaStream_t _stream)
     : random(rng)
-    , environment(_agentModel.getInstanceID(), env, macro_env)
+    , environment(_agentModel, _stream, env, macro_env)
     , agentModel(_agentModel)
     , d_output_space(nullptr)
     , d_output_space_size(0)

--- a/src/flamegpu/runtime/environment/HostEnvironment.cu
+++ b/src/flamegpu/runtime/environment/HostEnvironment.cu
@@ -1,10 +1,113 @@
 #include "flamegpu/runtime/environment/HostEnvironment.cuh"
 
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <numeric>
+#include <vector>
+
+#include "flamegpu/io/StateWriter.h"
+#include "flamegpu/io/StateWriterFactory.h"
+#include "flamegpu/io/StateReader.h"
+#include "flamegpu/io/StateReaderFactory.h"
+#include "flamegpu/simulation/CUDASimulation.h"
+
 namespace flamegpu {
 
-HostEnvironment::HostEnvironment(const unsigned int _instance_id, const std::shared_ptr<detail::EnvironmentManager> &env, const std::shared_ptr<detail::CUDAMacroEnvironment>& _macro_env)
-    : env_mgr(env)
-    , macro_env(_macro_env)
-    , instance_id(_instance_id) { }
+HostEnvironment::HostEnvironment(CUDASimulation &_simulation, cudaStream_t _stream,
+                                 std::shared_ptr<detail::EnvironmentManager> env,
+                                 std::shared_ptr<detail::CUDAMacroEnvironment> _macro_env)
+    : env_mgr(std::move(env))
+    , macro_env(std::move(_macro_env))
+    , instance_id(_simulation.getInstanceID())
+    , simulation(_simulation)
+    , stream(_stream) { }
+
+void HostEnvironment::importMacroProperty(const std::string& property_name, const std::string& file_path) const {
+    // Validate the property exists
+    const auto &m_props = macro_env->getPropertiesMap();
+    const auto &m_prop = m_props.find(property_name);
+    if (m_prop == m_props.end()) {
+        THROW exception::InvalidEnvProperty("The environment macro property '%s' was not found within the model description, in HostEnvironment::importMacroProperty().", property_name.c_str());
+    }
+    const unsigned int m_prop_elements = std::accumulate(m_prop->second.elements.begin(), m_prop->second.elements.end(), 1, std::multiplies<unsigned int>());
+    try {
+        io::StateReader *read__ = io::StateReaderFactory::createReader(file_path);
+        read__->parse(file_path, simulation.getModelDescription().shared_from_this(), Verbosity::Quiet);
+        std::unordered_map<std::string, std::vector<char>> macro_init;
+        read__->getMacroEnvironment(macro_init);
+        // Validate the property exists within macro_init
+        const auto &l_prop = macro_init.find(property_name);
+        if (l_prop == macro_init.end()) {
+            THROW exception::InvalidEnvProperty("The environment macro property '%s' was not found within the input file '%s'.", property_name.c_str(), file_path.c_str());
+        }
+        // Check the length validates
+        if (l_prop->second.size() != m_prop_elements * m_prop->second.type_size) {
+            THROW exception::InvalidInputFile("Length of input file '%s's environment macro property '%s'  does not match, (%u != %u), in HostEnvironment::importMacroProperty()",
+                file_path.c_str(), property_name.c_str(), static_cast<unsigned int>(l_prop->second.size()), static_cast<unsigned int>(m_prop_elements * m_prop->second.type_size));
+        }
+        gpuErrchk(cudaMemcpyAsync(m_prop->second.d_ptr, l_prop->second.data(), l_prop->second.size(), cudaMemcpyHostToDevice, stream));
+    } catch (const exception::UnsupportedFileType&) {
+        const std::string extension = std::filesystem::path(file_path).extension().string();
+        if (extension == ".bin") {
+            // Additionally support raw binary dump
+            // Read the file
+            std::ifstream input(file_path, std::ios::binary);
+            std::vector buffer(std::istreambuf_iterator<char>(input), {});
+            // Check the length validates
+            if (buffer.size() != m_prop_elements * m_prop->second.type_size) {
+                THROW exception::InvalidInputFile("Length of binary input file '%s' does not match the environment macro property '%s', (%u != %u), in HostEnvironment::importMacroProperty()",
+                    file_path.c_str(), property_name.c_str(), static_cast<unsigned int>(buffer.size()), static_cast<unsigned int>(m_prop_elements * m_prop->second.type_size));
+            }
+            // Update the property
+            gpuErrchk(cudaMemcpyAsync(m_prop->second.d_ptr, buffer.data(), buffer.size(), cudaMemcpyHostToDevice, stream));
+        } else {
+            throw;
+        }
+    }
+    gpuErrchk(cudaStreamSynchronize(stream));
+    // If macro property exists in cache sync cache
+    if (const auto cache = macro_env->getHostPropertyMetadata(property_name)) {
+        cache->force_download();
+    }
+}
+void HostEnvironment::exportMacroProperty(const std::string& property_name, const std::string& file_path, bool pretty_print) const {
+    // If macro property exists in cache sync cache
+    if (const auto cache = macro_env->getHostPropertyMetadata(property_name)) {
+        cache->upload();
+    }
+    try {
+        io::StateWriter* write__ = io::StateWriterFactory::createWriter(file_path);
+        write__->beginWrite(file_path, pretty_print);
+        write__->writeMacroEnvironment(macro_env, { property_name });
+        write__->endWrite();
+    } catch (const exception::UnsupportedFileType&) {
+        const std::string extension = std::filesystem::path(file_path).extension().string();
+        if (extension == ".bin") {
+            // Additionally support raw binary dump
+            // Validate the property exists
+            const auto &m_props = macro_env->getPropertiesMap();
+            const auto &m_prop = m_props.find(property_name);
+            if (m_prop == m_props.end()) {
+                THROW exception::InvalidEnvProperty("The environment macro property '%s' was not found within the model description, in HostEnvironment::exportMacroProperty().", property_name.c_str());
+            }
+            // Check the file doesn't already exist
+            if (std::filesystem::exists(file_path)) {
+                THROW exception::FileAlreadyExists("The binary output file '%s' already exists, in HostEnvironment::exportMacroProperty().", file_path.c_str());
+            }
+            // Copy the data to a temporary buffer on host
+            const unsigned int m_prop_elements = std::accumulate(m_prop->second.elements.begin(), m_prop->second.elements.end(), 1, std::multiplies<unsigned int>());
+            std::vector<char> buffer;
+            buffer.resize(m_prop_elements * m_prop->second.type_size);
+            gpuErrchk(cudaMemcpyAsync(buffer.data(), m_prop->second.d_ptr, m_prop_elements * m_prop->second.type_size, cudaMemcpyDeviceToHost, stream));
+            gpuErrchk(cudaStreamSynchronize(stream));
+            // Output to file
+            std::ofstream output(file_path, std::ios::binary);
+            output.write(buffer.data(), buffer.size());
+        } else {
+            throw;
+        }
+    }
+}
 
 }  // namespace flamegpu

--- a/src/flamegpu/runtime/environment/HostEnvironment.cu
+++ b/src/flamegpu/runtime/environment/HostEnvironment.cu
@@ -2,7 +2,7 @@
 
 namespace flamegpu {
 
-HostEnvironment::HostEnvironment(const unsigned int _instance_id, const std::shared_ptr<detail::EnvironmentManager> &env, detail::CUDAMacroEnvironment& _macro_env)
+HostEnvironment::HostEnvironment(const unsigned int _instance_id, const std::shared_ptr<detail::EnvironmentManager> &env, const std::shared_ptr<detail::CUDAMacroEnvironment>& _macro_env)
     : env_mgr(env)
     , macro_env(_macro_env)
     , instance_id(_instance_id) { }

--- a/src/flamegpu/simulation/Simulation.cu
+++ b/src/flamegpu/simulation/Simulation.cu
@@ -61,7 +61,8 @@ void Simulation::applyConfig() {
         }
 
         env_init.clear();
-        io::StateReader *read__ = io::StateReaderFactory::createReader(model->name, model->environment->properties, env_init, pops, config.input_file.c_str(), this);
+        macro_env_init.clear();
+        io::StateReader *read__ = io::StateReaderFactory::createReader(model->name, model->environment->properties, env_init, model->environment->macro_properties, macro_env_init, pops, config.input_file.c_str(), this);
         if (read__) {
             read__->parse();
             for (auto &agent : pops) {
@@ -140,7 +141,7 @@ void Simulation::exportData(const std::string &path, bool prettyPrint) {
         }
     }
 
-    io::StateWriter *write__ = io::StateWriterFactory::createWriter(model->name, getEnvironment(), pops, getStepCounter(), path, this);
+    io::StateWriter *write__ = io::StateWriterFactory::createWriter(model->name, getEnvironment(), pops, getMacroEnvironment(), getStepCounter(), path, this);
     write__->writeStates(prettyPrint);
 }
 void Simulation::exportLog(const std::string &path, bool steps, bool exit, bool stepTime, bool exitTime, bool prettyPrint) {
@@ -186,8 +187,10 @@ int Simulation::checkArgs(int argc, const char** argv) {
                     }
                 }
                 env_init.clear();
+                macro_env_init.clear();
                 const auto &env_desc = model->environment->properties;  // For some reason this method returns a copy, not a reference
-                io::StateReader *read__ = io::StateReaderFactory::createReader(model->name, env_desc, env_init, pops, config.input_file.c_str(), this);
+                const auto &macro_env_desc = model->environment->macro_properties;  // For some reason this method returns a copy, not a reference
+                io::StateReader *read__ = io::StateReaderFactory::createReader(model->name, env_desc, env_init, macro_env_desc, macro_env_init, pops, config.input_file.c_str(), this);
                 if (read__) {
                     try {
                         read__->parse();

--- a/src/flamegpu/simulation/Simulation.cu
+++ b/src/flamegpu/simulation/Simulation.cu
@@ -132,7 +132,7 @@ void Simulation::exportData(const std::string &path, bool prettyPrint) {
         THROW exception::FileAlreadyExists("File '%s' already exists, in Simulation::exportData()", path.c_str());
     }
     // Build population vector
-    util::StringPairUnorderedMap<std::shared_ptr<AgentVector>> pops;
+    util::StringPairUnorderedMap<std::shared_ptr<const AgentVector>> pops;
     for (auto &agent : model->agents) {
         for (auto &state : agent.second->states) {
             auto a = std::make_shared<AgentVector>(*agent.second);
@@ -141,8 +141,10 @@ void Simulation::exportData(const std::string &path, bool prettyPrint) {
         }
     }
 
-    io::StateWriter *write__ = io::StateWriterFactory::createWriter(model->name, getEnvironment(), pops, getMacroEnvironment(), getStepCounter(), path, this);
-    write__->writeStates(prettyPrint);
+    io::StateWriter* write__ = io::StateWriterFactory::createWriter(path);
+    write__->beginWrite(path, prettyPrint);
+    write__->writeFullModelState(this, getStepCounter(), getEnvironment(), getMacroEnvironment(), pops);
+    write__->endWrite();
 }
 void Simulation::exportLog(const std::string &path, bool steps, bool exit, bool stepTime, bool exitTime, bool prettyPrint) {
     if (!config.truncate_log_files && std::filesystem::exists(path)) {

--- a/src/flamegpu/simulation/detail/CUDAAgent.cu
+++ b/src/flamegpu/simulation/detail/CUDAAgent.cu
@@ -450,7 +450,7 @@ void CUDAAgent::clearFunctionCondition(const std::string &state) {
     fat_agent->setConditionState(fat_index, state, 0);
 }
 
-void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager> &env, const CUDAMacroEnvironment &macro_env, bool function_condition) {
+void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager> &env, std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env, bool function_condition) {
     // Generate the dynamic curve header
     detail::curve::CurveRTCHost &curve_header = *rtc_header_map.emplace(function_condition ? func.name + "_condition" : func.name, std::make_unique<detail::curve::CurveRTCHost>()).first->second;
 
@@ -500,7 +500,7 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, const 
     }
 
     // Set Environment macro properties in curve
-    macro_env.mapRTCVariables(curve_header);
+    macro_env->mapRTCVariables(curve_header);
 
     std::string header_filename = std::string(func.rtc_func_name).append("_impl");
     if (function_condition)
@@ -558,7 +558,7 @@ void CUDAAgent::addInstantitateRTCFunction(const AgentFunctionData& func, const 
     }
 }
 
-void CUDAAgent::addInstantitateFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager>& env, const CUDAMacroEnvironment& macro_env, bool function_condition) {
+void CUDAAgent::addInstantitateFunction(const AgentFunctionData& func, const std::shared_ptr<EnvironmentManager>& env, std::shared_ptr<const detail::CUDAMacroEnvironment> macro_env, bool function_condition) {
     // Generate the host curve instance
     std::unique_ptr<detail::curve::HostCurve> curve = std::make_unique<detail::curve::HostCurve>();
 
@@ -600,7 +600,7 @@ void CUDAAgent::addInstantitateFunction(const AgentFunctionData& func, const std
     }
 
     // Set Environment macro properties in curve
-    macro_env.registerCurveVariables(*curve);
+    macro_env->registerCurveVariables(*curve);
 
     // switch between normal agent function and agent function condition, and add to map
     const std::string key_name = function_condition ? func.name + "_condition" : func.name;

--- a/src/flamegpu/simulation/detail/CUDAMacroEnvironment.cu
+++ b/src/flamegpu/simulation/detail/CUDAMacroEnvironment.cu
@@ -102,6 +102,14 @@ void CUDAMacroEnvironment::unmapRTCVariables(detail::curve::CurveRTCHost& curve_
 const std::map<std::string, CUDAMacroEnvironment::MacroEnvProp>& CUDAMacroEnvironment::getPropertiesMap() const {
     return properties;
 }
+
+std::shared_ptr<HostMacroProperty_MetaData> CUDAMacroEnvironment::getHostPropertyMetadata(const std::string property_name) {
+    auto cache = host_cache.find(property_name);
+    if (cache != host_cache.end()) {
+        return cache->second.lock();
+    }
+    return nullptr;
+}
 #if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS
 void CUDAMacroEnvironment::resetFlagsAsync(const std::vector<cudaStream_t> &streams) {
     unsigned int i = 0;


### PR DESCRIPTION
Ended up refactoring much of the internal model state IO interface to make partial import/export possible.

- [x] BugFix: `JSONStateWriter` would create an agent object for each agent state, leading to multiple members with the same key.
- [x] Bugfix: `HostMacroProperty` did not use streams to copy data. (C tests still pass after this change)
- [x] Switch `CUDAMacroEnvironment` from reference to `shared_ptr`
* State
  * Export
    - [x] JSON
    - [x] XML
  * Import
    - [x] JSON
    - [x] XML
  - [x] tests
* HostAPI
  * Export
    - [x] JSON
    - [x] XML
    - [x] binary
  * Import
    - [x] JSON
    - [x] XML
    - [x] binary
  - [x] tests
- [x] Docs update PR (https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/152)

**Of note, macro properties can still not be initialised via `EnvironmentDescription` or `RunPlan`.**

It's a basic interface change (two new methods added to `HostAPI` with no weird types/templates, so only C API tests have been extended/updated.

Commits are split cleanly, does **not** require squash.

Closes #1070 