### PR TITLE
Test Fix: Fix DependencyGraphTest.UnattachedFunctionWarning

### DIFF
--- a/tests/test_cases/model/test_dependency_graph.cu
+++ b/tests/test_cases/model/test_dependency_graph.cu
@@ -535,7 +535,7 @@ TEST(DependencyGraphTest, UnattachedFunctionWarning) {
     _m.generateLayers();
     // Reset cerr
     std::cerr.rdbuf(prev);
-    EXPECT_EQ(buffer.str(), "WARNING: Not all agent functions are used in the dependency graph - have you forgotten to add one?");
+    EXPECT_EQ(buffer.str(), "WARNING: Not all agent functions are used in the dependency graph - have you forgotten to add one?\n");
 }
 TEST(DependencyGraphTest, ModelAlreadyHasLayers) {
     ModelDescription _m(MODEL_NAME);


### PR DESCRIPTION
Fix test `DependencyGraphTest.UnattachedFunctionWarning`.

This test was broken by changing the exception message to include a newline char in 0a7456eacc2a755e41f4a3d608dae71a265cf252