### PR TITLE
Adds RunPlanVector::setPropertyStep()

### DIFF
--- a/swig/python/flamegpu.i
+++ b/swig/python/flamegpu.i
@@ -957,6 +957,7 @@ TEMPLATE_VARIABLE_INSTANTIATE_ID(setProperty, flamegpu::RunPlanVector::setProper
 TEMPLATE_VARIABLE_ARRAY_INSTANTIATE_ID(setProperty, flamegpu::RunPlanVector::setProperty)
 TEMPLATE_VARIABLE_INSTANTIATE_ID(setPropertyArray, flamegpu::RunPlanVector::setPropertyArray)
 TEMPLATE_VARIABLE_INSTANTIATE(setPropertyLerpRange, flamegpu::RunPlanVector::setPropertyLerpRange)
+TEMPLATE_VARIABLE_INSTANTIATE(setPropertyStep, flamegpu::RunPlanVector::setPropertyStep)
 TEMPLATE_VARIABLE_INSTANTIATE(setPropertyUniformRandom, flamegpu::RunPlanVector::setPropertyUniformRandom)
 TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(setPropertyNormalRandom, flamegpu::RunPlanVector::setPropertyNormalRandom)
 TEMPLATE_VARIABLE_INSTANTIATE_FLOATS(setPropertyLogNormalRandom, flamegpu::RunPlanVector::setPropertyLogNormalRandom)


### PR DESCRIPTION
This has behaviour similar to Python's range(), more appropriate than lerp in many cases with integers.

Providing this will hopefully help people avoid using lerp wrongly for integers.

https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/175

alt possible names:
* `setPropertyUniformStep()`
* `setPropertyInterval()`
* `setPropertyUniformInterval()`
* `setPropertyRange()` (reminds me of Python's `range()` although it's not 1-1 as the length is predefined).