### PR TITLE
FLAMEGPU_SEATBELTS=OFF did not build

### DIFF
--- a/include/flamegpu/simulation/CUDASimulation.h
+++ b/include/flamegpu/simulation/CUDASimulation.h
@@ -562,15 +562,15 @@ class CUDASimulation : public Simulation {
          * Held here for tracking when to release cuda memory
          */
         std::shared_ptr<detail::EnvironmentManager> environment;
+        /**
+         * Provides copies of strings (agent/state names) on device
+         */
+        detail::DeviceStrings strings;
 #if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS
         /**
          * Provides buffers for device error checking
          */
         exception::DeviceExceptionManager exception;
-        /**
-         * Provides copies of strings (agent/state names) on device
-         */
-        detail::DeviceStrings strings;
 #endif
         explicit Singletons(const std::shared_ptr<detail::EnvironmentManager> &environment) : environment(environment) { }
     } * singletons;


### PR DESCRIPTION
This bug was introduced by #1116

Closes #1137

Debug/Windows/Seatbelts=OFF
```
[----------] Global test environment tear-down
[==========] 1116 tests from 85 test suites ran. (984962 ms total)
[  PASSED  ] 1116 tests.

  YOU HAVE 18 DISABLED TESTS
```