### PR TITLE
Telemetry: Fix inclusiong of NVCCVersion

### DIFF
--- a/src/flamegpu/simulation/CUDAEnsemble.cu
+++ b/src/flamegpu/simulation/CUDAEnsemble.cu
@@ -236,7 +236,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector &plans) {
         std::map<std::string, std::string> payload_items;
         payload_items["GPUDevices"] = flamegpu::detail::compute_capability::getDeviceNames(config.devices);
         payload_items["SimTime(s)"] = std::to_string(ensemble_elapsed_time);
-        #if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__) && defined(__CUDACC_VER_PATCH__)
+        #if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__) && defined(__CUDACC_VER_BUILD__)
             payload_items["NVCCVersion"] = std::to_string(__CUDACC_VER_MAJOR__) + "." + std::to_string(__CUDACC_VER_MINOR__) + "." + std::to_string(__CUDACC_VER_BUILD__);
         #endif
         // generate telemetry data

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -1256,7 +1256,7 @@ void CUDASimulation::simulate() {
         std::map<std::string, std::string> payload_items;
         payload_items["GPUDevices"] = flamegpu::detail::compute_capability::getDeviceName(deviceInitialised);
         payload_items["SimTime(s)"] = std::to_string(elapsedSecondsSimulation);
-        #if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__) && defined(__CUDACC_VER_PATCH__)
+        #if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__) && defined(__CUDACC_VER_BUILD__)
             payload_items["NVCCVersion"] = std::to_string(__CUDACC_VER_MAJOR__) + "." + std::to_string(__CUDACC_VER_MINOR__) + "." + std::to_string(__CUDACC_VER_BUILD__);
         #endif
         // generate telemtry data


### PR DESCRIPTION
Fixes the macro guarding out the inclusion of NVCCVersion in telemetry payloads. The payload had been fixed previously but not the macro guarding it's inclusion.