### PR TITLE
Python 3.12 and 3.7

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -26,9 +26,9 @@ defaults:
 # + Thorough Windows builds
 #   + Oldest and newest cuda, lots of arch, vis off, tests on
 # + Wheel producing manylinux builds
-#   + CUDA 11.2 and 12.0, py 3.7-11, vis on/off, py only.
+#   + CUDA 11.2 and 12.0, py 3.7-3.12, vis on/off, py only.
 # + Wheel producing Windows builds
-#   + CUDA 11.2 and 12.0, py 3.7-11, vis on/off, py only.
+#   + CUDA 11.2 and 12.0, py 3.7-3.12, vis on/off, py only.
 # + Draft github release workflow.
 
 jobs:
@@ -319,6 +319,7 @@ jobs:
             hostcxx: devtoolset-9
             os: ubuntu-20.04
         python: 
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
@@ -479,6 +480,7 @@ jobs:
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -26,9 +26,9 @@ defaults:
 # + Thorough Windows builds
 #   + Oldest and newest cuda, lots of arch, vis off, tests on
 # + Wheel producing manylinux builds
-#   + CUDA 11.2 and 12.0, py 3.7-3.12, vis on/off, py only.
+#   + CUDA 11.2 and 12.0, py 3.8-3.12, vis on/off, py only.
 # + Wheel producing Windows builds
-#   + CUDA 11.2 and 12.0, py 3.7-3.12, vis on/off, py only.
+#   + CUDA 11.2 and 12.0, py 3.8-3.12, vis on/off, py only.
 # + Draft github release workflow.
 
 jobs:
@@ -324,7 +324,6 @@ jobs:
           - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
         config:
           - name: "Release"
             config: "Release"
@@ -485,7 +484,6 @@ jobs:
           - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -42,7 +42,7 @@ jobs:
             hostcxx: devtoolset-9
             os: ubuntu-20.04
         python: 
-          - "3.11"
+          - "3.12"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
             hostcxx: gcc-8
             os: ubuntu-20.04
         python: 
-          - "3.11"
+          - "3.12"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -42,7 +42,7 @@ jobs:
             hostcxx: "Visual Studio 16 2019"
             os: windows-2019
         python: 
-          - "3.11"
+          - "3.12"
         config:
           - name: "Release"
             config: "Release"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Optionally:
 
 + [cpplint](https://github.com/cpplint/cpplint) for linting code
 + [Doxygen](http://www.doxygen.nl/) to build the documentation
-+ [Python](https://www.python.org/) `>= 3.7` for python integration
++ [Python](https://www.python.org/) `>= 3.8` for python integration
   + With `setuptools`, `wheel`, `build` and optionally `venv` python packages installed
 + [swig](http://www.swig.org/) `>= 4.0.2` for python integration
   + Swig `4.x` will be automatically downloaded by CMake if not provided (if possible).

--- a/swig/python/codegen/codegen.py
+++ b/swig/python/codegen/codegen.py
@@ -223,7 +223,7 @@ class CodeGenerator:
             bounds = tree_parent.args[1:]
             # process bounds by appending to cpp function template arguments
             for i in bounds:
-                if isinstance(i, ast.Num): # num required for python 3.7
+                if sys.version_info < (3,8,0) and isinstance(i, ast.Num): # num required for python 3.7
                     if not isinstance(i.n, int):
                         self.RaiseError(tree, f" Macro environment function argument '{i}' should be an integer value.")
                     cpp_func_name += f", {i.n}"
@@ -585,7 +585,7 @@ class CodeGenerator:
             if isinstance(tree.value.value, str):
                 return
         # catch special case of Python 3.7 Where doc string is a Str and not a Constant
-        elif isinstance(tree.value, ast.Str):
+        elif sys.version_info < (3,8,0) and isinstance(tree.value, ast.Str):
             return 
         # otherwise treat like a normal expression
         self.fill()

--- a/swig/python/codegen/codegen.py
+++ b/swig/python/codegen/codegen.py
@@ -585,7 +585,7 @@ class CodeGenerator:
             if isinstance(tree.value.value, str):
                 return
         # catch special case of Python 3.7 Where doc string is a Str and not a Constant
-        elif sys.version_info < (3,8,0) and isinstance(tree.value, ast.Str):
+        elif sys.version_info < (3,8,0) and isinstance(tree.value, ast.Str): # num required for python 3.7
             return 
         # otherwise treat like a normal expression
         self.fill()


### PR DESCRIPTION
+ Replaces python 3.11 with 3.12 in "regular" CI
+ Adds python 3.12 to the wheel build matrix
+ Removes python 3.7 from the wheel build matrix
  + EOL 2023-06-27 
  + python 3.7 specific code left-in place in case users are unable to upgrade
+ Address python 3.12 deprecation warnings
+ Test suite passes with python 3.7, 3.8 and 3.12 with no deprecation warnings