### PR TITLE
Update 'latest' CI to CUDA 12.2

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -43,6 +43,7 @@ $CUDA_KNOWN_URLS = @{
     "12.0.0" = "https://developer.download.nvidia.com/compute/cuda/12.0.0/network_installers/cuda_12.0.0_windows_network.exe";
     "12.0.1" = "https://developer.download.nvidia.com/compute/cuda/12.0.1/network_installers/cuda_12.0.1_windows_network.exe";
     "12.1.0" = "https://developer.download.nvidia.com/compute/cuda/12.1.0/network_installers/cuda_12.1.0_windows_network.exe";
+    "12.2.0" = "https://developer.download.nvidia.com/compute/cuda/12.2.0/network_installers/cuda_12.2.0_windows_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "12.1"
+          - cuda: "12.2"
             cuda_arch: "50"
             hostcxx: gcc-12
             os: ubuntu-22.04

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,7 +29,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "12.1.0"
+          - cuda: "12.2.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022


### PR DESCRIPTION
Update CI and windows installation script to CUDA 12.2.

Local linux builds behave as intended, although the included driver update may break the context creation timing test (see #1096)