### PR TITLE
Tests: Workaround for Swig 4.2.1 != None erorrs

### DIFF
--- a/tests/python/simulation/test_RunPlan.py
+++ b/tests/python/simulation/test_RunPlan.py
@@ -10,7 +10,7 @@ class TestRunPlan(TestCase):
         model = pyflamegpu.ModelDescription("test")
         plan = None
         plan = pyflamegpu.RunPlan(model)
-        assert plan != None
+        assert plan is not None
         plan = None
 
     def test_setRandomSimulationSeed(self):

--- a/tests/python/simulation/test_RunPlanVector.py
+++ b/tests/python/simulation/test_RunPlanVector.py
@@ -23,7 +23,7 @@ class TestRunPlanVector(TestCase):
         # Use New
         initialLength = 4
         plans = pyflamegpu.RunPlanVector(model, initialLength)
-        assert plans != None
+        assert plans is not None
         assert plans.size() == initialLength
         # Run the destructor
         plans = None

--- a/tests/python/simulation/test_cuda_ensemble.py
+++ b/tests/python/simulation/test_cuda_ensemble.py
@@ -72,7 +72,7 @@ class TestCUDAEnsemble(TestCase):
         # Use the ctor
         # explicit CUDAEnsemble(const ModelDescription& model, int argc = 0, const char** argv = None)
         ensemble = pyflamegpu.CUDAEnsemble(model, [])
-        assert ensemble != None
+        assert ensemble is not None
         # Check a property
         assert ensemble.Config().timing == False
         # Run the destructor ~CUDAEnsemble


### PR DESCRIPTION
Works around the swig 4.2.1 `x != None` errors in the pyflamegpu test suite by using the more idiomatic `x is not None`.

The underlying issue within Swig is resolved in 4.3.0.

Closes #1233