### PR TITLE
Bugfix: Allow DeviceAgentVector_impl to be copy constructed.

### DIFF
--- a/include/flamegpu/runtime/agent/DeviceAgentVector_impl.h
+++ b/include/flamegpu/runtime/agent/DeviceAgentVector_impl.h
@@ -286,12 +286,21 @@ class DeviceAgentVector_impl : protected AgentVector {
          */
          explicit VariableBufferPair(const std::shared_ptr<detail::VariableBuffer>& _device)
              : device(_device) { }
+         VariableBufferPair(const VariableBufferPair& other) {
+             this->device = other.device;
+             this->host_sz = other.host_sz;
+             if (other.host) {
+                 this->host = static_cast<char*>(malloc(this->host_sz));
+                 memcpy(this->host, other.host, this->host_sz);
+             }
+         }
          VariableBufferPair(VariableBufferPair&& other) {
              *this = std::move(other);
          }
          VariableBufferPair& operator=(VariableBufferPair&& other) {
              std::swap(this->host, other.host);
              std::swap(this->device, other.device);
+             std::swap(this->host_sz, other.host_sz);
              return *this;
          }
          /**
@@ -311,6 +320,10 @@ class DeviceAgentVector_impl : protected AgentVector {
          * nullptr until required to be allocated
          */
          char* host = nullptr;
+         /**
+          * Size of the allocated host ptr in bytes
+          */
+         size_t host_sz = 0;
          /**/
          std::shared_ptr<detail::VariableBuffer> device;
      };

--- a/src/flamegpu/runtime/agent/DeviceAgentVector_impl.cu
+++ b/src/flamegpu/runtime/agent/DeviceAgentVector_impl.cu
@@ -101,7 +101,8 @@ void DeviceAgentVector_impl::initUnboundBuffers() {
         }
         // Alloc
         const size_t var_size = buff.device->type_size * buff.device->elements;
-        buff.host = static_cast<char*>(malloc(_capacity * var_size));
+        buff.host_sz = _capacity * var_size;
+        buff.host = static_cast<char*>(malloc(buff.host_sz));
         // DtH memcpy
         gpuErrchk(cudaMemcpyAsync(buff.host, buff.device->data, copy_len * var_size, cudaMemcpyDeviceToHost, stream));
         // Not sure this will ever happen, but better safe
@@ -131,7 +132,8 @@ void DeviceAgentVector_impl::reinitUnboundBuffers() {
         if (unbound_host_buffer_capacity < _capacity) {
             free(buff.host);
             // Alloc
-            buff.host = static_cast<char*>(malloc(_capacity * var_size));
+            buff.host_sz = _capacity * var_size;
+            buff.host = static_cast<char*>(malloc(buff.host_sz));
         }
         // DtH memcpy
         gpuErrchk(cudaMemcpyAsync(buff.host, buff.device->data, copy_len * var_size, cudaMemcpyDeviceToHost, stream));
@@ -162,6 +164,7 @@ void DeviceAgentVector_impl::resizeUnboundBuffers(const unsigned int new_capacit
         // Free old
         free(buff.host);
         // Replace old ptr
+        buff.host_sz = new_capacity * var_size;
         buff.host = t;
         if (init) {
             for (unsigned int i = unbound_host_buffer_capacity; i < new_capacity; ++i) {


### PR DESCRIPTION
Tests pass, but requires some discussion before adding this. The 'bug' is unintended behaviour, which may increase memory transfers etc.

*Haven't updated test suite yet, bc not sure we actually want to fix this in this manner.*

Closes #1290