### PR TITLE
Included cstdint in DiscreteColor.h (it is necessary for gcc 12.3)

### DIFF
--- a/include/flamegpu/visualiser/color/DiscreteColor.h
+++ b/include/flamegpu/visualiser/color/DiscreteColor.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <cstdint>
 
 #include <sstream>
 


### PR DESCRIPTION
I discovered that with gcc 12.3 it is necessary to include cstdint in DiscreteColor.h to use the types int32_t, uint32_t, etc. (the compiler itself suggested me to do this).