### PR TITLE
Add post-release CI which triggers wheelhouse creation via gh

### DIFF
--- a/.github/workflows/Post-Release.yml
+++ b/.github/workflows/Post-Release.yml
@@ -1,0 +1,23 @@
+name: Post Release
+# On publication of a release, or when manually triggerered
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  # Trigger creation of the wheelhouse via an api call. PAT required.
+  trigger-wheelhouse-ci:
+    runs-on: ubuntu-latest
+    steps:
+      # Use gh to trigger the workflow_dispatch event on the appropriate workflow in another repository.
+      # This step may fail if the PAT is invalid or has expired
+      # If so, create a fine-grained pat with actions: write and permissions on the appropriate repository, storing it in the relevant secret on this repository.
+      - name: Trigger FLAMEGPU2-wheelhouse
+        env:
+          GH_TOKEN: ${{ secrets.WHEELHOUSE_TOKEN }}
+          REPO: "FLAMEGPU/FLAMEGPU2-wheelhouse"
+          WORKFLOW: "ci.yml"
+        run: |
+          gh workflow run ${WORKFLOW} -R ${REPO}
+          sleep 5
+          gh run watch -R ${REPO} $(gh run list -R ${REPO} -w ${WORKFLOW} -L1 --json databaseId --jq .[0].databaseId)


### PR DESCRIPTION
Adds a CI workflow which is triggered by release publication, which will then trigger a different workflow on another repository.

This requires a PAT to be created and stored in the appropraite repository secret. 

We could extend this to also trigger docs builds for us, but would need to maintain 2 PATs, and potentially the website if we were to make the website build fetch information about the wheelhouse for instance.

# Todo 

+ [ ] Finish setting up the other repository
+ [ ] Create PAT and store in the relevant secret on this repository
+ [ ] Update readme with wheelhouse information / instructions. 
  + I might add a basic html page to the wheelhouse with instructions on use, pointing at each of the generated sub-wheel houses? It could potentially just go in the root wheelhouse but not 100% if that is valid or not.


Closes #645 