### PR TITLE
Fix the FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE CMake option.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ set (FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT OFF)
 if (DEFINED ENV{FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE} AND "$ENV{FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE}")
     set (FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT ON)
 endif()
-cmake_dependent_option(FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE "Suppress notice encouraging telemetry to be enabled, which is emitted once per binary execution if telemetry is disabled." ${FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT} "FLAMEGPU_SHARE_USAGE_STATISTICS" ${FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT} )
+cmake_dependent_option(FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE "Suppress notice encouraging telemetry to be enabled, which is emitted once per binary execution if telemetry is disabled." ${FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT} "NOT FLAMEGPU_SHARE_USAGE_STATISTICS" ${FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT} )
 unset(FLAMEGPU_TELEMETRY_SUPPRESS_NOTICE_DEFAULT)
 
 # advanced developer option to switch telemetery to a test mode, which is reported separately on telemetry hub.


### PR DESCRIPTION
The option was defined using `cmake_dependent_option`, making it available if and only if `FLAMEGPU_SHARE_USAGE_STATISTICS` is true. Otherwise, its value is forced to false (or whatever was found in the environment).

This is the opposite of the expected behaviour. `SUPRESS_NOTICE` only makes sense when telemetry is disabled, i.e. `SHARE_USAGE_STATISTICS` is false.

This issue was making it impossible to suppress the notice through CMake configuration (other avenues still worked). Based on the examples in the [documentation for `cmake_dependent_option`][cmake_dependent_option], the list of conditions allows for negations, therefore using `NOT FLAMEGPU_SHARE_USAGE_STATISTICS` as the dependency fixes this.

[cmake_dependent_option]: https://cmake.org/cmake/help/latest/module/CMakeDependentOption.html