### PR TITLE
CI: install setuptools and wheel for py>=3.12 in Manylinux containers 

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -426,6 +426,11 @@ jobs:
         make
         make install
 
+    - name: Install setuptools and wheel
+      if: ${{ env.PYTHON >= 3.12 }}
+      run: |
+        python${{env.PYTHON}} -m pip install setuptools wheel
+
     # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
     - name: Enable git safe-directory
       run: git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/.github/workflows/Manylinux2014.yml
+++ b/.github/workflows/Manylinux2014.yml
@@ -132,6 +132,11 @@ jobs:
         make
         make install
 
+    - name: Install setuptools and wheel
+      if: ${{ env.PYTHON >= 3.12 }}
+      run: |
+        python${{env.PYTHON}} -m pip install setuptools wheel
+
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
 


### PR DESCRIPTION
Install `setuptools` and `wheel` in Manylinux containers on CI for Python >= 3.12

+ [x] ManyLinux2014
+ [x] DraftRelease

Similar changes made in #1228.

Closes of #1240