### PR TITLE
Fix test failures in multi-arch systems

### DIFF
--- a/src/flamegpu/simulation/CUDAEnsemble.cu
+++ b/src/flamegpu/simulation/CUDAEnsemble.cu
@@ -173,7 +173,10 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector& plans) {
     // Check that each device is capable, and init cuda context
     for (auto d = devices.begin(); d != devices.end(); ++d) {
         if (!detail::compute_capability::checkComputeCapability(*d)) {
-            fprintf(stderr, "FLAMEGPU2 has not been built with an appropriate compute capability for device %d, this device will not be used.\n", *d);
+            // Emit a warning unless quiet verbosity was specified.
+            if (config.verbosity >= Verbosity::Default) {
+                fprintf(stderr, "FLAMEGPU2 has not been built with an appropriate compute capability for device %d, this device will not be used.\n", *d);
+            }
             d = devices.erase(d);
             --d;
         } else {

--- a/src/flamegpu/simulation/CUDAEnsemble.cu
+++ b/src/flamegpu/simulation/CUDAEnsemble.cu
@@ -190,7 +190,7 @@ unsigned int CUDAEnsemble::simulate(const RunPlanVector& plans) {
     // If there are no devices left (and mpi is not being used), we need to error as the work cannot be executed.
 #ifndef FLAMEGPU_ENABLE_MPI
     if (devices.size() == 0) {
-        THROW exception::InvalidCUDAdevice("FLAMEGPU2 has not been built with an appropraite compute capability for any devices, unable to continue\n");
+        THROW exception::InvalidCUDAdevice("FLAMEGPU2 has not been built with an appropriate compute capability for any devices, unable to continue\n");
     }
 #endif  // ifndef FLAMEGPU_ENABLE_MPI
 

--- a/tests/python/simulation/test_cuda_ensemble.py
+++ b/tests/python/simulation/test_cuda_ensemble.py
@@ -649,7 +649,7 @@ class TestEnsembleVerbosity(TestCase):
         assert "CUDAEnsemble progress" in captured.out
         assert "CUDAEnsemble completed" in captured.out
         assert "Ensemble time elapsed" in captured.out
-        assert captured.err == ""
+        assert captured.err == "" or "FLAMEGPU2 has not been built with an appropriate compute capability for device" in captured.errr
 
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):

--- a/tests/test_cases/simulation/test_cuda_ensemble.cu
+++ b/tests/test_cases/simulation/test_cuda_ensemble.cu
@@ -426,7 +426,8 @@ TEST(TestCUDAEnsemble, verbosity) {
         EXPECT_TRUE(output.find("CUDAEnsemble progress") != std::string::npos);   // E.g. CUDAEnsemble progress: 1/2
         EXPECT_TRUE(output.find("CUDAEnsemble completed") != std::string::npos);  // E.g. CUDAEnsemble completed 2 runs successfully!
         EXPECT_TRUE(output.find("Ensemble time elapsed") == std::string::npos);   // E.g. Ensemble time elapsed: 0.006000s
-        EXPECT_TRUE(errors.empty());
+        // Errors should be empty but may contain compute capability warnings in mixed-architecture multi-GPU systems depending on compute capability options.
+        EXPECT_TRUE(errors.empty() || output.find("FLAMEGPU2 has not been built with an appropriate compute capability for device"));
     }
     // Verbosity::Verbose
     {
@@ -444,7 +445,8 @@ TEST(TestCUDAEnsemble, verbosity) {
         EXPECT_TRUE(output.find("CUDAEnsemble progress") != std::string::npos);   // E.g. CUDAEnsemble progress: 1/2
         EXPECT_TRUE(output.find("CUDAEnsemble completed") != std::string::npos);  // E.g. CUDAEnsemble completed 2 runs successfully!
         EXPECT_TRUE(output.find("Ensemble time elapsed") != std::string::npos);   // E.g. Ensemble time elapsed: 0.006000s
-        EXPECT_TRUE(errors.empty());
+        // Errors should be empty but may contain compute capability warnings in mixed-architecture multi-GPU systems depending on compute capability options.
+        EXPECT_TRUE(errors.empty() || output.find("FLAMEGPU2 has not been built with an appropriate compute capability for device"));
     }
 }
 // Logging is more thoroughly tested in Logging. Here just make sure the methods work


### PR DESCRIPTION
- CUDAEnsemble: Do not emit compute capability warning with quiet verbosity
- CUDAEnsemble: Fix typo in invalidCUDAdevice exception
- Tests: Fix CUDAEnesemble verbosity tests in multi-gpu-arch systems with compute capability errors.

Closes #1278 