### PR TITLE
Cpplint 2 fixes

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent 
 linelength=320
-filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11
+filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11,-build/c++17

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent 
 linelength=320
-filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11,-build/c++17
+filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11,-build/c++17,-whitespace/indent_namespace

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent 
 linelength=320
-filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11,-build/c++17,-whitespace/indent_namespace
+filter=-legal/copyright,-readability/todo,-runtime/references,-build/c++11,-build/c++17,-whitespace/indent_namespace,-whitespace/newline

--- a/examples/cpp/circles_bruteforce/src/main.cu
+++ b/examples/cpp/circles_bruteforce/src/main.cu
@@ -1,4 +1,5 @@
 #include <float.h>
+#include <cstdio>
 #include "flamegpu/flamegpu.h"
 
 FLAMEGPU_AGENT_FUNCTION(output_message, flamegpu::MessageNone, flamegpu::MessageBruteForce) {

--- a/examples/cpp/circles_spatial3D/src/main.cu
+++ b/examples/cpp/circles_spatial3D/src/main.cu
@@ -1,4 +1,5 @@
 #include <float.h>
+#include <cstdio>
 #include "flamegpu/flamegpu.h"
 
 FLAMEGPU_AGENT_FUNCTION(output_message, flamegpu::MessageNone, flamegpu::MessageSpatial3D) {

--- a/examples/cpp/ensemble/src/main.cu
+++ b/examples/cpp/ensemble/src/main.cu
@@ -1,3 +1,6 @@
+#include <cstdio>
+#include <map>
+
 #include "flamegpu/flamegpu.h"
 
 FLAMEGPU_AGENT_FUNCTION(AddOffset, flamegpu::MessageNone, flamegpu::MessageNone) {

--- a/examples/cpp/host_functions/src/main.cu
+++ b/examples/cpp/host_functions/src/main.cu
@@ -1,3 +1,6 @@
+#include <cstdio>
+#include <vector>
+
 #include "flamegpu/flamegpu.h"
 
 const unsigned int AGENT_COUNT = 1024;

--- a/examples/cpp/sugarscape/src/main.cu
+++ b/examples/cpp/sugarscape/src/main.cu
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <array>
+#include <vector>
 
 #include "flamegpu/flamegpu.h"
 

--- a/include/flamegpu/visualiser/color/Color.h
+++ b/include/flamegpu/visualiser/color/Color.h
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <array>
+#include <cstdio>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 

--- a/src/flamegpu/detail/JitifyCache.cu
+++ b/src/flamegpu/detail/JitifyCache.cu
@@ -6,6 +6,9 @@
 #include <regex>
 #include <array>
 #include <filesystem>
+#include <vector>
+#include <memory>
+#include <string>
 
 #include "flamegpu/version.h"
 #include "flamegpu/exception/FLAMEGPUException.h"

--- a/src/flamegpu/detail/TestSuiteTelemetry.cpp
+++ b/src/flamegpu/detail/TestSuiteTelemetry.cpp
@@ -1,4 +1,6 @@
 #include <cstdio>
+#include <map>
+#include <string>
 
 #include "flamegpu/detail/TestSuiteTelemetry.h"
 

--- a/src/flamegpu/detail/compute_capability.cu
+++ b/src/flamegpu/detail/compute_capability.cu
@@ -1,6 +1,8 @@
 #include <nvrtc.h>
 
 #include <cassert>
+#include <vector>
+#include <string>
 
 #include "flamegpu/detail/compute_capability.cuh"
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"

--- a/src/flamegpu/exception/FLAMEGPUDeviceException.cu
+++ b/src/flamegpu/exception/FLAMEGPUDeviceException.cu
@@ -1,3 +1,6 @@
+#include <cstdio>
+#include <string>
+
 #include "flamegpu/exception/FLAMEGPUDeviceException.cuh"
 
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"

--- a/src/flamegpu/exception/FLAMEGPUException.cpp
+++ b/src/flamegpu/exception/FLAMEGPUException.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <sstream>
 #include <limits>
+#include <string>
 
 namespace flamegpu {
 namespace exception {

--- a/src/flamegpu/io/JSONGraphReader.cpp
+++ b/src/flamegpu/io/JSONGraphReader.cpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <map>
 #include <set>
+#include <cstdio>
+#include <memory>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"

--- a/src/flamegpu/io/JSONGraphWriter.cpp
+++ b/src/flamegpu/io/JSONGraphWriter.cpp
@@ -4,6 +4,10 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 #include <fstream>
+#include <cstdio>
+#include <utility>
+#include <string>
+#include <memory>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"

--- a/src/flamegpu/io/JSONStateReader.cu
+++ b/src/flamegpu/io/JSONStateReader.cu
@@ -9,6 +9,10 @@
 #include <unordered_map>
 #include <cerrno>
 #include <numeric>
+#include <cstdio>
+#include <vector>
+#include <functional>
+#include <memory>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/simulation/AgentVector.h"

--- a/src/flamegpu/io/JSONStateWriter.cu
+++ b/src/flamegpu/io/JSONStateWriter.cu
@@ -9,6 +9,9 @@
 #include <numeric>
 #include <set>
 #include <algorithm>
+#include <memory>
+#include <map>
+#include <functional>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/model/AgentDescription.h"

--- a/src/flamegpu/io/StateReader.cu
+++ b/src/flamegpu/io/StateReader.cu
@@ -1,5 +1,9 @@
 #include "flamegpu/io/StateReader.h"
 
+#include <vector>
+#include <unordered_map>
+#include <string>
+
 namespace flamegpu {
 namespace io {
 

--- a/src/flamegpu/io/Telemetry.cpp
+++ b/src/flamegpu/io/Telemetry.cpp
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <cctype>
 #include <sstream>
+#include <string>
+#include <map>
 
 #include "flamegpu/version.h"
 

--- a/src/flamegpu/io/XMLLogger.cu
+++ b/src/flamegpu/io/XMLLogger.cu
@@ -1,6 +1,8 @@
 #include "flamegpu/io/XMLLogger.h"
 
 #include <sstream>
+#include <cstdio>
+#include <string>
 
 #include "tinyxml2/tinyxml2.h"              // downloaded from https:// github.com/leethomason/tinyxml2, the list of xml parsers : http:// lars.ruoff.free.fr/xmlcpp/
 

--- a/src/flamegpu/io/XMLStateReader.cu
+++ b/src/flamegpu/io/XMLStateReader.cu
@@ -3,6 +3,12 @@
 #include <algorithm>
 #include <numeric>
 #include <tuple>
+#include <cstdio>
+#include <vector>
+#include <functional>
+#include <memory>
+#include <string>
+
 #include "tinyxml2/tinyxml2.h"              // downloaded from https:// github.com/leethomason/tinyxml2, the list of xml parsers : http:// lars.ruoff.free.fr/xmlcpp/
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/simulation/AgentVector.h"

--- a/src/flamegpu/io/XMLStateWriter.cu
+++ b/src/flamegpu/io/XMLStateWriter.cu
@@ -2,6 +2,13 @@
 
 #include <numeric>
 #include <sstream>
+#include <string>
+#include <functional>
+#include <algorithm>
+#include <set>
+#include <map>
+#include <memory>
+
 #include "tinyxml2/tinyxml2.h"              // downloaded from https:// github.com/leethomason/tinyxml2, the list of xml parsers : http:// lars.ruoff.free.fr/xmlcpp/
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/model/AgentDescription.h"

--- a/src/flamegpu/model/AgentData.cpp
+++ b/src/flamegpu/model/AgentData.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/model/AgentData.h"
 
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/model/AgentFunctionDescription.h"
 

--- a/src/flamegpu/model/AgentDescription.cpp
+++ b/src/flamegpu/model/AgentDescription.cpp
@@ -1,5 +1,9 @@
 #include "flamegpu/model/AgentDescription.h"
 
+#include <utility>
+#include <set>
+#include <string>
+
 #include "flamegpu/model/AgentFunctionDescription.h"
 #include "flamegpu/exception/FLAMEGPUException.h"
 

--- a/src/flamegpu/model/AgentFunctionData.cpp
+++ b/src/flamegpu/model/AgentFunctionData.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/model/AgentFunctionData.cuh"
 
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/model/AgentFunctionDescription.h"
 #include "flamegpu/runtime/detail/curve/curve_rtc.cuh"

--- a/src/flamegpu/model/AgentFunctionDescription.cpp
+++ b/src/flamegpu/model/AgentFunctionDescription.cpp
@@ -5,6 +5,10 @@
 #include <sstream>
 #include <string>
 #include <regex>
+#include <utility>
+#include <vector>
+#include <memory>
+#include <set>
 
 #include "flamegpu/model/AgentFunctionDescription.h"
 #include "flamegpu/detail/cxxname.hpp"

--- a/src/flamegpu/model/DependencyGraph.cpp
+++ b/src/flamegpu/model/DependencyGraph.cpp
@@ -1,5 +1,11 @@
 #include "flamegpu/model/DependencyGraph.h"
 
+#include <vector>
+#include <memory>
+#include <set>
+#include <iostream>
+#include <string>
+
 namespace flamegpu {
 
 DependencyGraph::DependencyGraph(ModelData* _model) : model(_model) {

--- a/src/flamegpu/model/DependencyNode.cpp
+++ b/src/flamegpu/model/DependencyNode.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "flamegpu/model/DependencyNode.h"
 

--- a/src/flamegpu/model/EnvironmentData.cpp
+++ b/src/flamegpu/model/EnvironmentData.cpp
@@ -1,4 +1,7 @@
 #include "flamegpu/model/EnvironmentData.h"
+
+#include <memory>
+
 #include "flamegpu/model/EnvironmentDirectedGraphData.cuh"
 
 namespace flamegpu {

--- a/src/flamegpu/model/EnvironmentDescription.cpp
+++ b/src/flamegpu/model/EnvironmentDescription.cpp
@@ -1,3 +1,7 @@
+#include <utility>
+#include <memory>
+#include <string>
+
 #include "flamegpu/model/EnvironmentDescription.h"
 #include "flamegpu/model/EnvironmentDirectedGraphDescription.cuh"
 

--- a/src/flamegpu/model/EnvironmentDirectedGraphData.cu
+++ b/src/flamegpu/model/EnvironmentDirectedGraphData.cu
@@ -1,5 +1,8 @@
 #include "flamegpu/model/EnvironmentDirectedGraphData.cuh"
 
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/EnvironmentDirectedGraphDescription.cuh"
 #include "flamegpu/defines.h"
 

--- a/src/flamegpu/model/EnvironmentDirectedGraphDescription.cu
+++ b/src/flamegpu/model/EnvironmentDirectedGraphDescription.cu
@@ -1,4 +1,8 @@
 #include "flamegpu/model/EnvironmentDirectedGraphDescription.cuh"
+
+#include <utility>
+#include <string>
+
 namespace flamegpu {
 
 CEnvironmentDirectedGraphDescription::CEnvironmentDirectedGraphDescription(std::shared_ptr<EnvironmentDirectedGraphData> data)

--- a/src/flamegpu/model/LayerData.cpp
+++ b/src/flamegpu/model/LayerData.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/model/LayerData.h"
 
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/LayerDescription.h"
 #include "flamegpu/model/SubModelData.h"
 

--- a/src/flamegpu/model/LayerDescription.cpp
+++ b/src/flamegpu/model/LayerDescription.cpp
@@ -1,4 +1,8 @@
 #include "flamegpu/model/LayerDescription.h"
+
+#include <utility>
+#include <string>
+
 #include "flamegpu/model/AgentFunctionDescription.h"
 #include "flamegpu/model/SubModelDescription.h"
 #include "flamegpu/model/SubModelData.h"

--- a/src/flamegpu/model/ModelData.cpp
+++ b/src/flamegpu/model/ModelData.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <algorithm>
+#include <string>
+#include <memory>
 
 #include "flamegpu/model/ModelData.h"
 

--- a/src/flamegpu/model/ModelDescription.cpp
+++ b/src/flamegpu/model/ModelDescription.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/model/ModelDescription.h"
 
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/DependencyGraph.h"
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/model/LayerDescription.h"

--- a/src/flamegpu/model/SubAgentData.cpp
+++ b/src/flamegpu/model/SubAgentData.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/model/SubAgentData.h"
 
+#include <utility>
+#include <memory>
+
 #include "flamegpu/model/SubAgentDescription.h"
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/model/ModelData.h"

--- a/src/flamegpu/model/SubAgentDescription.cpp
+++ b/src/flamegpu/model/SubAgentDescription.cpp
@@ -1,4 +1,8 @@
 #include "flamegpu/model/SubAgentDescription.h"
+
+#include <utility>
+#include <string>
+
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/model/SubAgentData.h"
 #include "flamegpu/model/AgentData.h"

--- a/src/flamegpu/model/SubEnvironmentData.cpp
+++ b/src/flamegpu/model/SubEnvironmentData.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/model/SubEnvironmentData.h"
 
+#include <utility>
+#include <memory>
+
 #include "flamegpu/model/SubEnvironmentDescription.h"
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/model/SubModelData.h"

--- a/src/flamegpu/model/SubEnvironmentDescription.cpp
+++ b/src/flamegpu/model/SubEnvironmentDescription.cpp
@@ -1,4 +1,8 @@
 #include "flamegpu/model/SubEnvironmentDescription.h"
+
+#include <utility>
+#include <string>
+
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/model/SubModelData.h"
 #include "flamegpu/model/SubEnvironmentData.h"

--- a/src/flamegpu/model/SubModelData.cpp
+++ b/src/flamegpu/model/SubModelData.cpp
@@ -1,5 +1,9 @@
 #include "flamegpu/model/SubModelData.h"
 
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/model/SubModelDescription.h"

--- a/src/flamegpu/model/SubModelDescription.cpp
+++ b/src/flamegpu/model/SubModelDescription.cpp
@@ -1,4 +1,9 @@
 #include "flamegpu/model/SubModelDescription.h"
+
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/model/SubModelData.h"

--- a/src/flamegpu/runtime/HostAPI.cu
+++ b/src/flamegpu/runtime/HostAPI.cu
@@ -1,6 +1,9 @@
 #include "flamegpu/runtime/HostAPI.h"
 
 #include <map>
+#include <string>
+#include <memory>
+
 #include "flamegpu/runtime/agent/HostAgentAPI.cuh"
 #include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/simulation/Simulation.h"

--- a/src/flamegpu/runtime/agent/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/runtime/agent/DeviceAgentVector_impl.cu
@@ -1,3 +1,7 @@
+#include <utility>
+#include <vector>
+#include <string>
+
 #include "flamegpu/runtime/agent/DeviceAgentVector_impl.h"
 #include "flamegpu/simulation/detail/CUDAAgent.h"
 #include "flamegpu/runtime/agent/HostNewAgentAPI.h"

--- a/src/flamegpu/runtime/agent/HostAgentAPI.cu
+++ b/src/flamegpu/runtime/agent/HostAgentAPI.cu
@@ -1,4 +1,7 @@
 #include "flamegpu/runtime/agent/HostAgentAPI.cuh"
+
+#include <memory>
+
 #include "flamegpu/runtime/agent/DeviceAgentVector_impl.h"
 
 namespace flamegpu {

--- a/src/flamegpu/runtime/detail/curve/Curve.cu
+++ b/src/flamegpu/runtime/detail/curve/Curve.cu
@@ -2,6 +2,7 @@
 
 #include <cuda_runtime.h>
 
+#include <string>
 #include <cstring>
 
 namespace flamegpu {

--- a/src/flamegpu/runtime/detail/curve/HostCurve.cu
+++ b/src/flamegpu/runtime/detail/curve/HostCurve.cu
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <map>
 #include <memory>
+#include <string>
 
 #include "flamegpu/runtime/detail/curve/HostCurve.cuh"
 

--- a/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
+++ b/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
@@ -732,7 +732,9 @@ void CurveRTCHost::initHeaderSetters() {
                 setAgentVariableImpl << "              (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << agent_data_offset + (ct++ * sizeof(void*)) << ")))[index] = (T) variable;\n";
                 setAgentVariableImpl << "              return;\n";
                 setAgentVariableImpl << "          }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         setAgentVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         setAgentVariableImpl <<         "          DTHROW(\"Agent variable '%s' was not found during setVariable().\\n\", name);\n";
@@ -759,7 +761,9 @@ void CurveRTCHost::initHeaderSetters() {
                 setMessageVariableImpl << "              (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << messageOut_data_offset + (ct++ * sizeof(void*)) << ")))[index] = (T) variable;\n";
                 setMessageVariableImpl << "              return;\n";
                 setMessageVariableImpl << "          }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         setMessageVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         setMessageVariableImpl <<         "          DTHROW(\"Message variable '%s' was not found during setVariable().\\n\", name);\n";
@@ -786,7 +790,9 @@ void CurveRTCHost::initHeaderSetters() {
                 setNewAgentVariableImpl << "              (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << newAgent_data_offset + (ct++ * sizeof(void*)) << ")))[index] = (T) variable;\n";
                 setNewAgentVariableImpl << "              return;\n";
                 setNewAgentVariableImpl << "          }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         setNewAgentVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         setNewAgentVariableImpl <<         "          DTHROW(\"New agent variable '%s' was not found during setVariable().\\n\", name);\n";
@@ -819,7 +825,9 @@ void CurveRTCHost::initHeaderSetters() {
                 setAgentArrayVariableImpl << "              (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << agent_data_offset + (ct++ * sizeof(void*)) << ")))[i] = (T) variable;\n";
                 setAgentArrayVariableImpl << "              return;\n";
                 setAgentArrayVariableImpl << "          }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         setAgentArrayVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         setAgentArrayVariableImpl <<         "          DTHROW(\"Agent array variable '%s' was not found during setVariable().\\n\", name);\n";
@@ -852,7 +860,9 @@ void CurveRTCHost::initHeaderSetters() {
                 setMessageArrayVariableImpl << "              (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << messageOut_data_offset + (ct++ * sizeof(void*)) << ")))[i] = (T) variable;\n";
                 setMessageArrayVariableImpl << "              return;\n";
                 setMessageArrayVariableImpl << "          }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         setMessageArrayVariableImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         setMessageArrayVariableImpl << "          DTHROW(\"Message array variable '%s' was not found during setVariable().\\n\", name);\n";
@@ -885,7 +895,9 @@ void CurveRTCHost::initHeaderSetters() {
                 setNewAgentArrayVariableImpl << "              (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << newAgent_data_offset + (ct++ * sizeof(void*)) << ")))[i] = (T) variable;\n";
                 setNewAgentArrayVariableImpl << "              return;\n";
                 setNewAgentArrayVariableImpl << "          }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         setNewAgentArrayVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         setNewAgentArrayVariableImpl <<         "          DTHROW(\"New agent array variable '%s' was not found during setVariable().\\n\", name);\n";
@@ -913,7 +925,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getAgentVariableImpl << "#endif\n";
                 getAgentVariableImpl << "                return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << agent_data_offset + (ct++ * sizeof(void*)) << ")))[index];\n";
                 getAgentVariableImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getAgentVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getAgentVariableImpl <<         "            DTHROW(\"Agent variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -940,7 +954,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getMessageVariableImpl << "#endif\n";
                 getMessageVariableImpl << "                return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << messageIn_data_offset + (ct++ * sizeof(void*)) << ")))[index];\n";
                 getMessageVariableImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getMessageVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getMessageVariableImpl <<         "            DTHROW(\"Message variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -958,7 +974,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getDirectedGraphPBMImpl << "            if (graphHash == " << Curve::variableRuntimeHash(element.first.first) << ") {\n";
                 getDirectedGraphPBMImpl << "                return (*static_cast<unsigned int**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphVertex_data_offset + (ct++ * sizeof(void*)) << ")));\n";
                 getDirectedGraphPBMImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getDirectedGraphPBMImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getDirectedGraphPBMImpl << "            DTHROW(\"Directed graph PBM was not found during getEnvironmentDirectedGraphPBM().\\n\");\n";
@@ -976,7 +994,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getDirectedGraphIPBMImpl << "            if (graphHash == " << Curve::variableRuntimeHash(element.first.first) << ") {\n";
                 getDirectedGraphIPBMImpl << "                return (*static_cast<unsigned int**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphVertex_data_offset + (ct++ * sizeof(void*)) << ")));\n";
                 getDirectedGraphIPBMImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getDirectedGraphIPBMImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getDirectedGraphIPBMImpl << "            DTHROW(\"Directed graph IPBM was not found during getEnvironmentDirectedGraphIPBM().\\n\");\n";
@@ -994,7 +1014,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getDirectedGraphIPBMEdgesImpl << "            if (graphHash == " << Curve::variableRuntimeHash(element.first.first) << ") {\n";
                 getDirectedGraphIPBMEdgesImpl << "                return (*static_cast<unsigned int**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphVertex_data_offset + (ct++ * sizeof(void*)) << ")));\n";
                 getDirectedGraphIPBMEdgesImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getDirectedGraphIPBMEdgesImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getDirectedGraphIPBMEdgesImpl << "            DTHROW(\"Directed graph IPBM edge list was not found during getEnvironmentDirectedGraphIPBMEdges().\\n\");\n";
@@ -1021,7 +1043,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getGraphVertexPropertyImpl << "#endif\n";
                 getGraphVertexPropertyImpl << "                return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphVertex_data_offset + (ct++ * sizeof(void*)) << ")))[index];\n";
                 getGraphVertexPropertyImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getGraphVertexPropertyImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getGraphVertexPropertyImpl << "            DTHROW(\"Directed graph vertex property '%s' was not found during getProperty().\\n\", name);\n";
@@ -1048,7 +1072,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getGraphEdgePropertyImpl << "#endif\n";
                 getGraphEdgePropertyImpl << "                return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphEdge_data_offset + (ct++ * sizeof(void*)) << ")))[index];\n";
                 getGraphEdgePropertyImpl << "            }\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getGraphEdgePropertyImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getGraphEdgePropertyImpl << "            DTHROW(\"Directed graph edge property '%s' was not found during getProperty().\\n\", name);\n";
@@ -1073,7 +1099,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getAgentVariableLDGImpl << "                return (T) __ldg((*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << agent_data_offset + (ct * sizeof(void*)) << "))) + index);\n";
                 getAgentVariableLDGImpl << "            }\n";
                 ++ct;  // Prev was part of the return line, but don't want confusion
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getAgentVariableLDGImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getAgentVariableLDGImpl <<         "            DTHROW(\"Agent variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -1098,7 +1126,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getMessageVariableLDGImpl << "                return (T) __ldg((*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << messageIn_data_offset + (ct * sizeof(void*)) << "))) + index);\n";
                 getMessageVariableLDGImpl << "            }\n";
                 ++ct;  // Prev was part of the return line, but don't want confusion
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getMessageVariableLDGImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getMessageVariableLDGImpl <<         "            DTHROW(\"Message variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -1131,7 +1161,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getAgentArrayVariableImpl << "#endif\n";
                 getAgentArrayVariableImpl << "              return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << agent_data_offset + (ct++ * sizeof(void*)) << ")))[i];\n";
                 getAgentArrayVariableImpl << "           };\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getAgentArrayVariableImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getAgentArrayVariableImpl <<         "           DTHROW(\"Agent array variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -1164,7 +1196,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getMessageArrayVariableImpl << "#endif\n";
                 getMessageArrayVariableImpl << "              return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << messageIn_data_offset + (ct++ * sizeof(void*)) << ")))[i];\n";
                 getMessageArrayVariableImpl << "           };\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getMessageArrayVariableImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getMessageArrayVariableImpl << "           DTHROW(\"Message array variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -1197,7 +1231,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getGraphVertexArrayPropertyImpl << "#endif\n";
                 getGraphVertexArrayPropertyImpl << "              return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphVertex_data_offset + (ct++ * sizeof(void*)) << ")))[i];\n";
                 getGraphVertexArrayPropertyImpl << "           };\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getGraphVertexArrayPropertyImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getGraphVertexArrayPropertyImpl << "           DTHROW(\"Directed graph vertex array property '%s' was not found during getProperty().\\n\", name);\n";
@@ -1230,7 +1266,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getGraphEdgeArrayPropertyImpl << "#endif\n";
                 getGraphEdgeArrayPropertyImpl << "              return (*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << directedGraphEdge_data_offset + (ct++ * sizeof(void*)) << ")))[i];\n";
                 getGraphEdgeArrayPropertyImpl << "           };\n";
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getGraphEdgeArrayPropertyImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getGraphEdgeArrayPropertyImpl << "           DTHROW(\"Directed graph edge array property '%s' was not found during getProperty().\\n\", name);\n";
@@ -1263,7 +1301,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getAgentArrayVariableLDGImpl << "                return (T) __ldg((*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << agent_data_offset + (ct * sizeof(void*)) << "))) + i);\n";
                 getAgentArrayVariableLDGImpl << "           };\n";
                 ++ct;  // Prev was part of the return line, but don't want confusion
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getAgentArrayVariableLDGImpl <<         "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getAgentArrayVariableLDGImpl <<         "           DTHROW(\"Agent array variable '%s' was not found during getVariable().\\n\", name);\n";
@@ -1296,7 +1336,9 @@ void CurveRTCHost::initHeaderGetters() {
                 getMessageArrayVariableLDGImpl << "                return (T) __ldg((*static_cast<T**>(static_cast<void*>(flamegpu::detail::curve::" << getVariableSymbolName() << " + " << messageIn_data_offset + (ct * sizeof(void*)) << "))) + i);\n";
                 getMessageArrayVariableLDGImpl << "           };\n";
                 ++ct;  // Prev was part of the return line, but don't want confusion
-            } else { ++ct; }
+            } else {
+                ++ct;
+            }
         }
         getMessageArrayVariableLDGImpl << "#if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS\n";
         getMessageArrayVariableLDGImpl << "           DTHROW(\"Message array variable '%s' was not found during getVariable().\\n\", name);\n";

--- a/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
+++ b/src/flamegpu/runtime/detail/curve/curve_rtc.cpp
@@ -1,4 +1,6 @@
 #include <sstream>
+#include <set>
+#include <string>
 
 #include "flamegpu/runtime/detail/curve/curve_rtc.cuh"
 #include "flamegpu/exception/FLAMEGPUException.h"

--- a/src/flamegpu/runtime/environment/HostEnvironment.cu
+++ b/src/flamegpu/runtime/environment/HostEnvironment.cu
@@ -5,6 +5,11 @@
 #include <iterator>
 #include <numeric>
 #include <vector>
+#include <utility>
+#include <memory>
+#include <unordered_map>
+#include <functional>
+#include <string>
 
 #include "flamegpu/io/StateWriter.h"
 #include "flamegpu/io/StateWriterFactory.h"

--- a/src/flamegpu/runtime/environment/HostEnvironmentDirectedGraph.cu
+++ b/src/flamegpu/runtime/environment/HostEnvironmentDirectedGraph.cu
@@ -2,6 +2,9 @@
 
 #include <cstring>
 #include <stdexcept>
+#include <utility>
+#include <string>
+#include <memory>
 
 #include "flamegpu/io/JSONGraphReader.h"
 #include "flamegpu/io/JSONGraphWriter.h"

--- a/src/flamegpu/runtime/messaging/MessageArray.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray.cu
@@ -1,4 +1,9 @@
 #include "flamegpu/runtime/messaging/MessageArray.h"
+
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
 #include "flamegpu/simulation/detail/CUDAMessage.h"
 #include "flamegpu/simulation/detail/CUDAScatter.cuh"

--- a/src/flamegpu/runtime/messaging/MessageArray2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray2D.cu
@@ -1,4 +1,9 @@
 #include "flamegpu/runtime/messaging/MessageArray2D.h"
+
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
 #include "flamegpu/simulation/detail/CUDAMessage.h"
 #include "flamegpu/simulation/detail/CUDAScatter.cuh"

--- a/src/flamegpu/runtime/messaging/MessageArray3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageArray3D.cu
@@ -1,4 +1,9 @@
 #include "flamegpu/runtime/messaging/MessageArray3D.h"
+
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign
 #include "flamegpu/simulation/detail/CUDAMessage.h"
 #include "flamegpu/simulation/detail/CUDAScatter.cuh"

--- a/src/flamegpu/runtime/messaging/MessageBruteForce.cu
+++ b/src/flamegpu/runtime/messaging/MessageBruteForce.cu
@@ -1,3 +1,7 @@
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h"
 #include "flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceDevice.cuh"
 #include "flamegpu/model/AgentDescription.h"  // Used by Move-Assign

--- a/src/flamegpu/runtime/messaging/MessageBucket.cu
+++ b/src/flamegpu/runtime/messaging/MessageBucket.cu
@@ -1,5 +1,10 @@
 #include "flamegpu/runtime/messaging/MessageBucket.h"
 
+#include <utility>
+#include <string>
+#include <memory>
+#include <limits>
+
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)

--- a/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial2D.cu
@@ -1,5 +1,9 @@
 #include "flamegpu/runtime/messaging/MessageSpatial2D.h"
 
+#include <utility>
+#include <string>
+#include <memory>
+
 #ifdef _MSC_VER
 #pragma warning(push, 1)
 #pragma warning(disable : 4706 4834)

--- a/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
+++ b/src/flamegpu/runtime/messaging/MessageSpatial3D.cu
@@ -1,3 +1,7 @@
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DHost.h"
 #include "flamegpu/runtime/messaging/MessageSpatial3D/MessageSpatial3DDevice.cuh"
 #include "flamegpu/detail/cuda.cuh"

--- a/src/flamegpu/simulation/AgentInstance.cpp
+++ b/src/flamegpu/simulation/AgentInstance.cpp
@@ -1,5 +1,7 @@
 #include "flamegpu/runtime/agent/AgentInstance.h"
 
+#include <utility>
+
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/simulation/AgentVector.h"

--- a/src/flamegpu/simulation/AgentLoggingConfig.cu
+++ b/src/flamegpu/simulation/AgentLoggingConfig.cu
@@ -1,6 +1,9 @@
-#include <utility>
-
 #include "flamegpu/simulation/AgentLoggingConfig.h"
+
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/model/AgentData.h"
 
 namespace flamegpu {

--- a/src/flamegpu/simulation/AgentVector.cpp
+++ b/src/flamegpu/simulation/AgentVector.cpp
@@ -1,6 +1,10 @@
 #include "flamegpu/simulation/AgentVector.h"
 
 #include <limits>
+#include <utility>
+#include <string>
+#include <memory>
+
 
 #include "flamegpu/model/AgentDescription.h"
 #include "flamegpu/simulation/AgentVector_Agent.h"

--- a/src/flamegpu/simulation/AgentVector_Agent.cpp
+++ b/src/flamegpu/simulation/AgentVector_Agent.cpp
@@ -1,5 +1,7 @@
 #include "flamegpu/simulation/AgentVector_Agent.h"
 
+#include <memory>
+
 namespace flamegpu {
 
 AgentVector_CAgent::AgentVector_CAgent(AgentVector* parent, const std::shared_ptr<const AgentData>& agent, const std::weak_ptr<AgentVector::AgentDataMap>& data, flamegpu::size_type pos)

--- a/src/flamegpu/simulation/CUDAEnsemble.cu
+++ b/src/flamegpu/simulation/CUDAEnsemble.cu
@@ -10,6 +10,9 @@
 #include <condition_variable>
 #include <filesystem>
 #include <map>
+#include <cstdio>
+#include <vector>
+#include <string>
 
 #ifdef FLAMEGPU_ENABLE_MPI
 #include "flamegpu/simulation/detail/MPIEnsemble.h"

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -5,6 +5,11 @@
 #include <string>
 #include <map>
 #include <numeric>
+#include <cstdio>
+#include <vector>
+#include <utility>
+#include <functional>
+#include <memory>
 
 #include "flamegpu/detail/curand.cuh"
 #include "flamegpu/model/AgentFunctionData.cuh"

--- a/src/flamegpu/simulation/LogFrame.cu
+++ b/src/flamegpu/simulation/LogFrame.cu
@@ -1,5 +1,9 @@
 #include "flamegpu/simulation/LogFrame.h"
 
+#include <utility>
+#include <string>
+#include <map>
+
 namespace flamegpu {
 
 LogFrame::LogFrame()

--- a/src/flamegpu/simulation/LoggingConfig.cu
+++ b/src/flamegpu/simulation/LoggingConfig.cu
@@ -1,5 +1,8 @@
 #include "flamegpu/simulation/LoggingConfig.h"
 
+#include <utility>
+#include <string>
+
 #include "flamegpu/simulation/AgentLoggingConfig.h"
 #include "flamegpu/model/ModelDescription.h"
 #include "flamegpu/model/ModelData.h"

--- a/src/flamegpu/simulation/RunPlan.cpp
+++ b/src/flamegpu/simulation/RunPlan.cpp
@@ -1,4 +1,9 @@
 #include "flamegpu/simulation/RunPlan.h"
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+
 #include "flamegpu/simulation/RunPlanVector.h"
 
 #include "flamegpu/model/ModelDescription.h"

--- a/src/flamegpu/simulation/RunPlanVector.cpp
+++ b/src/flamegpu/simulation/RunPlanVector.cpp
@@ -1,4 +1,12 @@
 #include "flamegpu/simulation/RunPlanVector.h"
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <algorithm>
+
+
 #include "flamegpu/model/ModelDescription.h"
 
 namespace flamegpu {

--- a/src/flamegpu/simulation/Simulation.cu
+++ b/src/flamegpu/simulation/Simulation.cu
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>  // For PRIu64
+#include <cstdio>
+#include <string>
+#include <memory>
 
 #include "flamegpu/version.h"
 #include "flamegpu/model/ModelData.h"

--- a/src/flamegpu/simulation/detail/AbstractSimRunner.cu
+++ b/src/flamegpu/simulation/detail/AbstractSimRunner.cu
@@ -1,5 +1,11 @@
 #include "flamegpu/simulation/detail/AbstractSimRunner.h"
 
+#include <utility>
+#include <vector>
+#include <queue>
+#include <memory>
+#include <map>
+
 #ifdef _MSC_VER
 #include <windows.h>
 #else

--- a/src/flamegpu/simulation/detail/CUDAAgent.cu
+++ b/src/flamegpu/simulation/detail/CUDAAgent.cu
@@ -6,6 +6,11 @@
 #include <fstream>
 #include <string>
 #include <filesystem>
+#include <vector>
+#include <unordered_map>
+#include <utility>
+#include <list>
+#include <memory>
 
 #ifdef _MSC_VER
 #pragma warning(push, 1)

--- a/src/flamegpu/simulation/detail/CUDAAgentStateList.cu
+++ b/src/flamegpu/simulation/detail/CUDAAgentStateList.cu
@@ -3,6 +3,12 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
+#include <string>
+#include <memory>
+#include <vector>
+#include <list>
+#include <set>
+
 #include "flamegpu/simulation/detail/CUDAAgent.h"
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"
 #include "flamegpu/simulation/AgentVector.h"

--- a/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
+++ b/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
@@ -1,6 +1,11 @@
 #include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"
 
 #include <algorithm>
+#include <utility>
+#include <string>
+#include <memory>
+#include <vector>
+#include <limits>
 
 #include "flamegpu/simulation/detail/CUDAAgent.h"
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"

--- a/src/flamegpu/simulation/detail/CUDAFatAgent.cu
+++ b/src/flamegpu/simulation/detail/CUDAFatAgent.cu
@@ -1,5 +1,11 @@
 #include "flamegpu/simulation/detail/CUDAFatAgent.h"
 
+#include <unordered_map>
+#include <memory>
+#include <string>
+#include <vector>
+#include <algorithm>
+
 #include "flamegpu/simulation/detail/CUDAScatter.cuh"
 #include "flamegpu/runtime/HostAPI.h"
 #include "flamegpu/util/nvtx.h"

--- a/src/flamegpu/simulation/detail/CUDAFatAgentStateList.cu
+++ b/src/flamegpu/simulation/detail/CUDAFatAgentStateList.cu
@@ -1,4 +1,12 @@
 #include "flamegpu/simulation/detail/CUDAFatAgentStateList.h"
+
+#include <utility>
+#include <string>
+#include <memory>
+#include <vector>
+#include <list>
+#include <unordered_map>
+
 #include "flamegpu/simulation/detail/CUDAScatter.cuh"
 #include "flamegpu/detail/cuda.cuh"
 

--- a/src/flamegpu/simulation/detail/CUDAMacroEnvironment.cu
+++ b/src/flamegpu/simulation/detail/CUDAMacroEnvironment.cu
@@ -1,5 +1,10 @@
 #include "flamegpu/simulation/detail/CUDAMacroEnvironment.h"
 
+#include <string>
+#include <memory>
+#include <map>
+#include <vector>
+
 #include "flamegpu/model/EnvironmentDescription.h"
 #include "flamegpu/simulation/CUDASimulation.h"
 #include "flamegpu/model/AgentFunctionData.cuh"

--- a/src/flamegpu/simulation/detail/CUDAMessage.cu
+++ b/src/flamegpu/simulation/detail/CUDAMessage.cu
@@ -1,6 +1,10 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
+#include <string>
+#include <memory>
+#include <algorithm>
+
 #include "flamegpu/simulation/detail/CUDAMessage.h"
 #include "flamegpu/simulation/detail/CUDAAgent.h"
 #include "flamegpu/simulation/detail/CUDAMessageList.h"

--- a/src/flamegpu/simulation/detail/CUDAMessageList.cu
+++ b/src/flamegpu/simulation/detail/CUDAMessageList.cu
@@ -1,8 +1,10 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
-#include "flamegpu/simulation/detail/CUDAMessageList.h"
+#include <string>
+#include <utility>
 
+#include "flamegpu/simulation/detail/CUDAMessageList.h"
 #include "flamegpu/simulation/detail/CUDAMessage.h"
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"
 #include "flamegpu/runtime/messaging/MessageBruteForce/MessageBruteForceHost.h"

--- a/src/flamegpu/simulation/detail/CUDAScatter.cu
+++ b/src/flamegpu/simulation/detail/CUDAScatter.cu
@@ -3,6 +3,12 @@
 #include <cuda_runtime.h>
 #include <vector>
 #include <cassert>
+#include <cstdio>
+#include <list>
+#include <map>
+#include <string>
+#include <algorithm>
+#include <limits>
 
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"
 #include "flamegpu/simulation/detail/CUDAFatAgentStateList.h"

--- a/src/flamegpu/simulation/detail/DeviceStrings.cu
+++ b/src/flamegpu/simulation/detail/DeviceStrings.cu
@@ -1,5 +1,7 @@
 #include "flamegpu/simulation/detail/DeviceStrings.h"
 
+#include <string>
+
 #include "flamegpu/detail/cuda.cuh"
 #include "flamegpu/simulation/detail/CUDAErrorChecking.cuh"
 

--- a/src/flamegpu/simulation/detail/EnvironmentManager.cu
+++ b/src/flamegpu/simulation/detail/EnvironmentManager.cu
@@ -1,6 +1,10 @@
 #include "flamegpu/simulation/detail/EnvironmentManager.cuh"
 
 #include <iostream>
+#include <utility>
+#include <string>
+#include <memory>
+#include <set>
 
 #include "flamegpu/model/EnvironmentData.h"
 #include "flamegpu/model/SubEnvironmentData.h"

--- a/src/flamegpu/simulation/detail/MPIEnsemble.cu
+++ b/src/flamegpu/simulation/detail/MPIEnsemble.cu
@@ -1,4 +1,11 @@
 #ifdef FLAMEGPU_ENABLE_MPI
+#include <cstdio>
+#include <string>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <set>
+
 #include "flamegpu/simulation/detail/MPIEnsemble.h"
 
 #include "flamegpu/detail/compute_capability.cuh"

--- a/src/flamegpu/simulation/detail/MPISimRunner.cu
+++ b/src/flamegpu/simulation/detail/MPISimRunner.cu
@@ -1,6 +1,10 @@
 #include "flamegpu/simulation/detail/MPISimRunner.h"
 
 #include <utility>
+#include <map>
+#include <memory>
+#include <queue>
+#include <vector>
 
 #include "flamegpu/model/ModelData.h"
 #include "flamegpu/simulation/CUDASimulation.h"

--- a/src/flamegpu/simulation/detail/SimLogger.cu
+++ b/src/flamegpu/simulation/detail/SimLogger.cu
@@ -1,6 +1,10 @@
 #include "flamegpu/simulation/detail/SimLogger.h"
 
 #include <filesystem>
+#include <string>
+#include <map>
+#include <queue>
+#include <memory>
 
 #include "flamegpu/io/LoggerFactory.h"
 #include "flamegpu/simulation/RunPlanVector.h"

--- a/src/flamegpu/simulation/detail/SimRunner.cu
+++ b/src/flamegpu/simulation/detail/SimRunner.cu
@@ -1,3 +1,9 @@
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <queue>
+#include <vector>
+
 #include "flamegpu/simulation/detail/SimRunner.h"
 
 #include "flamegpu/simulation/RunPlanVector.h"

--- a/src/flamegpu/visualiser/AgentStateVis.cpp
+++ b/src/flamegpu/visualiser/AgentStateVis.cpp
@@ -1,6 +1,8 @@
 // @todo - ifdef visualisation?
 #include "flamegpu/visualiser/AgentStateVis.h"
 
+#include <string>
+
 #include "flamegpu/exception/FLAMEGPUException.h"
 #include "flamegpu/visualiser/AgentVis.h"
 #include "flamegpu/model/AgentData.h"

--- a/src/flamegpu/visualiser/AgentVis.cpp
+++ b/src/flamegpu/visualiser/AgentVis.cpp
@@ -2,6 +2,10 @@
 
 #include "flamegpu/visualiser/AgentVis.h"
 
+#include <utility>
+#include <string>
+#include <memory>
+
 #include "flamegpu/simulation/detail/CUDAAgent.h"
 #include "flamegpu/model/AgentData.h"
 #include "flamegpu/model/AgentDescription.h"

--- a/src/flamegpu/visualiser/EnvironmentGraphVis.cpp
+++ b/src/flamegpu/visualiser/EnvironmentGraphVis.cpp
@@ -1,5 +1,8 @@
 #include "flamegpu/visualiser/EnvironmentGraphVis.h"
 
+#include <utility>
+#include <string>
+#include <memory>
 
 #include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"
 #include "flamegpu/visualiser/LineVis.h"

--- a/src/flamegpu/visualiser/LineVis.cpp
+++ b/src/flamegpu/visualiser/LineVis.cpp
@@ -2,6 +2,8 @@
 
 #include "flamegpu/visualiser/LineVis.h"
 
+#include <utility>
+
 namespace flamegpu {
 namespace visualiser {
 

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -4,6 +4,9 @@
 
 #include <thread>
 #include <utility>
+#include <string>
+#include <memory>
+#include <unordered_map>
 
 #include "flamegpu/simulation/CUDASimulation.h"
 #include "flamegpu/model/AgentData.h"

--- a/src/flamegpu/visualiser/PanelVis.cpp
+++ b/src/flamegpu/visualiser/PanelVis.cpp
@@ -1,4 +1,6 @@
 #include <utility>
+#include <string>
+#include <memory>
 
 #include "flamegpu/visualiser/PanelVis.h"
 

--- a/src/flamegpu/visualiser/StaticModelVis.cpp
+++ b/src/flamegpu/visualiser/StaticModelVis.cpp
@@ -1,6 +1,8 @@
 // @todo - ifdef visualisation
 #include "flamegpu/visualiser/StaticModelVis.h"
 
+#include <utility>
+
 #include "flamegpu/exception/FLAMEGPUException.h"
 
 namespace flamegpu {

--- a/src/flamegpu/visualiser/color/DiscreteColor.cpp
+++ b/src/flamegpu/visualiser/color/DiscreteColor.cpp
@@ -1,4 +1,8 @@
 #include "flamegpu/visualiser/color/DiscreteColor.h"
+
+#include <string>
+#include <map>
+
 #include "flamegpu/visualiser/color/Palette.h"
 
 namespace flamegpu {

--- a/src/flamegpu/visualiser/color/HSVInterpolation.cpp
+++ b/src/flamegpu/visualiser/color/HSVInterpolation.cpp
@@ -2,6 +2,7 @@
 #include "flamegpu/visualiser/color/HSVInterpolation.h"
 
 #include <sstream>
+#include <string>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 

--- a/src/flamegpu/visualiser/color/StaticColor.cpp
+++ b/src/flamegpu/visualiser/color/StaticColor.cpp
@@ -2,6 +2,7 @@
 #include "flamegpu/visualiser/color/StaticColor.h"
 
 #include <sstream>
+#include <string>
 
 #include "flamegpu/exception/FLAMEGPUException.h"
 

--- a/src/flamegpu/visualiser/color/ViridisInterpolation.cpp
+++ b/src/flamegpu/visualiser/color/ViridisInterpolation.cpp
@@ -1,7 +1,9 @@
 // @todo -  #ifdef FLAMEGPU_VISUALISATION
 #include "flamegpu/visualiser/color/ViridisInterpolation.h"
 
+#include <utility>
 #include <sstream>
+#include <string>
 
 namespace flamegpu {
 namespace visualiser {

--- a/tests/helpers/device_initialisation.cu
+++ b/tests/helpers/device_initialisation.cu
@@ -1,6 +1,7 @@
 #include "helpers/device_initialisation.h"
 #include <cuda.h>
 #include <stdio.h>
+#include <cstdio>
 #include "flamegpu/flamegpu.h"
 
 namespace flamegpu {

--- a/tests/helpers/host_reductions_common.cu
+++ b/tests/helpers/host_reductions_common.cu
@@ -1,3 +1,6 @@
+#include <utility>
+#include <vector>
+
 #include "helpers/host_reductions_common.h"
 
 namespace flamegpu {

--- a/tests/helpers/main.cu
+++ b/tests/helpers/main.cu
@@ -1,6 +1,7 @@
 #include <cuda_runtime.h>
 #include <cstdio>
 #include <map>
+#include <string>
 
 #include "flamegpu/simulation/CUDASimulation.h"
 #include "gtest/gtest.h"

--- a/tests/test_cases/detail/test_multi_thread_device.cu
+++ b/tests/test_cases/detail/test_multi_thread_device.cu
@@ -1,6 +1,8 @@
 #include <thread>
 #include <vector>
 #include <memory>
+#include <cstdio>
+#include <utility>
 
 #include "flamegpu/flamegpu.h"
 #include "gtest/gtest.h"

--- a/tests/test_cases/detail/test_rtc_multi_thread_device.cu
+++ b/tests/test_cases/detail/test_rtc_multi_thread_device.cu
@@ -1,6 +1,8 @@
 #include <thread>
 #include <vector>
 #include <memory>
+#include <cstdio>
+#include <utility>
 
 #include "flamegpu/flamegpu.h"
 #include "gtest/gtest.h"

--- a/tests/test_cases/exception/test_device_exception.cu
+++ b/tests/test_cases/exception/test_device_exception.cu
@@ -1,3 +1,4 @@
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/tests/test_cases/exception/test_flamegpu_exception.cpp
+++ b/tests/test_cases/exception/test_flamegpu_exception.cpp
@@ -1,3 +1,4 @@
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/tests/test_cases/exception/test_rtc_device_exception.cu
+++ b/tests/test_cases/exception/test_rtc_device_exception.cu
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "gtest/gtest.h"
 
 #include "flamegpu/flamegpu.h"

--- a/tests/test_cases/io/test_io.cu
+++ b/tests/test_cases/io/test_io.cu
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <fstream>
+#include <limits>
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/tests/test_cases/io/test_logging.cu
+++ b/tests/test_cases/io/test_logging.cu
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <thread>
 #include <filesystem>
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/tests/test_cases/model/test_dependency_graph.cu
+++ b/tests/test_cases/model/test_dependency_graph.cu
@@ -1,4 +1,6 @@
 #include <cstdio>
+#include <string>
+#include <iostream>
 
 #include "flamegpu/flamegpu.h"
 

--- a/tests/test_cases/model/test_layer.cu
+++ b/tests/test_cases/model/test_layer.cu
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/model/test_model.cu
+++ b/tests/test_cases/model/test_model.cu
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/runtime/agent/detail/test_spatial_agent_sort.cu
+++ b/tests/test_cases/runtime/agent/detail/test_spatial_agent_sort.cu
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/runtime/agent/host_reduction/test_histogram_even.cu
+++ b/tests/test_cases/runtime/agent/host_reduction/test_histogram_even.cu
@@ -1,4 +1,7 @@
+#include <vector>
+
 #include "helpers/host_reductions_common.h"
+
 namespace flamegpu {
 
 

--- a/tests/test_cases/runtime/agent/host_reduction/test_min.cu
+++ b/tests/test_cases/runtime/agent/host_reduction/test_min.cu
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "helpers/host_reductions_common.h"
 
 namespace flamegpu {

--- a/tests/test_cases/runtime/agent/host_reduction/test_transform_reduce.cu
+++ b/tests/test_cases/runtime/agent/host_reduction/test_transform_reduce.cu
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "helpers/host_reductions_common.h"
 namespace flamegpu {
 

--- a/tests/test_cases/runtime/agent/test_device_agent_creation.cu
+++ b/tests/test_cases/runtime/agent/test_device_agent_creation.cu
@@ -9,6 +9,9 @@
 * > With birthing agent conditional state change
 */
 #include <set>
+#include <cstdio>
+#include <utility>
+#include <map>
 
 #include "flamegpu/flamegpu.h"
 

--- a/tests/test_cases/runtime/agent/test_device_agent_vector.cu
+++ b/tests/test_cases/runtime/agent/test_device_agent_vector.cu
@@ -1,5 +1,6 @@
 #include <string>
 #include <set>
+#include <vector>
 
 #include "flamegpu/flamegpu.h"
 

--- a/tests/test_cases/runtime/messaging/test_bucket.cu
+++ b/tests/test_cases/runtime/messaging/test_bucket.cu
@@ -4,7 +4,7 @@
 * Tests cover:
 * > validation on MessageBucket::Description
 */
-
+#include <unordered_map>
 
 #include "gtest/gtest.h"
 #include "flamegpu/flamegpu.h"

--- a/tests/test_cases/runtime/messaging/test_spatial_2d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_2d.cu
@@ -4,6 +4,8 @@
 * Tests cover:
 * > mandatory messaging, send/recieve
 */
+#include <unordered_map>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/runtime/messaging/test_spatial_3d.cu
+++ b/tests/test_cases/runtime/messaging/test_spatial_3d.cu
@@ -4,6 +4,8 @@
 * Tests cover:
 * > mandatory messaging, send/recieve
 */
+#include <unordered_map>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/runtime/random/test_host_random.cu
+++ b/tests/test_cases/runtime/random/test_host_random.cu
@@ -2,6 +2,7 @@
 #define TESTS_TEST_CASES_RUNTIME_TEST_HOST_RANDOM_H_
 
 #include <array>
+#include <string>
 
 #include "flamegpu/flamegpu.h"
 

--- a/tests/test_cases/simulation/detail/test_cuda_subagent.cu
+++ b/tests/test_cases/simulation/detail/test_cuda_subagent.cu
@@ -1,3 +1,6 @@
+#include <limits>
+#include <set>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/simulation/test_RunPlan.cu
+++ b/tests/test_cases/simulation/test_RunPlan.cu
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/simulation/test_RunPlanVector.cu
+++ b/tests/test_cases/simulation/test_RunPlanVector.cu
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/simulation/test_agent_instance.cu
+++ b/tests/test_cases/simulation/test_agent_instance.cu
@@ -1,3 +1,6 @@
+#include <string>
+#include <utility>
+
 #include "flamegpu/flamegpu.h"
 
 #include "gtest/gtest.h"

--- a/tests/test_cases/simulation/test_agent_vector.cu
+++ b/tests/test_cases/simulation/test_agent_vector.cu
@@ -1,5 +1,8 @@
 #ifndef TESTS_TEST_CASES_POP_TEST_AGENT_VECTOR_H_
 #define TESTS_TEST_CASES_POP_TEST_AGENT_VECTOR_H_
+
+#include <utility>
+
 #include "flamegpu/flamegpu.h"
 #include "gtest/gtest.h"
 

--- a/tests/test_cases/simulation/test_cuda_ensemble.cu
+++ b/tests/test_cases/simulation/test_cuda_ensemble.cu
@@ -1,6 +1,8 @@
 #include <thread>
 #include <chrono>
 #include <filesystem>
+#include <string>
+#include <set>
 
 #include "flamegpu/flamegpu.h"
 

--- a/tests/test_cases/simulation/test_cuda_simulation.cu
+++ b/tests/test_cases/simulation/test_cuda_simulation.cu
@@ -2,6 +2,8 @@
 #include <filesystem>
 #include <thread>
 #include <set>
+#include <vector>
+#include <string>
 
 #include "flamegpu/flamegpu.h"
 #include "flamegpu/detail/compute_capability.cuh"

--- a/tests/test_cases/simulation/test_cuda_simulation_concurrency.cu
+++ b/tests/test_cases/simulation/test_cuda_simulation_concurrency.cu
@@ -1,3 +1,6 @@
+#include <vector>
+#include <string>
+
 #include "flamegpu/flamegpu.h"
 #include "flamegpu/detail/compute_capability.cuh"
 

--- a/tests/test_cases/simulation/test_host_functions.cu
+++ b/tests/test_cases/simulation/test_host_functions.cu
@@ -2,6 +2,7 @@
 #define TESTS_TEST_CASES_SIM_TEST_SIM_VALIDATION_H_
 
 #include <algorithm>
+#include <vector>
 
 #include "flamegpu/flamegpu.h"
 


### PR DESCRIPTION
+ [x] Suppress `<filesystem>` warnings
+ [x] Suppress namespace indenting warnings which are incorrect
+ [x] Fix some whitespace warnings
+ [x] Suppress whitespace warnings in macros that would result in a change of `__LINE__` behaviour in macros 
+ [x] Fix missing include warnings

Closes #1241 