### PR TITLE
2.0.0-rc.2 final changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -->
 
+## [2.0.0-rc.2] - 2024-11-22
+
+### Added
+
++ Emit CMake warnings for MSVC + CUDA incompatibilities introduced by MSVC 1940 & 1941 ([#1225](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1225))
++ Add visualisation support for Environment Directed Graphs ([#1239](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1239))
++ Add visualisation support for setting the initial camera roll angle ([#1239](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1239))
++ Add cpplint 2 support, with lint fixes and suppressions ([#1245](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1245))
++ Add CMake options & cache variables to allow per-build SWIG version requirements / selection ([#1247](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1247))
++ Add CMake warnings for SWIG 4.2.0 and 4.2.1 issues ([#1247](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1247))
++ Telemetry accuracy improved using a per-user random id rather than a per build directory configuration file ([#1252](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1252))
+
+### Changed
+
++ Update CITATION.cff and README.md with preferred citation ([#1198](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1198))
++ Updates visualisation dependency to tag `flamegpu-2.0.0-rc.2`
+
+### Deprecated
+
++ Binary wheel artifacts produced via CI will not be compatible with glibc < 2.28 from the next release, due to a changes in GitHub Actions forcing a switch to `Manylinux_2_28` and the EoL for `Manylinux2014`'s base distribution (CentOS 7)
++ Python 3.8 binary wheel artifacts will not be produced from the next release, as it is EoL
++ Support for CUDA 11.0 and CUDA 11.1 will be dropped from a future release due to [nvidia/CCCL support](https://github.com/NVIDIA/cccl/?tab=readme-ov-file#platform-support) ([#1155](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1155))
+
+### Fixed
+
++ Fix CMake patching of RapidJSON for windows ([#1181](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1181))
++ Suppress platform specific ABI warnings from GCC >= 10.1 on Aarch64 ([#1185](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1185))
++ Add missing `#include <cstdint>` impliclty included from older CUDA toolkits ([#1197](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1197))
++ Optionally remove versioned `libnvrtc-builtins.so` dependency via `patchelf` when compiling on ManyLinux for wider wheel compatibility ([#1201](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1201))
++ Short-term fix for CMake 3.30 deprecating some use of `FetchContent_Populate` ([#1225](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1225))
++ Fix pretty-printed JSON output from `JSONStateWriter` ([#1232](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1232))
++ Fix Swig 4.2.1 not wrapping methods for the `flamegpu::id_t` type ([#1234](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1234))
++ Improved exceptions for invalid character handling in filepaths on MSVC ([#1243](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1243))
++ Test Suite workaround for Swig 4.2.1 errors with `== None` and `!= None` ([#1244](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1244))
++ Updated NVIDIA/Jitify dependency version to resolve RTC warnings with recent CUDA/Thrust/CUB/CCCL versions ([#1255](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1255))
++ Resolve sign comparison warnings in `test_transform_reduce.cu` under MSVC ([#1247](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1247))
++ Warning fixes ([#1209](https://github.com/FLAMEGPU/FLAMEGPU2/issues/1209))
++ Multiple CI fixes/workarounds ([#1225](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1225), [#1242](https://github.com/FLAMEGPU/FLAMEGPU2/pull/1242))
++ Workaround for wrapped spatial radius bug in `python_native/boids_spatial3D_wrapped` example by changing interaction radius to `0.04` (see [#1177](https://github.com/FLAMEGPU/FLAMEGPU2/issues/1177)).
+
 ## [2.0.0-rc.1] - 2024-01-12
 
 ### Added
@@ -311,7 +351,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial alpha release of FLAME GPU 2.0.0, a CUDA C++ / python3 library for agent based simulations
 
-[Unreleased]: https://github.com/FLAMEGPU/FLAMEGPU2/compare/v2.0.0-rc.1...HEAD
+[Unreleased]: https://github.com/FLAMEGPU/FLAMEGPU2/compare/v2.0.0-rc.2...HEAD
+[2.0.0-rc.2]: https://github.com/FLAMEGPU/FLAMEGPU2/releases/tag/v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/FLAMEGPU/FLAMEGPU2/releases/tag/v2.0.0-rc.1
 [2.0.0-rc]: https://github.com/FLAMEGPU/FLAMEGPU2/releases/tag/v2.0.0-rc
 [2.0.0-alpha.2]: https://github.com/FLAMEGPU/FLAMEGPU2/releases/tag/v2.0.0-alpha.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ title: "FLAME GPU"
 license: MIT
 repository-code: "https://github.com/FLAMEGPU/FLAMEGPU2"
 url: "https://flamegpu.com"
-version: "2.0.0-rc.1"
-date-released: 2024-01-12
+version: "2.0.0-rc.2"
+date-released: 2024-11-22
 type: software
 authors: 
   - given-names: Paul

--- a/README.md
+++ b/README.md
@@ -373,4 +373,5 @@ For a full list of known issues pleases see the [Issue Tracker](https://github.c
 + Windows/MSVC builds using CUDA 11.0 may encounter errors when performing incremental builds if the static library has been recompiled. If this presents itself, re-save any `.cu` file in your executable producing project and re-trigger the build.
 + Debug builds under linux with CUDA 11.0 may encounter cuda errors during `validateIDCollisions`. Consider using an alternate CUDA version if this is required ([#569](https://github.com/FLAMEGPU/FLAMEGPU2/issues/569)).
 + CUDA 11.0 with GCC 9 may encounter a segmentation fault during compilation of the test suite. Consider using GCC 8 with CUDA 11.0.
-+ CUDA 12.2+ suffers from poor RTC compilation times, to be fixed in a future release. ([#1118](https://github.com/FLAMEGPU/FLAMEGPU2/issues/1118)).
++ CUDA 12.2+ suffers from poor RTC compilation times, to be fixed in a future release ([#1118](https://github.com/FLAMEGPU/FLAMEGPU2/issues/1118)).
++ Wrapped spatial message iteration with may incorrectly report that the radius is not a factor of the environment with `FLAMEGPU_SEATBELTS=ON` for certain floating point values, to be fixed in a future release ([#1177](https://github.com/FLAMEGPU/FLAMEGPU2/issues/1177)).

--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -11,7 +11,7 @@ if(POLICY CMP0169)
 endif()
 
 # Set the visualiser repo and tag to use unless overridden by the user.
-set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "dab83d071d0354f8bede5f16fc7bd24d89d453f8")
+set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "flamegpu-2.0.0-rc.2")
 set(DEFAULT_FLAMEGPU_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # Set a VISUSLAITION_ROOT cache entry so it is available in the GUI to override the location if required

--- a/examples/python_native/boids_spatial3D_wrapped/boids_spatial3D.py
+++ b/examples/python_native/boids_spatial3D_wrapped/boids_spatial3D.py
@@ -292,7 +292,7 @@ env.newPropertyFloat("MAX_INITIAL_SPEED", 1.0)
 env.newPropertyFloat("MIN_INITIAL_SPEED", 0.1)
 
 # Interaction radius
-env.newPropertyFloat("INTERACTION_RADIUS", 0.05)
+env.newPropertyFloat("INTERACTION_RADIUS", 0.04)  # 0.04 is a workaround for wrapped spatial messaging bug
 env.newPropertyFloat("SEPARATION_RADIUS", 0.01)
 
 # Global Scalers

--- a/src/flamegpu/model/DependencyGraph.cpp
+++ b/src/flamegpu/model/DependencyGraph.cpp
@@ -283,7 +283,7 @@ void DependencyGraph::checkForUnattachedFunctions() {
 
     // Compare sets
     if (modelFunctions != graphFunctions) {
-        std::cerr << "WARNING: Not all agent functions are used in the dependency graph - have you forgotten to add one?" << std::flush;
+        std::cerr << "WARNING: Not all agent functions are used in the dependency graph - have you forgotten to add one?" << std::endl;
     }
 }
 


### PR DESCRIPTION
Final changes required for the 2.0.0-rc.2 release

+ Merge required PRs
  + [x] #1245
  + [x] #1247
  + [x] #1252 (#1212)
  + [x] https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/139
+ [x] Update CHANGELOG.md incl. deprecated python wheels
+ [x] Update Citation.cff
+ [x] Known issue: spatial wrapping
+ [x] Workaround: spatial wrapping python native example 
+ [x] Windows test suite fixes
+ [x] Push vis repo tag and update hash
+ [x] Double check produced wheels from are usable
  + Manually checked on linux
  
Release notes to include 

+ Highlight deprecations
+ Known issue: MSVC PTX Jit? #1253 (not in readme, as not confirmed by a second party yet)

Closes #1246
