### PR TITLE
chore: more descriptive error message for python/codegen

### DIFF
--- a/swig/python/codegen/codegen.py
+++ b/swig/python/codegen/codegen.py
@@ -1271,7 +1271,7 @@ class CodeGenerator:
                 self.write(f"static_cast<{t.func.id}>")
             else:
                 if (t.func.id not in funcs):
-                    self.RaiseWarning(t, "Function call is not a defined FLAME GPU device function or a supported python built in.")
+                    self.RaiseWarning(t, f"Function call to '{t.func.id}' is not a defined FLAME GPU device function or a supported python built in.")
                 # dispatch even if warning raised
                 self.dispatch(t.func)
         elif isinstance(t.func, ast.Lambda):


### PR DESCRIPTION
In case of a function-not-found warning during code generation, only tree-relative line numbers are given in the warning message, an explicit function name is added for finding the culprit quickly.