### PR TITLE
Make individual example CI builds use FLAMEGPU_SEATBELTS=OFF

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -199,6 +199,7 @@ jobs:
         -DFLAMEGPU_WARNINGS_AS_ERRORS="ON"
         -DCMAKE_CUDA_ARCHITECTURES="${{ env.CUDA_ARCH }}"
         -DFLAMEGPU_ENABLE_NVTX="ON"
+        -DFLAMEGPU_SEATBELTS="OFF"
     
     - name: Build Individual example
       if: ${{ env.INDIVIDUAL_EXAMPLE != '' }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -169,6 +169,7 @@ jobs:
         -DFLAMEGPU_WARNINGS_AS_ERRORS="ON"
         -DCMAKE_CUDA_ARCHITECTURES="${{ env.CUDA_ARCH }}"
         -DFLAMEGPU_ENABLE_NVTX="ON"
+        -DFLAMEGPU_SEATBELTS="OFF"
     
     - name: Build Individual example
       if: ${{ env.INDIVIDUAL_EXAMPLE != '' }}


### PR DESCRIPTION
This is a short-term / quick way to get a beltsoff build into CI, suggested by @robadob as short term part of #1138.

This does not give full coverage with belts off, just `flamegpu` and a single example (i.e. no tests or pyflamegpu coverage). 

This will be replaced by a 'correct' version in the future (as our current matrix is technically unsupported, although it mostly works, and is not expliucitly documented as such other than in the web workflow editor. 