### PR TITLE
Fix for standalone msg variables inside agent python

### DIFF
--- a/tests/python/codegen/test_codegen.py
+++ b/tests/python/codegen/test_codegen.py
@@ -310,6 +310,17 @@ for (const auto& m : FLAMEGPU->message_in){
 }
 """
 
+py_fgpu_standalone_msg_input = """\
+m = message_in.at(1)
+pass
+n = m.getVariableInt("foo")
+"""
+cpp_fgpu_standalone_msg_input = """\
+auto m = FLAMEGPU->message_in.at(1);
+;
+auto n = m.getVariable<int>("foo");
+"""
+
 py_fgpu_for_msg_input_args = """\
 for m in message_in(x, y, z) : 
     pass
@@ -754,6 +765,8 @@ class CodeGenTest(unittest.TestCase):
         self._checkException(py_fgpu_for_msg_input_func_unknown, "Function 'unsupported' does not exist") 
         # Test math function inside message loop (Previously bug #1077)
         self._checkExpected(py_fgpu_for_msg_input_math_func, cpp_fgpu_for_msg_input_math_func) 
+        # Test standalone input message (Previously bug #1110)
+        self._checkExpected(py_fgpu_standalone_msg_input, cpp_fgpu_standalone_msg_input) 
         # Test message input where message input requires arguments (e.g. spatial messaging)
         self._checkExpected(py_fgpu_for_msg_input_args, cpp_fgpu_for_msg_input_args)
         # Test to ensure that arguments are processed as local variables 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -40,7 +40,7 @@ def pytest_sessionfinish(session, exitstatus):
         # Exit if the terminalreport plugin could not be found
         if not terminalreporter:
             return
-        outcome = "Passed" if exitstatus == 0 else "Failed(code={exitstatus})"
+        outcome = "Passed" if exitstatus == 0 else f"Failed(code={exitstatus})"
         passed = len(terminalreporter.stats.get('passed', []))
         failed = len(terminalreporter.stats.get('failed', []))
         skipped = len(terminalreporter.stats.get('skipped', []))


### PR DESCRIPTION
This change:
* `CodeGen::_Assign()` Added a detection when a variable is created via `<inputmsg>.at()`, adding the variables identifier to `self._standalone_message_var`.
* `CodeGen::dispatchMemberFunction()` Check whether the variable can be found inside `self._standalone_message_var`, if so treat it similar to an input message iterator.
* Associated new test case.

**Note:**
Potential issue that these variables are never removed from the list, e.g. if they should be going out of scope.

Closes #1110 