### PR TITLE
BugFix: Edgecase in handling standalone msg input would break transpilation.

### DIFF
--- a/swig/python/codegen/codegen.py
+++ b/swig/python/codegen/codegen.py
@@ -622,7 +622,7 @@ class CodeGenerator:
         # check if target exists in locals
         if t.targets[0].id not in self._locals :
             # Special case, catch message.at() where a message is returned outside a message loop
-            if hasattr(t.value, "func") and t.value.func.attr == 'at' :
+            if hasattr(t.value, "func") and isinstance(t.value.func, ast.Attribute) and t.value.func.attr == 'at' :
                 if t.value.func.value.id == self._input_message_var :
                     self._standalone_message_var.append(t.targets[0].id)
             self.write("auto ")

--- a/swig/python/codegen/codegen.py
+++ b/swig/python/codegen/codegen.py
@@ -1150,10 +1150,14 @@ class CodeGenerator:
         # check calls but let attributes check in their own dispatcher
         funcs = self._device_functions + self.pythonbuiltins + [self._input_message_var] # message_input variable is a valid function name as certain message types have arguments on iterator
         if isinstance(t.func, ast.Name):
-            if (t.func.id not in funcs):
-                self.RaiseWarning(t, "Function call is not a defined FLAME GPU device function or a supported python built in.")
-            # dispatch even if warning raised
-            self.dispatch(t.func)
+            if t.func.id in self.basic_arg_types:
+                # Special case for casting python basic types (int/float)
+                self.write(f"static_cast<{t.func.id}>")
+            else:
+                if (t.func.id not in funcs):
+                    self.RaiseWarning(t, "Function call is not a defined FLAME GPU device function or a supported python built in.")
+                # dispatch even if warning raised
+                self.dispatch(t.func)
         elif isinstance(t.func, ast.Lambda):
             self.dispatch(t.func) # not supported
         else:

--- a/tests/python/codegen/test_codegen.py
+++ b/tests/python/codegen/test_codegen.py
@@ -268,7 +268,7 @@ def movement_request(message_in: pyflamegpu.MessageArray2D, message_out: pyflame
 """
 cpp_fgpu_name_not_attr = """\
 FLAMEGPU_AGENT_FUNCTION(movement_request, flamegpu::MessageArray2D, flamegpu::MessageArray2D){
-    auto AGENT_START_COUNT = int(2);
+    auto AGENT_START_COUNT = static_cast<int>(2);
     return flamegpu::ALIVE;
 }
 """


### PR DESCRIPTION
Adds a test that covers the previous error, and moves the standalone msg test into it's own case.

Closes #1141

Additionally I noticed and fixed that `foo = int(1)` translates to `auto foo = int(1);` rather than what I expected `auto foo = static_cast<int>(1);`. The existing cast code only looked for `numpy` type casting (which is handled differently as the AST sees it as a member function).