### PR TITLE
BugFix: DeviceAgentVector::setVariable() array element did not sync

### DIFF
--- a/include/flamegpu/simulation/AgentVector_Agent.h
+++ b/include/flamegpu/simulation/AgentVector_Agent.h
@@ -249,6 +249,8 @@ void AgentVector_Agent::setVariable(const std::string &variable_name, const unsi
     }
     _parent->_require(variable_name);
     static_cast<T*>(v_buff->getDataPtr())[(index * (v_buff->getElements() / detail::type_decode<T>::len_t)) + array_index] = value;
+    // Notify (_data was locked above)
+    _parent->_changed(variable_name, index);
 }
 #ifdef SWIG
 template <typename T>

--- a/src/flamegpu/io/Telemetry.cpp
+++ b/src/flamegpu/io/Telemetry.cpp
@@ -372,8 +372,7 @@ std::string Telemetry::getUserId() {
                     return cached_id;
                 else
                     return userId;
-            }
-            else {
+            } else {
                 throw std::runtime_error("Unable to open user ID file for reading");
             }
         }
@@ -382,8 +381,7 @@ std::string Telemetry::getUserId() {
         if (file.is_open()) {
             file << userId;
             file.close();
-        }
-        else {
+        } else {
             throw std::runtime_error("Unable to create user ID file");
         }
     } catch (const std::exception&) {


### PR DESCRIPTION
Trivially, the _changed() flag was not being called like in other `setVariable()` methods

Test case added which would have caught this bug and for full arrays.

Thanks @ptheywood for spotting this bug, I don't think an issue was created.