### PR TITLE
Bump version number to 2.0.0-rc.2

### DIFF
--- a/include/flamegpu/version.h
+++ b/include/flamegpu/version.h
@@ -39,7 +39,7 @@ static constexpr unsigned int VERSION_PATCH = flamegpu::VERSION % 1000;
  * Namespaced FLAME GPU version Prerelease component
  * A set of . separated pre-release components as a string, following the semver rules for comparison.
  */
-static constexpr char VERSION_PRERELEASE[] = "rc.1";
+static constexpr char VERSION_PRERELEASE[] = "rc.2";
 
 /**
  * Namespaced FLAME GPU version build metadata component


### PR DESCRIPTION
Bump version number to 2.0.0-rc.2 for correct version comparisons during development of 2.0.0-rc.2