### PR TITLE
Graph visualisation would only work if CUDASimulation was explicitly init()

### DIFF
--- a/include/flamegpu/io/LoggerFactory.h
+++ b/include/flamegpu/io/LoggerFactory.h
@@ -31,9 +31,12 @@ class LoggerFactory {
             return std::make_unique<XMLLogger>(output_path, prettyPrint, truncateFile);
         } else if (extension == ".json") {
             return std::make_unique<JSONLogger>(output_path, prettyPrint, truncateFile);
+        } else if (extension.empty()) {
+                THROW exception::InvalidFilePath("Filepath '%s' contains unsuitable characters or lacks a file extension, "
+                    "in LoggerFactory::createLogger().", output_path.c_str());
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be written "
-            "by StateWriterFactory::createLogger().",
+            "by LoggerFactory::createLogger().",
             output_path.c_str());
     }
 };

--- a/include/flamegpu/io/StateReaderFactory.h
+++ b/include/flamegpu/io/StateReaderFactory.h
@@ -37,6 +37,9 @@ class StateReaderFactory {
             return new XMLStateReader();
         } else if (extension == ".json") {
             return new JSONStateReader();
+        } else if (extension.empty()) {
+                THROW exception::InvalidFilePath("Filepath '%s' contains unsuitable characters or lacks a file extension, "
+                    "in StateReaderFactory::createLogger().", input.c_str());
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be read "
             "by StateReaderFactory::createReader().",

--- a/include/flamegpu/io/StateWriterFactory.h
+++ b/include/flamegpu/io/StateWriterFactory.h
@@ -32,6 +32,9 @@ class StateWriterFactory {
             return new XMLStateWriter();
         } else if (extension == ".json") {
             return new JSONStateWriter();
+        } else if (extension.empty()) {
+            THROW exception::InvalidFilePath("Filepath '%s' contains unsuitable characters or lacks a file extension, "
+                "in StateWriterFactory::createLogger().", output_file.c_str());
         }
         THROW exception::UnsupportedFileType("File '%s' is not a type which can be written "
             "by StateWriterFactory::createWriter().",

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -1542,12 +1542,6 @@ void CUDASimulation::applyConfig_derived() {
 
     // We init Random through submodel hierarchy after singletons
     reseed(getSimulationConfig().random_seed);
-
-#ifdef FLAMEGPU_VISUALISATION
-    if (visualisation) {
-        visualisation->hookVis(visualisation, directed_graph_map);
-    }
-#endif
 }
 
 void CUDASimulation::reseed(const uint64_t seed) {
@@ -1662,6 +1656,12 @@ void CUDASimulation::initialiseSingletons() {
 
     // Ensure RTC is set up.
     initialiseRTC();
+
+#ifdef FLAMEGPU_VISUALISATION
+    if (visualisation) {
+        visualisation->hookVis(visualisation, directed_graph_map);
+    }
+#endif
 }
 
 void CUDASimulation::initialiseRTC() {
@@ -1717,6 +1717,10 @@ const CUDASimulation::Config &CUDASimulation::getCUDAConfig() const {
 visualiser::ModelVis CUDASimulation::getVisualisation() {
     if (!visualisation) {
         visualisation = std::make_shared<visualiser::ModelVisData>(*this);
+        // If visualisation is init after sim has been init ensure graphs are linked to vis
+        if (directed_graph_map.size()) {
+            visualisation->hookVis(visualisation, directed_graph_map);
+        }
     }
     return visualiser::ModelVis(visualisation, isSWIG);
 }

--- a/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
+++ b/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
@@ -583,10 +583,12 @@ void CUDAEnvironmentDirectedGraphBuffers::syncDevice_async(detail::CUDAScatter& 
     if (has_changed) {
 #ifdef FLAMEGPU_VISUALISATION
         if (auto vis = visualisation.lock()) {
-            vis->visualiser->lockDynamicLinesMutex();
-            vis->rebuildEnvGraph(graph_description.name);
-            vis->visualiser->updateDynamicLine(std::string("graph_") + graph_description.name);
-            vis->visualiser->releaseDynamicLinesMutex();
+            if (vis->graphs.find(graph_description.name) != vis->graphs.end()) {
+                vis->visualiser->lockDynamicLinesMutex();
+                vis->rebuildEnvGraph(graph_description.name);
+                vis->visualiser->updateDynamicLine(std::string("graph_") + graph_description.name);
+                vis->visualiser->releaseDynamicLinesMutex();
+            }
         }
 #endif
     }

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -19,9 +19,11 @@ ModelVisData::ModelVisData(const flamegpu::CUDASimulation &_model)
 , modelData(_model.getModelDescription()) { }
 
 void ModelVisData::hookVis(std::shared_ptr<visualiser::ModelVisData>& vis, std::unordered_map<std::string, std::shared_ptr<detail::CUDAEnvironmentDirectedGraphBuffers>> &map) {
+    for (auto [key, buf] : map) {
+        buf->setVisualisation(vis);
+    }
     for (auto [name, graph] : graphs) {
         auto &graph_buffs = map.at(name);
-        graph_buffs->setVisualisation(vis);
         graph->constructGraph(graph_buffs);
         vis->rebuildEnvGraph(name);
     }


### PR DESCRIPTION
`applyConfig_derived()` is not implicitly called, I assumed otherwise. Hence, `CUDAEnvironmentDirectedGraphBuffers` was not receiving it's ptr to the visualisation.

Also noticed an edge-case with invalid characters in filepaths on Windows so improved the exception thrown.