### PR TITLE
BugFix: MsgSpatial interaction radius correct when not a factor of en…

### DIFF
--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
@@ -500,6 +500,13 @@ class MessageSpatial2D::In {
              // Return iterator at min corner of env, this should be safe
              return WrapFilter(metadata, metadata->min[0], metadata->min[1]);
          }
+         if (fmodf(metadata->max[0] - metadata->min[0], metadata->radius) > 0.00001f ||
+             fmodf(metadata->max[1] - metadata->min[1], metadata->radius) > 0.00001f) {
+             DTHROW("Spatial messaging radius (%g) is not a factor of environment dimensions (%g, %g),"
+                 " this is unsupported for the wrapped iterator, MessageSpatial2D::In::wrap().\n", metadata->radius,
+                 metadata->max[0] - metadata->min[0],
+                 metadata->max[1] - metadata->min[1]);
+         }
 #endif
          return WrapFilter(metadata, x, y);
      }

--- a/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial2D/MessageSpatial2DDevice.cuh
@@ -599,8 +599,8 @@ T MessageSpatial2D::In::WrapFilter::Message::getVariable(const char(&variable_na
 __device__ __forceinline__ MessageSpatial2D::GridPos2D getGridPosition2D(const MessageSpatial2D::MetaData *md, float x, float y) {
     // Clamp each grid coord to 0<=x<dim
     int gridPos[2] = {
-        static_cast<int>(floorf(((x-md->min[0]) / md->environmentWidth[0])*md->gridDim[0])),
-        static_cast<int>(floorf(((y-md->min[1]) / md->environmentWidth[1])*md->gridDim[1]))
+        static_cast<int>(floorf((x-md->min[0]) / md->radius)),
+        static_cast<int>(floorf((y-md->min[1]) / md->radius))
     };
     MessageSpatial2D::GridPos2D rtn = {
         gridPos[0] < 0 ? 0 : (gridPos[0] >= static_cast<int>(md->gridDim[0]) ? static_cast<int>(md->gridDim[0]) - 1 : gridPos[0]),

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
@@ -539,6 +539,15 @@ class MessageSpatial3D::In {
             // Return iterator at min corner of env, this should be safe
             return WrapFilter(metadata, metadata->min[0], metadata->min[1], metadata->min[2]);
         }
+        if (fmodf(metadata->max[0] - metadata->min[0], metadata->radius) > 0.00001f ||
+            fmodf(metadata->max[1] - metadata->min[1], metadata->radius) > 0.00001f ||
+            fmodf(metadata->max[2] - metadata->min[2], metadata->radius) > 0.00001f) {
+            DTHROW("Spatial messaging radius (%g) is not a factor of environment dimensions (%g, %g, %g),"
+                " this is unsupported for the wrapped iterator, MessageSpatial3D::In::wrap().\n", metadata->radius,
+                metadata->max[0] - metadata->min[0],
+                metadata->max[1] - metadata->min[1],
+                metadata->max[2] - metadata->min[2]);
+        }
 #endif
         return WrapFilter(metadata, x, y, z);
     }

--- a/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh
@@ -639,9 +639,9 @@ T MessageSpatial3D::In::WrapFilter::Message::getVariable(const char(&variable_na
 __device__ __forceinline__ MessageSpatial3D::GridPos3D getGridPosition3D(const MessageSpatial3D::MetaData *md, float x, float y, float z) {
     // Clamp each grid coord to 0<=x<dim
     int gridPos[3] = {
-        static_cast<int>(floorf(((x-md->min[0]) / md->environmentWidth[0])*md->gridDim[0])),
-        static_cast<int>(floorf(((y-md->min[1]) / md->environmentWidth[1])*md->gridDim[1])),
-        static_cast<int>(floorf(((z-md->min[2]) / md->environmentWidth[2])*md->gridDim[2]))
+        static_cast<int>(floorf((x-md->min[0]) / md->radius)),
+        static_cast<int>(floorf((y-md->min[1]) / md->radius)),
+        static_cast<int>(floorf((z-md->min[2]) / md->radius))
     };
     MessageSpatial3D::GridPos3D rtn = {
         gridPos[0] < 0 ? 0 : (gridPos[0] >= static_cast<int>(md->gridDim[0]) ? static_cast<int>(md->gridDim[0]) - 1 : gridPos[0]),

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -964,5 +964,80 @@ TEST(Spatial2DMessageTest, buffer_not_init) {
     EXPECT_NO_THROW(c.simulate());
 }
 
+FLAMEGPU_AGENT_FUNCTION(in_bounds_not_factor, MessageSpatial2D, MessageNone) {
+    const float x1 = FLAMEGPU->getVariable<float>("x");
+    const float y1 = FLAMEGPU->getVariable<float>("y");
+    unsigned int count = 0;
+    // Count how many messages we received (including our own)
+    for (const auto& message : FLAMEGPU->message_in(x1, y1)) {
+        ++count;
+    }
+    FLAMEGPU->setVariable<unsigned int>("count", count);
+    return ALIVE;
+}
+TEST(Spatial2DMessageTest, bounds_not_factor_radius) {
+    // This tests that bug #1157 is fixed
+    // When the interaction radius is not a factor of the width
+    // that agent's near the max env bound all have the full interaction radius
+    ModelDescription m("model");
+    MessageSpatial2D::Description message = m.newMessage<MessageSpatial2D>("location");
+    message.setMin(0, 0);
+    message.setMax(50.1f, 50.1f);
+    message.setRadius(10);
+    // Grid will be 6x6
+    // 6th column/row should only be  0.1 wide of the environment
+    // Bug would incorrectly divide the whole environment by 6
+    // So bin widths would instead become 8.35 (down from 10)
+    message.newVariable<flamegpu::id_t>("id");  // unused by current test
+    AgentDescription agent = m.newAgent("agent");
+    agent.newVariable<float>("x");
+    agent.newVariable<float>("y");
+    agent.newVariable<unsigned int>("count", 0);
+    AgentFunctionDescription fo = agent.newFunction("out", out_mandatory2D);
+    fo.setMessageOutput(message);
+    AgentFunctionDescription fi = agent.newFunction("in", in_bounds_not_factor);
+    fi.setMessageInput(message);
+    LayerDescription lo = m.newLayer();
+    lo.addAgentFunction(fo);
+    LayerDescription li = m.newLayer();
+    li.addAgentFunction(fi);
+    // Set pop in model
+    CUDASimulation c(m);
+    // Create an agent in the middle of each edge
+    AgentVector population(agent, 4);
+    // Initialise agents
+    // Vertical pair that can interact
+    // Top side
+    AgentVector::Agent i1 = population[0];
+    i1.setVariable<float>("x", 10.0f);
+    i1.setVariable<float>("y", 0.0f);
+    // Top side inner
+    AgentVector::Agent i2 = population[1];
+    i2.setVariable<float>("x", 10.0f);
+    i2.setVariable<float>("y", 18.0f);
+    // Right side
+    AgentVector::Agent i3 = population[2];
+    i3.setVariable<float>("x", 50.1f);
+    i3.setVariable<float>("y", 40.0f);
+    // Horizontal pair that can interact
+    // Right side inner
+    AgentVector::Agent i4 = population[3];
+    i4.setVariable<float>("x", 50.1f - 10.11f);
+    i4.setVariable<float>("y", 40.0f);
+    c.setPopulationData(population);
+    c.SimulationConfig().steps = 1;
+    EXPECT_NO_THROW(c.simulate());
+    // Recover the results and check they match what was expected
+    c.getPopulationData(population);
+    // Validate each agent has same result
+    for (AgentVector::Agent ai : population) {
+        if (ai.getID() < 3) {
+            EXPECT_EQ(2u, ai.getVariable<unsigned int>("count"));
+        } else {
+            EXPECT_EQ(1u, ai.getVariable<unsigned int>("count"));
+        }
+    }
+}
+
 }  // namespace test_message_spatial2d
 }  // namespace flamegpu


### PR DESCRIPTION
## todo
- [x] Fix bug
- [x] Seatbelts error if wrapped is used when radius is not a factor of environment bounds
    * Happy for someone to update my `fmod()` solution to something cleaner, floating point isn't great.
- [x] Test that bug is fixed
- [x] Test that wrapped is blocked under `SEATBELTS=ON`
- [x]  document wrapped limitation (https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/176)

Closes #1157 