### PR TITLE
Telemetry ensemble config

### DIFF
--- a/src/flamegpu/detail/compute_capability.cu
+++ b/src/flamegpu/detail/compute_capability.cu
@@ -125,17 +125,23 @@ const std::string compute_capability::getDeviceName(int deviceIndex) {
 const std::string compute_capability::getDeviceNames(std::set<int> devices) {
     std::string device_names;
     bool first = true;
+    // Get the count of devices
+    int deviceCount = 0;
+    gpuErrchk(cudaGetDeviceCount(&deviceCount));
+    // If no devices were passed in, add each device to the set of devices.
+    if (devices.size() == 0) {
+        for (int i = 0; i < deviceCount; i++) {
+            devices.emplace_hint(devices.end(), i);
+        }
+    }
     for (int device_id : devices) {
         // Throw an exception if the deviceIndex is negative.
         if (device_id < 0) {
             THROW exception::InvalidCUDAdevice();
         }
-
         // Ensure deviceIndex is valid.
-        int deviceCount = 0;
-        gpuErrchk(cudaGetDeviceCount(&deviceCount));
         if (device_id >= deviceCount) {
-            // Throw an excpetion if the device index is bad.
+            // Throw an exception if the device index is bad.
             THROW exception::InvalidCUDAdevice();
         }
         // Load device properties

--- a/src/flamegpu/simulation/CUDAEnsemble.cu
+++ b/src/flamegpu/simulation/CUDAEnsemble.cu
@@ -239,6 +239,9 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
         #if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__) && defined(__CUDACC_VER_PATCH__)
             payload_items["NVCCVersion"] = std::to_string(__CUDACC_VER_MAJOR__) + "." + std::to_string(__CUDACC_VER_MINOR__) + "." + std::to_string(__CUDACC_VER_BUILD__);
         #endif
+        // Add the ensemble size to the ensemble telemetry payload
+        payload_items["PlansSize"] = std::to_string(plans.size());
+        payload_items["ConcurrentRuns"] = std::to_string(config.concurrent_runs);
         // generate telemetry data
         std::string telemetry_data = flamegpu::io::Telemetry::generateData("ensemble-run", payload_items, isSWIG);
         // send the telemetry packet


### PR DESCRIPTION
+ Fixes list of devices in enesemble telemetry payload if no explicit device indicies are provided (i.e. use all). 
+ Adds the `PlansSize` and `ConcurrentRuns` payload data for `ensemble-run` payloads, contianing the total number of runs for the ensemble, and how many to run at once.

---
+ [x] Test Payload data now includes this in telemetry deck
  ![image](https://github.com/FLAMEGPU/FLAMEGPU2/assets/628937/463c05cd-f32e-4bef-bc81-638eba6849b9)
+ [x] Test multi-gpu data is correctly passed to telemetry deck
  ![image](https://github.com/FLAMEGPU/FLAMEGPU2/assets/628937/1e5dd054-c125-409c-9f59-8d82d2350bc5)
