### PR TITLE
BugFix: JSONStateWriter prettyprint output is nolonger minified.

### DIFF
--- a/include/flamegpu/io/JSONStateWriter.h
+++ b/include/flamegpu/io/JSONStateWriter.h
@@ -61,9 +61,13 @@ class JSONStateWriter : public StateWriter {
     bool environment_written = false;
     bool macro_environment_written = false;
     bool agents_written = false;
+    // Dirty workaround for PrettyWriter overloads not being virtual
+    bool newline_purge_required = false;
     std::string outputPath;
     rapidjson::StringBuffer buffer;
-    std::unique_ptr<rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag>> writer;
+    // Typedef because the template is too long
+    typedef rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag> PrettyWriter;
+    std::unique_ptr<PrettyWriter> writer;
 };
 }  // namespace io
 }  // namespace flamegpu

--- a/src/flamegpu/io/JSONStateWriter.cu
+++ b/src/flamegpu/io/JSONStateWriter.cu
@@ -57,8 +57,10 @@ void JSONStateWriter::endWrite() {
         std::string t_buffer = buffer.GetString();
         // Replace all spaces outside of quotes with \n
         bool in_string = false;
-        for (auto it = t_buffer.begin(); it != t_buffer.end(); ++it) {
-            if (*it == '"') in_string = !in_string;
+        auto it = t_buffer.begin();
+        ++it;  // First char in generated JSON will never be a quote or space
+        for (; it != t_buffer.end(); ++it) {
+            if (*it == '"' && *(it-1) != '\\') in_string = !in_string; // Catch string begin/end, ignore nested quotes
             if (*it == ' ' && !in_string) *it = '\n';
         }
         // Remove newlines


### PR DESCRIPTION
rapidjson's `PrettyWriter` extends `Writer`, but methods are non-virtual, leading to the bug which has been resolved.

This fix is the best solution of the bad options (e.g. heavy templating or dual internal writers/`std::variant` with an if/cast every time a method is called) given this implementation's modular approach to writing.

I have tested this works manually, I have no plans to write a test that parses the output to check whether it's minified or not as it would essentially be an inverse of the parsing rules I've written unless you had ground truths to compare against for a specific input. But you can if that's your prerogative.

`JSONLogger` does not suffer from the same bug, I have a feeling it was noticed when that was implemented and worked around.

Closes #1231