### PR TITLE
Bump version to 2.0.0-rc.3

### DIFF
--- a/include/flamegpu/version.h
+++ b/include/flamegpu/version.h
@@ -39,7 +39,7 @@ static constexpr unsigned int VERSION_PATCH = flamegpu::VERSION % 1000;
  * Namespaced FLAME GPU version Prerelease component
  * A set of . separated pre-release components as a string, following the semver rules for comparison.
  */
-static constexpr char VERSION_PRERELEASE[] = "rc.2";
+static constexpr char VERSION_PRERELEASE[] = "rc.3";
 
 /**
  * Namespaced FLAME GPU version build metadata component


### PR DESCRIPTION
Bump the version to 2.0.0-rc.3, mainly for python version package comparisons 