### PR TITLE
CUDA 12.8 & 12.9 + MSVC CI CUDA < 12.4

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -54,6 +54,13 @@ $CUDA_KNOWN_URLS = @{
     "12.5.0" = "https://developer.download.nvidia.com/compute/cuda/12.5.0/network_installers/cuda_12.5.0_windows_network.exe";
     "12.5.1" = "https://developer.download.nvidia.com/compute/cuda/12.5.1/network_installers/cuda_12.5.1_windows_network.exe";
     "12.6.0" = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe";
+    "12.6.1" = "https://developer.download.nvidia.com/compute/cuda/12.6.1/network_installers/cuda_12.6.1_windows_network.exe";
+    "12.6.2" = "https://developer.download.nvidia.com/compute/cuda/12.6.2/network_installers/cuda_12.6.2_windows_network.exe";
+    "12.6.3" = "https://developer.download.nvidia.com/compute/cuda/12.6.3/network_installers/cuda_12.6.3_windows_network.exe";
+    "12.8.0" = "https://developer.download.nvidia.com/compute/cuda/12.8.0/network_installers/cuda_12.8.0_windows_network.exe"
+    "12.8.1" = "https://developer.download.nvidia.com/compute/cuda/12.8.1/network_installers/cuda_12.8.1_windows_network.exe"
+    "12.9.0" = "https://developer.download.nvidia.com/compute/cuda/12.9.0/network_installers/cuda_12.9.0_windows_network.exe"
+    "12.9.1" = "https://developer.download.nvidia.com/compute/cuda/12.9.1/network_installers/cuda_12.9.1_windows_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
-          - cuda: "12.6"
+          - cuda: "12.9"
             cuda_arch: "50-real;90-real;90-virtual;"
             hostcxx: gcc-13
             os: ubuntu-24.04

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -186,13 +186,22 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
+          # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
           - cuda: "12.6.0"
-            cuda_arch: "50-real;90-real;90-virtual"
+            cuda_arch: "50"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2025
+          - cuda: "12.0.0"
+            cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
-          # CUDA 12.4 is the oldest CUDA supported by recent visual studio 2022 versions :(
-          - cuda: "12.4.0"
-            cuda_arch: "50-real;90-real;90-virtual"
+          # Newest and oldest CUDA 11.x we can use with VS2022 (11.6+), not an officially supported combination with MSVC >= 1940
+          - cuda: "11.8.0"
+            cuda_arch: "35"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          - cuda: "11.6.0"
+            cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
         python:
@@ -224,7 +233,7 @@ jobs:
       PYTHON: ${{ matrix.python}}
       VISUALISATION: ${{ matrix.VISUALISATION }}
       # Ensure MSVC >= 1940 works with CUDA <= 12.3
-      CUDAFLAGS: -allow-unsupported-compiler
+      NVCC_PREPEND_FLAGS: "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH --allow-unsupported-compiler"
 
     steps:
     - uses: actions/checkout@v4
@@ -478,9 +487,14 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          # VS2022 on required 12.4, which prevents older wheel building.
-          - cuda: "12.4.0"
+          # Oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
+          - cuda: "12.0.0"
             cuda_arch: "50-real;60-real;70-real;80-real;90-real;90-virtual"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          # Oldest CUDA 11.x we can use with VS2022 (11.6+), not an officially supported combination with MSVC >= 1940
+          - cuda: "11.6.0"
+            cuda_arch: "35-real;50-real;60-real;70-real;80-real;80-virtual"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
         python:
@@ -520,7 +534,7 @@ jobs:
       PYTHON: ${{ matrix.python}}
       VISUALISATION: ${{ matrix.VISUALISATION }}
       # Ensure MSVC >= 1940 works with CUDA <= 12.3
-      CUDAFLAGS: -allow-unsupported-compiler
+      NVCC_PREPEND_FLAGS: "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH --allow-unsupported-compiler"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -187,7 +187,7 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
-          - cuda: "12.6.0"
+          - cuda: "12.9.1"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2025

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -30,7 +30,7 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "11.8"
+          - cuda: "11.7"
             os: ubuntu-22.04
     env:
       # Define constants

--- a/.github/workflows/Manylinux_2_28.yml
+++ b/.github/workflows/Manylinux_2_28.yml
@@ -33,18 +33,15 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
+          # Oldest CUDA 12.x and 11.x we support, which are used for wheel production
           - cuda: "12.0"
             cuda_arch: "50"
             hostcxx: gcc-toolset-12
-            os: ubuntu-22.04
-          - cuda: "11.8"
-            cuda_arch: "35"
-            hostcxx: gcc-toolset-10
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - cuda: "11.2"
             cuda_arch: "35"
             hostcxx: gcc-toolset-9
-            os: ubuntu-22.04
+            os: ubuntu-24.04
         python:
           - "3.12"
         config:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -29,19 +29,20 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
-          - cuda: "12.6"
-            cuda_arch: "50"
+          # Oldest and newest CUDA 12.x
+          - cuda: "12.9"
+            cuda_arch: "120"
             hostcxx: gcc-13
             os: ubuntu-24.04
           - cuda: "12.0"
             cuda_arch: "50"
             hostcxx: gcc-12
             os: ubuntu-22.04
+          # Oldest and newest CUDA 11.x with network installers on ubuntu 22.04
           - cuda: "11.8"
             cuda_arch: "35"
             hostcxx: gcc-11
             os: ubuntu-22.04
-          # 11.7 is the oldest supported CUDA on 22.04
           - cuda: "11.7"
             cuda_arch: "35"
             hostcxx: gcc-9

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -23,13 +23,22 @@ jobs:
       matrix:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
+          # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
           - cuda: "12.6.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2022
-          # CUDA 12.4 is the oldest CUDA supported by recent visual studio 2022 versions :(
-          - cuda: "12.4.0"
+            os: windows-2025
+          - cuda: "12.0.0"
             cuda_arch: "50"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          # Newest and oldest CUDA 11.x we can use with VS2022 (11.6+), not an officially supported combination with MSVC >= 1940
+          - cuda: "11.8.0"
+            cuda_arch: "35"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          - cuda: "11.6.0"
+            cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
         config:
@@ -57,7 +66,7 @@ jobs:
       FLAMEGPU_SEATBELTS: ${{ matrix.config.SEATBELTS }}
       VISUALISATION: ${{ matrix.VISUALISATION }}
       # Ensure MSVC >= 1940 works with CUDA <= 12.3
-      CUDAFLAGS: -allow-unsupported-compiler
+      NVCC_PREPEND_FLAGS: "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH --allow-unsupported-compiler"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -24,7 +24,7 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
-          - cuda: "12.6.0"
+          - cuda: "12.9.1"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2025

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         cudacxx:
           # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
-          - cuda: "12.6.0"
+          - cuda: "12.9.1"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2025

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -29,13 +29,22 @@ jobs:
       # optional exclude: can be partial, include: must be specific
       matrix:
         cudacxx:
+          # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, but we have a workaround in place
           - cuda: "12.6.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2025
-          # CUDA 12.4 is the oldest CUDA supported by recent visual studio 2022 versions :(
-          - cuda: "12.4.0"
+          - cuda: "12.0.0"
             cuda_arch: "50"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          # Newest and oldest CUDA 11.x we can use with VS2022 (11.6+), not an officially supported combination with MSVC >= 1940
+          - cuda: "11.8.0"
+            cuda_arch: "35"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
+          - cuda: "11.6.0"
+            cuda_arch: "35"
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
 
@@ -104,7 +113,7 @@ jobs:
       PYTHON: ${{ matrix.python}}
       VISUALISATION: ${{ matrix.VISUALISATION }}
       # Ensure MSVC >= 1940 works with CUDA <= 12.3
-      CUDAFLAGS: -allow-unsupported-compiler
+      NVCC_PREPEND_FLAGS: "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH --allow-unsupported-compiler"
 
 
     steps:

--- a/cmake/CheckCompilerFunctionality.cmake
+++ b/cmake/CheckCompilerFunctionality.cmake
@@ -25,36 +25,46 @@ function(flamegpu_check_compiler_functionality)
             message(WARNING
                 " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1941)\n"
                 " \n"
-                " The MSVC STL included with MSVC 1941 requires CUDA 12.4 or newer\n"
-                " If you have CUDA <= 12.3 installed you must either:\n"
+                " The MSVC STL included with MSVC >= 1941 requires CUDA >= 12.4\n"
+                " If you have CUDA < 12.4 installed you must either:\n"
+                " \n"
+                "  - Set the NVCC_PREPEND_FLAGS environment variable to include '-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH -allow-unsupported-compiler' for configuration and compilation\n"
                 "  - Upgrade CUDA to >= 12.4\n"
                 "  - Downgrade MSVC to 1940 and set the CUDAFLAGS environment variable to contain '-allow-unsupported-compiler'\n"
                 "  - Downgrade MSVC to 1939 or older\n"
-                " You must then clear the CMake cache before reconfiguring\n"
+                " \n"
+                " You must clear the CMake Cache before reconfiguring this project\n"
             )
         # If using MSVC >= 1940 then CUDA <= 12.3 support requires -allow-unsupported-compiler, so warn about this
         elseif(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL "1940")
             # If this is the case, then CMake >= 3.29.4 is also required, otherwise CMake does not pass -allow-unsupported-compiler along, warn as appropriate
             if(CMAKE_VERSION VERSION_LESS "3.29.4")
                 message(WARNING
-                    " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1940)\n"
+                    " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1940 and CMake < 3.29.4)\n"
                     " \n"
-                    " If you have CUDA <= 12.3 installed:\n"
-                    "  - You must upgrade CMake to be >= 3.29.4\n"
-                    "    The CUDAFLAGS environment variable must include '-allow-unsupported-compiler'\n"
-                    "    You must clear the CMake Cache before reconfiguring this project\n"
+                    " If you have CUDA <= 12.3 installed you must either:\n"
                     " \n"
-                    "  - Alternatively you may upgrade CUDA to >= 12.4 and clear the CMake Cache before reconfiguring\n"
+                    "  - Set the NVCC_PREPEND_FLAGS environment variable to include '-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH -allow-unsupported-compiler' for configuration and compilation\n"
+                    "  - Upgrade CMake to >= 3.29.4 and set the CUDAFLAGS environment variable to contain '-allow-unsupported-compiler'\n"
+                    "  - Upgrade CUDA to >= 12.4\n"
+                    "  - Downgrade MSVC to 1939 or older\n"
+                    " \n"
+                    " You must clear the CMake Cache before reconfiguring this project\n"
+                    " \n"
                 )
             else()
                 message(WARNING
-                    " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1940)\n"
+                    " CUDA Language Support Not Found (with MSVC ${MSVC_VERSION} >= 1940 and CMake >= 3.29.4)\n"
                     " \n"
-                    " If you have CUDA <= 12.3 installed:\n"
-                    "  - The CUDAFLAGS environment variable must include '-allow-unsupported-compiler'\n"
-                    "    You must clear the CMake Cache before reconfiguring this project\n"
+                    " If you have CUDA <= 12.3 installed you must either:\n"
                     " \n"
-                    "  - Alternatively you may upgrade CUDA to >= 12.4 and clear the CMake Cache before reconfiguring\n"
+                    "  - Set the NVCC_PREPEND_FLAGS environment variable to include '-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH -allow-unsupported-compiler' for configuration and compilation\n"
+                    "  - Set the CUDAFLAGS environment variable to contain '-allow-unsupported-compiler'\n"
+                    "  - Upgrade CUDA to >= 12.4\n"
+                    "  - Downgrade MSVC to 1939 or older\n"
+                    " \n"
+                    " You must clear the CMake Cache before reconfiguring this project\n"
+                    " \n"
                 )
             endif()
         else()


### PR DESCRIPTION
- Updates the CMake warnings when cuda support is not found on windows to include the new workaround and be more consistent
- Uses NVCC_PREPEND_FLAGS on CI for CUDA < 12.4 with MSVC on CI, including CUDA 11.6, 11.8 and 12.0.
- Adds CUDA 12.6.1-12.9.1 to the known cuda downloads on windows
- Updates the "latest" CUDA in CI to use 12.9, and on ubuntu uses SM_120 (consumer blackwell) for one workflow to check compatibility.
  - Also standardises CUDA versions across workflows. 
    - 11.2/11.6/11.7, 11.8, 12.0 & 12.9 for regular CI
    - 11.2 and 12.0 for linux wheels. 
    - 11.6 and 12.0 for windows wheels (oldest possible even with workaround)


Closes #1274
Part of #1292