### PR TITLE
CI: Manylinux2014 -> Manylinux_2_28 and update deprecated actions

### DIFF
--- a/.github/scripts/install_cuda_el8.sh
+++ b/.github/scripts/install_cuda_el8.sh
@@ -1,0 +1,173 @@
+# Install CUDA on Alma8/manylinux_2_28.
+
+## -------------------
+## Constants
+## -------------------
+
+# dnf install cuda-nvrtc-devel-11-4 cuda-compiler-11-4 cuda-cudart-devel-11-4 cuda-nvcc-11-4 cuda-nvrtc-11-4 cuda-nvtx-11-4 libcurand-devel-11-4
+
+# List of sub-packages to install.
+# @todo - pass this in from outside the script?
+# @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
+
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too)
+CUDA_PACKAGES_IN=(
+    "cuda-compiler"
+    "cuda-cudart-devel" # libcudart.so
+    "cuda-driver-devel" # libcuda.so
+    "cuda-nvtx"
+    "cuda-nvrtc-devel"
+    "libcurand-devel" # 11-0+
+)
+
+## -------------------
+## Bash functions
+## -------------------
+# returns 0 (true) if a >= b
+function version_ge() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]
+}
+# returns 0 (true) if a > b
+function version_gt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_ge $1 $2
+}
+# returns 0 (true) if a <= b
+function version_le() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]
+}
+# returns 0 (true) if a < b
+function version_lt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_le $1 $2
+}
+
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as $cuda.
+CUDA_VERSION_MAJOR_MINOR=${cuda}
+
+# Split the version.
+# We (might/probably) don't know PATCH at this point - it depends which version gets installed.
+CUDA_MAJOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f1)
+CUDA_MINOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f2)
+CUDA_PATCH=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f3)
+# query rpm to find the major enterprise linux release
+EL_MAJOR=$(rpm -E %{rhel})
+
+echo "CUDA_MAJOR: ${CUDA_MAJOR}"
+echo "CUDA_MINOR: ${CUDA_MINOR}"
+echo "CUDA_PATCH: ${CUDA_PATCH}"
+echo "EL_MAJOR:   ${EL_MAJOR}"
+
+# If we don't know the CUDA_MAJOR or MINOR, error.
+if [ -z "${CUDA_MAJOR}" ] ; then
+    echo "Error: Unknown CUDA Major version. Aborting."
+    exit 1
+fi
+if [ -z "${CUDA_MINOR}" ] ; then
+    echo "Error: Unknown CUDA Minor version. Aborting."
+    exit 1
+fi
+# If we don't know the Ubuntu version, error.
+if [ -z ${EL_MAJOR} ]; then
+    echo "Error: Unknown EL version. Aborting."
+    exit 1
+fi
+
+## -------------------------------
+## Select CUDA packages to install
+## -------------------------------
+CUDA_PACKAGES=""
+for package in "${CUDA_PACKAGES_IN[@]}"
+do :
+    # CUDA < 11, lib* packages were actually cuda-cu* (generally, this might be greedy.)
+    if [[ ${package} == libcu* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
+        package="${package/libcu/cuda-cu}"
+    fi
+    # CUDA < 11, -devel- packages were actually -dev
+    if [[ ${package} == *devel* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
+        package="${package//devel/dev}"
+    fi
+    # Build the full package name and append to the string.
+    CUDA_PACKAGES+=" ${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
+done
+echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
+
+## -----------------
+## Prepare to install
+## -----------------
+
+CPU_ARCH="x86_64"
+# Nvidia don't provide an explicit alma repo. 11.2's closest is RHEL.
+# 12.4 includes rocky8/9, rhel7/8/9, cent7, so RHEL is the closes that should hopefully be fine, otherwise will have to switch to the much slower runfile installer.
+DNF_REPO_URI="https://developer.download.nvidia.com/compute/cuda/repos/rhel${EL_MAJOR}/${CPU_ARCH}/cuda-rhel${EL_MAJOR}.repo"
+
+echo "DNF_REPO_URI ${DNF_REPO_URI}"
+
+## -----------------
+## Check for root/sudo
+## -----------------
+
+# Detect if the script is being run as root, storing true/false in is_root.
+is_root=false
+if (( $EUID == 0)); then
+   is_root=true
+fi
+# Find if sudo is available
+has_sudo=false
+if command -v sudo &> /dev/null ; then
+    has_sudo=true
+fi
+# Decide if we can proceed or not (root or sudo is required) and if so store whether sudo should be used or not.
+if [ "$is_root" = false ] && [ "$has_sudo" = false ]; then
+    echo "Root or sudo is required. Aborting."
+    exit 1
+elif [ "$is_root" = false ] ; then
+    USE_SUDO=sudo
+else
+    USE_SUDO=
+fi
+
+## -----------------
+## Install
+## -----------------
+echo "Adding CUDA Repository"
+$USE_SUDO dnf config-manager --add-repo ${DNF_REPO_URI}
+$USE_SUDO dnf clean all
+
+echo "Installing CUDA packages ${CUDA_PACKAGES}"
+$USE_SUDO dnf -y install ${CUDA_PACKAGES}
+
+if [[ $? -ne 0 ]]; then
+    echo "CUDA Installation Error."
+    exit 1
+fi
+
+## -----------------
+## Set environment vars / vars to be propagated
+## -----------------
+
+CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
+echo "CUDA_PATH=${CUDA_PATH}"
+export CUDA_PATH=${CUDA_PATH}
+export PATH="$CUDA_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib64:$LD_LIBRARY_PATH"
+# Check nvcc is now available.
+nvcc -V
+
+# If executed on github actions, make the appropriate echo statements to update the environment
+if [[ $GITHUB_ACTIONS ]]; then
+    # Set paths for subsequent steps, using ${CUDA_PATH}
+    echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
+    echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
+    echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
+    echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+    echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+fi

--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -68,7 +68,7 @@ jobs:
       CMAKE: ${{ matrix.cmake }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install cmake from GitHub Releases
       if: ${{ env.CMAKE != '' && env.CMAKE != 'default' }}
@@ -96,7 +96,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
 

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -26,7 +26,7 @@ jobs:
       # Define constants
       BUILD_DIR: "build"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install doxygen >= 1.9.0 + other dependencies
       run: |

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -371,8 +371,6 @@ jobs:
       FLAMEGPU_SEATBELTS: ${{ matrix.config.SEATBELTS }}
       PYTHON: ${{ matrix.python}}
       VISUALISATION: ${{ matrix.VISUALISATION }}
-      # Short term fix to use node16 not node20 for actions. This will stop working eventually, forcing our hand in dropping manylinux2014 support.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - uses: actions/checkout@v4
@@ -429,6 +427,11 @@ jobs:
         python${{env.PYTHON}} -m pip install setuptools wheel
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
+
+    - name: Install setuptools and wheel
+      if: ${{ env.PYTHON >= 3.12 }}
+      run: |
+        python${{env.PYTHON}} -m pip install setuptools wheel
 
     # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
     - name: Enable git safe-directory

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -87,7 +87,7 @@ jobs:
       VISUALISATION: ${{ matrix.VISUALISATION }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
@@ -106,7 +106,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
 
@@ -249,7 +249,7 @@ jobs:
       CUDAFLAGS: -allow-unsupported-compiler
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
@@ -261,7 +261,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
     
@@ -312,11 +312,11 @@ jobs:
       run: cmake --build . --config ${{ env.CONFIG }} --target ALL_BUILD --verbose -j `nproc`
 
 
-  # Manylinux2014 Wheel builds, using the manylinux2014 container
-  wheel-manylinux2014:
+  # Manylinux Wheel builds, using the ManyLinux_2_28 container. 2014's base OS is depreacted and no longer supported on GitHub actions
+  wheel-manylinux_2_28:
     runs-on: ${{ matrix.cudacxx.os }}
     # Run steps inside a manylinux container.
-    container: quay.io/pypa/manylinux2014_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
       fail-fast: false
       # Multiplicative build matrix
@@ -325,12 +325,12 @@ jobs:
         cudacxx:
           - cuda: "12.0"
             cuda_arch: "50-real;60-real;70-real;80-real;90-real;90-virtual"
-            hostcxx: devtoolset-10
-            os: ubuntu-20.04
+            hostcxx: gcc-toolset-12
+            os: ubuntu-22.04
           - cuda: "11.2"
             cuda_arch: "35-real;50-real;60-real;70-real;80-real;80-virtual"
-            hostcxx: devtoolset-9
-            os: ubuntu-20.04
+            hostcxx: gcc-toolset-9
+            os: ubuntu-22.04
         python: 
           - "3.12"
           - "3.11"
@@ -346,17 +346,17 @@ jobs:
           - "OFF"
 
     # Name the job based on matrix/env options
-    name: "wheel-manylinux2014 (${{ matrix.cudacxx.cuda }}, ${{matrix.python}}, ${{ matrix.VISUALISATION }}, ${{ matrix.config.name }}, ${{ matrix.cudacxx.os }})"
+    name: "wheel-manylinux_2_28 (${{ matrix.cudacxx.cuda }}, ${{matrix.python}}, ${{ matrix.VISUALISATION }}, ${{ matrix.config.name }}, ${{ matrix.cudacxx.os }})"
 
     env:
       # Control if the wheel should be repaired. This will fail until .so's are addressed
       AUDITWHEEL_REPAIR: "OFF"
-      MANYLINUX: "manylinux2014"
+      MANYLINUX: "manylinux_2_28"
       ARCH: "x86_64"
       # Control if static GLEW should be built and used or not.
       USE_STATIC_GLEW: "ON"
       # Compute the wheelhouse name which should be unique within the matrix. This must be unique per build matrix/job combination
-      ARTIFACT_NAME: wheel-manylinux2014-${{ matrix.cudacxx.cuda }}-${{matrix.python}}-${{ matrix.VISUALISATION }}-${{ matrix.config.name }}-${{ matrix.cudacxx.os }}
+      ARTIFACT_NAME: wheel-manylinux_2_28-${{ matrix.cudacxx.cuda }}-${{matrix.python}}-${{ matrix.VISUALISATION }}-${{ matrix.config.name }}-${{ matrix.cudacxx.os }}
       # Define constants
       BUILD_DIR: "build"
       FLAMEGPU_BUILD_TESTS: "OFF"
@@ -375,16 +375,13 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    # Downgrade the devtoolset in the image based on the build matrix, using:
-    # gcc-10 for CUDA >= 11.2. Unclear if devtoolset-10 will upgrade to unpatched 11.3 which breaks CUDA builds that use <chrono>. 
-    # gcc-9 for CUDA >= 11.0
-    # these are not the officially supported toolset on centos by cuda, but it's what works.
-    - name: Install RHEL devtoolset (CentOS)
-      if: ${{ startsWith(env.HOSTCXX, 'devtoolset-') }}
+   # Downgrade the gcc-toolset in the image based on the build matrix
+    - name: Install RHEL gcc-toolset (EL 8)
+      if: ${{ startsWith(env.HOSTCXX, 'gcc-toolset-') }}
       run: |
-        # Install devtoolset-X
+        # Install gcc-toolset-X
         yum install -y ${{ env.HOSTCXX }}
         # Enable the toolset via source not scl enable which doesn't get on with multi-step GHA 
         source /opt/rh/${{ env.HOSTCXX }}/enable
@@ -394,13 +391,13 @@ jobs:
         echo "CXX=$(which g++)" >> $GITHUB_ENV
         echo "CUDAHOSTCXX=$(which g++)" >> $GITHUB_ENV
 
-    - name: Install CUDA (CentOS)
+    - name: Install CUDA (EL 8)
       if: ${{ env.CUDA != '' }}
       env:
         cuda: ${{ env.CUDA }}
-      run: .github/scripts/install_cuda_centos.sh
+      run: .github/scripts/install_cuda_el8.sh
 
-    - name: Install Visualisation Dependencies (CentOS)
+    - name: Install Visualisation Dependencies (EL 8)
       if: ${{ env.VISUALISATION == 'ON' }}
       run: |
         yum install -y glew-devel fontconfig-devel SDL2-devel freetype-devel 
@@ -430,12 +427,13 @@ jobs:
       if: ${{ env.PYTHON >= 3.12 }}
       run: |
         python${{env.PYTHON}} -m pip install setuptools wheel
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
 
     # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
     - name: Enable git safe-directory
       run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-    # Unlike other builds manylinux, uses static glew as it has been built and installed.
     - name: Configure cmake
       run: >
         cmake . -B "${{ env.BUILD_DIR }}"
@@ -477,7 +475,7 @@ jobs:
     # Use a unique name per job matrix run, to avoid a risk of corruption according to the docs (although it should work with unique filenames)
     - name: Upload Wheel Artifacts
       if: ${{ env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.BUILD_DIR }}/lib/${{ env.CONFIG }}/python/dist/*.whl
@@ -542,7 +540,7 @@ jobs:
       CUDAFLAGS: -allow-unsupported-compiler
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
@@ -554,7 +552,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
 
@@ -598,7 +596,7 @@ jobs:
     # Use a unique name per job matrix run, to avoid a risk of corruption according to the docs (although it should work with unique filenames)
     - name: Upload Wheel Artifacts
       if: ${{env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.BUILD_DIR }}/lib/${{ env.CONFIG }}/python/dist/*.whl
@@ -611,17 +609,17 @@ jobs:
     needs: 
       - build-ubuntu
       - build-windows
-      - wheel-manylinux2014
+      - wheel-manylinux_2_28
       - wheel-windows
     if: ${{ success() && startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Download python wheels from previous jobs.
     - name: Download Wheel Artifacts
       id: download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: artifacts
 

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -41,7 +41,7 @@ jobs:
       OS: ${{ matrix.cudacxx.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}

--- a/.github/workflows/MPI.yml
+++ b/.github/workflows/MPI.yml
@@ -91,7 +91,7 @@ jobs:
       VISUALISATION: ${{ matrix.VISUALISATION }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
@@ -162,7 +162,7 @@ jobs:
     
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
 

--- a/.github/workflows/Manylinux_2_28.yml
+++ b/.github/workflows/Manylinux_2_28.yml
@@ -77,8 +77,6 @@ jobs:
       FLAMEGPU_SEATBELTS: ${{ matrix.config.SEATBELTS }}
       PYTHON: ${{ matrix.python}}
       VISUALISATION: ${{ matrix.VISUALISATION }}
-      # Short term fix to use node16 not node20 for actions. This will stop working eventually, forcing our hand in dropping manylinux2014 support.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - uses: actions/checkout@v4
@@ -136,6 +134,11 @@ jobs:
 
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
+
+    - name: Install setuptools and wheel
+      if: ${{ env.PYTHON >= 3.12 }}
+      run: |
+        python${{env.PYTHON}} -m pip install setuptools wheel
 
     # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
     - name: Enable git safe-directory

--- a/.github/workflows/Manylinux_2_28.yml
+++ b/.github/workflows/Manylinux_2_28.yml
@@ -1,5 +1,5 @@
 # Build manylinux wheels, and upload them to the action for testing within a short time frame
-name: Manylinux2014
+name: Manylinux_2_28
 
 # Run on branch push events (i.e. not tag pushes) and on pull requests
 on:
@@ -10,8 +10,8 @@ on:
     paths:
       - "**"
       - "!.github/**"
-      - ".github/scripts/install_cuda_centos.sh"
-      - ".github/workflows/Manylinux2014.yml"
+      - ".github/scripts/install_cuda_el8.sh"
+      - ".github/workflows/Manylinux_2_28.yml"
   # Disabled for now. See https://github.com/FLAMEGPU/FLAMEGPU2/pull/644
   # pull_request:
   # Allow manual invocation.
@@ -21,12 +21,12 @@ defaults:
   run:
     shell: bash
 
-# A single job, which builds manylinux2014 wheels, which ships with GCC 10.2.1 at the time of writing. If this bumps to unpatched 10.3 we might have issues w/ cuda. 
+# A single job, which builds manylinux_2_28 wheels, which ships with GCC 12.
 jobs:
   build:
     runs-on: ${{ matrix.cudacxx.os }}
     # Run steps inside a manylinux container.
-    container: quay.io/pypa/manylinux2014_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
       fail-fast: false
       # Multiplicative build matrix
@@ -35,12 +35,12 @@ jobs:
         cudacxx:
           - cuda: "12.0"
             cuda_arch: "50"
-            hostcxx: devtoolset-10
-            os: ubuntu-20.04
+            hostcxx: gcc-toolset-12
+            os: ubuntu-22.04
           - cuda: "11.2"
             cuda_arch: "35"
-            hostcxx: devtoolset-9
-            os: ubuntu-20.04
+            hostcxx: gcc-toolset-9
+            os: ubuntu-22.04
         python: 
           - "3.12"
         config:
@@ -57,12 +57,12 @@ jobs:
     env:
       # Control if the wheel should be repaired. This will fail until .so's are addressed
       AUDITWHEEL_REPAIR: "OFF"
-      MANYLINUX: "manylinux2014"
+      MANYLINUX: "manylinux_2_28"
       ARCH: "x86_64"
       # Control if static GLEW should be built and used or not.
       USE_STATIC_GLEW: "ON"
       # Compute the wheelhouse name which should be unique within the matrix. This must be unique per build matrix/job combination
-      ARTIFACT_NAME: wheel-manylinux2014-${{ matrix.cudacxx.cuda }}-${{matrix.python}}-${{ matrix.VISUALISATION }}-${{ matrix.config.name }}-${{ matrix.cudacxx.os }}
+      ARTIFACT_NAME: wheel-manylinux_2_28-${{ matrix.cudacxx.cuda }}-${{matrix.python}}-${{ matrix.VISUALISATION }}-${{ matrix.config.name }}-${{ matrix.cudacxx.os }}
       # Define constants
       BUILD_DIR: "build"
       FLAMEGPU_BUILD_TESTS: "OFF"
@@ -81,16 +81,13 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    # Downgrade the devtoolset in the image based on the build matrix, using:
-    # gcc-10 for CUDA >= 11.2. Unclear if devtoolset-10 will upgrade to unpatched 11.3 which breaks CUDA builds that use <chrono>. 
-    # gcc-9 for CUDA >= 11.0
-    # these are not the officially supported toolset on centos by cuda, but it's what works.
-    - name: Install RHEL devtoolset (CentOS)
-      if: ${{ startsWith(env.HOSTCXX, 'devtoolset-') }}
+    # Downgrade the gcc-toolset in the image based on the build matrix
+    - name: Install RHEL gcc-toolset (EL 8)
+      if: ${{ startsWith(env.HOSTCXX, 'gcc-toolset-') }}
       run: |
-        # Install devtoolset-X
+        # Install gcc-toolset-X
         yum install -y ${{ env.HOSTCXX }}
         # Enable the toolset via source not scl enable which doesn't get on with multi-step GHA 
         source /opt/rh/${{ env.HOSTCXX }}/enable
@@ -100,13 +97,13 @@ jobs:
         echo "CXX=$(which g++)" >> $GITHUB_ENV
         echo "CUDAHOSTCXX=$(which g++)" >> $GITHUB_ENV
 
-    - name: Install CUDA (CentOS)
+    - name: Install CUDA (EL 8)
       if: ${{ env.CUDA != '' }}
       env:
         cuda: ${{ env.CUDA }}
-      run: .github/scripts/install_cuda_centos.sh
+      run: .github/scripts/install_cuda_el8.sh
 
-    - name: Install Visualisation Dependencies (CentOS)
+    - name: Install Visualisation Dependencies (EL 8)
       if: ${{ env.VISUALISATION == 'ON' }}
       run: |
         yum install -y glew-devel fontconfig-devel SDL2-devel freetype-devel 
@@ -185,7 +182,7 @@ jobs:
     # Use a unique name per job matrix run, to avoid a risk of corruption according to the docs (although it should work with unique filenames)
     - name: Upload Wheel Artifacts
       if: ${{env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.BUILD_DIR }}/lib/${{ env.CONFIG }}/python/dist/*.whl

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -107,7 +107,7 @@ jobs:
       VISUALISATION: ${{ matrix.VISUALISATION }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
@@ -126,7 +126,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
 

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -67,7 +67,7 @@ jobs:
       CUDAFLAGS: -allow-unsupported-compiler
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -114,7 +114,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
@@ -126,7 +126,7 @@ jobs:
 
     - name: Select Python
       if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }} 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
 
@@ -177,7 +177,7 @@ jobs:
     # Use a unique name per job matrix run, to avoid a risk of corruption according to the docs (although it should work with unique filenames)
     - name: Upload Wheel Artifacts
       if: ${{env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.BUILD_DIR }}/lib/${{ env.CONFIG }}/python/dist/*.whl


### PR DESCRIPTION
Node 16 Github actions are deprecated, but node 20 actions are incompatible with Manylinux_2014/CentOS7.

- Replaces manylinux wheel building to use 2_28 (based on Alma 8)
- Updates depreacted actions in all workflows.

Produced wheels are still not technically Manylinux compliant due to linkage against non-packaged .so files (see #647)

This will reduce wheel compatibility, by increasing the required glibc to 2.28 or newer.

Closes #1190
Closes #1224 

Replaces #1200 and #1194 as they must be coupled. 


## Todo

+ [x] Test the built wheels on recent linux
+ [x] Test installation on Centos7 to check the error (Liberty Linux 7 is still supported)
  - Installation is allowed, but error at runtime. Installation errors via `auditwheel repair` requires #1194 

The use of download_artifact will not have been tested by CI, as it is only used if a version tag is created. We might want to do a dry run on a fork.

