### PR TITLE
BugFix: Unable to cast floating point to enum.

### DIFF
--- a/src/flamegpu/io/JSONStateReader.cu
+++ b/src/flamegpu/io/JSONStateReader.cu
@@ -364,7 +364,7 @@ class JSONStateReader_agentsize_counter : public rapidjson::BaseReaderHandler<ra
             } else if (lastKey == "timing") {
                 simulation_config.emplace(lastKey, static_cast<bool>(val));
             } else if (lastKey == "verbosity") {
-                simulation_config.emplace(lastKey, static_cast<flamegpu::Verbosity>(val));
+                simulation_config.emplace(lastKey, static_cast<flamegpu::Verbosity>(static_cast<int>(val)));
             } else if (lastKey == "console_mode") {
 #ifdef FLAMEGPU_VISUALISATION
                 simulation_config.emplace(lastKey, static_cast<bool>(val));


### PR DESCRIPTION
Addresses the below issue, actual reproduction unclear (builds with vs2019 and vs2022 for me).

```
3>C:\Code\FLAMEGPU2\src\flamegpu\io\JSONStateReader.cu(367): error C2440: 'static_cast': cannot convert from 'const T' to 'flamegpu::Verbosity'
3>        with
3>        [
3>            T=double
3>        ]
3>C:\Code\FLAMEGPU2\src\flamegpu\io\JSONStateReader.cu(367): note: Conversions between enumeration and floating point values are no longer allowed
3>C:\Code\FLAMEGPU2\src\flamegpu\io\JSONStateReader.cu(400): note: see reference to function template instantiation 'bool flamegpu::io::JSONStateReader_agentsize_counter::processValue<double>(const T)' being compiled
3>        with
3>        [
3>            T=double
3>        ]
3>C:/Code/FLAMEGPU2/include\flamegpu/runtime/environment/HostMacroProperty.cuh(76): note: see reference to class template instantiation 'std::array<unsigned int,4>' being compiled
3>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\BuildCustomizations\CUDA 11.7.targets(790,9): error MSB3721: The command ""C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\bin\nvcc.exe" -gencode=arch=compute_52,code=\"compute_52,compute_52\" -gencode=arch=compute_52,code=\"sm_52,compute_52\" --use-local-env -ccbin "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.21.27702\bin\HostX64\x64" -x cu -rdc=true  -IC:\Code\FLAMEGPU2\include -IC:\Code\FLAMEGPU2\src -I"C:\Code\FLAMEGPU2\build\_deps\thrust-src\dependencies\cub" -I"C:\Code\FLAMEGPU2\build\_deps\thrust-src" -I"C:\Code\FLAMEGPU2\build\_deps\tinyxml2-src" -I"C:\Code\FLAMEGPU2\build\_deps\rapidjson-src\include" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\include" -I"C:\Code\FLAMEGPU2\build\_deps\jitify-src" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.7\include"     --keep-dir x64\Release  -maxrregcount=0  --machine 64 --compile -cudart shared --Wreorder -Xcudafe --display_error_number -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=declared_but_not_referenced -Xcudafe --diag_suppress=2809 -lineinfo --expt-relaxed-constexpr --threads 2 -std=c++17 -Xcompiler="/EHsc -Ob2 /wd4503 /wd4505 /wd4100 /wd4127 /MP"   -D_WINDOWS -DNDEBUG -D__CDPRT_SUPPRESS_SYNC_DEPRECATION_WARNING -DNOMINMAX -DFLAMEGPU_SEATBELTS=1 -DFLAMEGPU_MIN_CUDA_ARCH=52 -DFLAMEGPU_CURAND_Philox4_32_10 -DFLAMEGPU_SHARE_USAGE_STATISTICS=1 -DJITIFY_PRINT_LOG -D_CRT_SECURE_NO_WARNINGS -D"CMAKE_INTDIR=\"Release\"" -D_MBCS -DWIN32 -D_WINDOWS -DNDEBUG -D__CDPRT_SUPPRESS_SYNC_DEPRECATION_WARNING -DNOMINMAX -DFLAMEGPU_SEATBELTS=1 -DFLAMEGPU_MIN_CUDA_ARCH=52 -DFLAMEGPU_CURAND_Philox4_32_10 -DFLAMEGPU_SHARE_USAGE_STATISTICS=1 -DJITIFY_PRINT_LOG -D_CRT_SECURE_NO_WARNINGS -D"CMAKE_INTDIR=\"Release\"" -Xcompiler "/EHsc /W4 /nologo /O2 /Fdflamegpu.dir\Release\flamegpu.pdb /FS   /MD /GR" -o flamegpu.dir\Release\JSONStateReader.obj "C:\Code\FLAMEGPU2\src\flamegpu\io\JSONStateReader.cu"" exited with code -1.
3>Done building project "flamegpu.vcxproj" -- FAILED.
```