### PR TITLE
Fix CMake's EscapeRegex fn

### DIFF
--- a/cmake/EscapeRegex.cmake
+++ b/cmake/EscapeRegex.cmake
@@ -3,5 +3,5 @@
 function(escape_regex IN_STRING OUT_VAR)
     # https://gitlab.kitware.com/cmake/cmake/-/issues/18580#note_483128
     string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" OUT_STRING "${IN_STRING}")
-    set(${OUT_VAR} "${OUT_VAR}" PARENT_SCOPE)
+    set(${OUT_VAR} "${OUT_STRING}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Must have got broken when tidying up #1085 and missed in review.