### PR TITLE
Cmake version deprecations fix

### DIFF
--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 cmake_policy(SET CMP0079 NEW)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
-set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "02097b5ca1bf38a52693e926d0d750d972a2ae80")
+set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "5de60dc004d524ce9dd07898daa3c84ea1e32203")
 set(DEFAULT_FLAMEGPU_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # Set a VISUSLAITION_ROOT cache entry so it is available in the GUI to override the location if required

--- a/cmake/dependencies/googletest.cmake
+++ b/cmake/dependencies/googletest.cmake
@@ -6,11 +6,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
 cmake_policy(SET CMP0079 NEW)
 
-# Googltest newer than 389cb68b87193358358ae87cc56d257fd0d80189 (included in release-1.11.0) or newer is required for CMake >= 3.19
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.11.0
+  GIT_TAG        v1.14.0
 )
 
 FetchContent_GetProperties(googletest)

--- a/cmake/dependencies/patches/rapidjson-cmake-3.5-deprecation.patch
+++ b/cmake/dependencies/patches/rapidjson-cmake-3.5-deprecation.patch
@@ -1,0 +1,12 @@
+diff --git a/RapidJSONConfig.cmake.in b/RapidJSONConfig.cmake.in
+index c25d3125..2e49514b 100644
+--- a/RapidJSONConfig.cmake.in
++++ b/RapidJSONConfig.cmake.in
+@@ -1,6 +1,6 @@
+ ################################################################################
+ # CMake minimum version required
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ 
+ ################################################################################
+ # RapidJSON source dir

--- a/cmake/dependencies/rapidjson.cmake
+++ b/cmake/dependencies/rapidjson.cmake
@@ -7,12 +7,14 @@ include(FetchContent)
 include(ExternalProject)
 cmake_policy(SET CMP0079 NEW)
 
-# Head of master as of 2020-07-14, as last release is ~500 commits behind head
+# a95e013b97ca6523f32da23f5095fcc9dd6067e5 is the last commit before a change which breaks our method of finding rapid json without running a cmake install first.
+# but we also need to patch this to avoid a cmake >= 3.26.4 deprecation
 FetchContent_Declare(
     rapidjson
     GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-    GIT_TAG        f56928de85d56add3ca6ae7cf7f119a42ee1585b
+    GIT_TAG        a95e013b97ca6523f32da23f5095fcc9dd6067e5
     GIT_PROGRESS   ON
+    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patches/rapidjson-cmake-3.5-deprecation.patch || true
     # UPDATE_DISCONNECTED   ON
 )
 FetchContent_GetProperties(rapidjson)


### PR DESCRIPTION
Fixes deprecation notice of removal of `cmake_minimum_required` <= 3.5 in dependencencies with CMake >= 3.27 (or 3.26.4?). 

+ [x] Updates Google test to the latest tagged release 
+ [x] Updates rapid json to the most recent version which does not break our method of fetch content + find_package without cmake install, and patches that commit to avoid the cmake_minimum_required error
+ [x] https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/132 fixes the same issue with CMakeRC there. The commit hash here will need updating post merge, and then again for the next release.

Closes #1156 