### PR TITLE
Tests: Increase robustness of context creation testing

### DIFF
--- a/tests/helpers/device_initialisation.h
+++ b/tests/helpers/device_initialisation.h
@@ -4,10 +4,16 @@
 namespace flamegpu {
 namespace tests {
 /**
- * Function to time the creation of the cuda context within the scope of FLAME GPU initialisation.
- * Must be run first to ensure a fresh context is being created, rather than within the google test suite which may be executed in a random order.
- */
-void timeCUDASimulationContextCreationTest();
+ *  Test that no cuda context is established prior to  CUDASimulation::applyConfig_derived().
+ *
+ * I.e. make sure that nothing occurs before device selection.
+ *
+ * This is performed by checking the cuda driver api current context is null, rather than the runtime api + timing based approach which was fluffy / driver updates improving context creation time would break the test.
+ *
+ * @note - This needs to be called first, and only once, hence it is not a true google test.
+ * @todo - It may be better places in it's own test binary, orchestrated via ctest to ensure it is first and only called once.
+*/
+void runCUDASimulationContextCreationTest();
 
 /**
  * Determine the success of the cuda context creation test.

--- a/tests/helpers/main.cu
+++ b/tests/helpers/main.cu
@@ -16,8 +16,8 @@ GTEST_API_ int main(int argc, char **argv) {
     flamegpu::io::Telemetry::disable();
     // Suppress the notice about telemetry.
     flamegpu::io::Telemetry::suppressNotice();
-    // Time the cuda agent model initialisation, to check it creates the context.
-    flamegpu::tests::timeCUDASimulationContextCreationTest();
+    // Check cuda context creation, once and only once prior to any CUDA call. This would be better in it's own test binary.
+    flamegpu::tests::runCUDASimulationContextCreationTest();
     // Run the main google test body
     printf("Running main() from %s\n", __FILE__);
     testing::InitGoogleTest(&argc, argv);

--- a/tests/test_cases/simulation/test_cuda_simulation_concurrency.cu
+++ b/tests/test_cases/simulation/test_cuda_simulation_concurrency.cu
@@ -1,6 +1,5 @@
 #include "flamegpu/flamegpu.h"
 #include "flamegpu/detail/compute_capability.cuh"
-#include "helpers/device_initialisation.h"
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
To ensure that no cuda calls occur prior to device selection, an always run method in the test suite previously used timing and a cutoff threshold to make sure a new context was being established. This was quite flakey, as new driver updates could improve context creation times, requiring a lower threshold.

Instead, getting the current context via the driver api is used, and it should return null (or a cuda error) if no context yet exists. This should be a much more robust testing mechanism.

This is still created per run of the test suite, regardless of if the specific test is requested or not, which is wasted time if running with a filter (one more context creation than needed, so extra time).

We may wish to move this test to a separate ctest orcestrated test binary, to ensure it is the first to run (Google test has no way to enforce test order as a feature)

---

Tested on linux with CUDA 11.0 and 12.2 (12.2/driver 535 broke the old test on my 3060ti as context creation was too fast), and manually added a context creating call prior to `applyConfig` to ensure it will identify any errors that it is checking for.

Also removed a superfluos include. 