### PR TITLE
BugFix: Agent ID's were not static during host functions.

### DIFF
--- a/src/flamegpu/runtime/agent/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/runtime/agent/DeviceAgentVector_impl.cu
@@ -185,10 +185,10 @@ void DeviceAgentVector_impl::_insert(size_type pos, size_type count) {
             _require(ID_VARIABLE_NAME);
             id_t *h_ptr = static_cast<id_t*>(d->second->getDataPtr());
             for (unsigned int i = pos; i < pos + count; ++i) {
-                // Always assign ID, as AgentVector should reset these to unset, but this saves us checking
-                // if (h_ptr[i] == ID_NOT_SET) {
+                // Do not reassign ID if it has been set during HostAgentCreation
+                if (h_ptr[i] == ID_NOT_SET) {
                     h_ptr[i] = cuda_agent.nextID();
-                // }
+                }
             }
             _changedAfter(ID_VARIABLE_NAME, pos);
         } else {


### PR DESCRIPTION
Fixes a bug found by @ptheywood (reported via Slack, no GitHub issue), and introduced a new test that covers the former issue.

## Bug

If agents were created during a host function, and then accessed via a DeviceAgentVector in the same host function (layer). The internal transfer from host agent creation storage to DeviceAgentVector would see their IDs regenerated. This bug was also present if performed across multiple init functions, as host agent creation is only performed at the end of the init "layer".

## Resolution

`DeviceAgentVector_impl::_insert()` was always assigning IDs, the check for ID already being set was commented out as assumed redundant(?). So it was uncommented, which resolved the failing test case.

The full test suite still passes (Windows/Debug/SEATBELTS=ON)

```
[==========] 1116 tests from 86 test suites ran. (514508 ms total)
[  PASSED  ] 1116 tests.

  YOU HAVE 53 DISABLED TESTS
```