### PR TITLE
Fix: fix device exception message string in MessageBucketDevice.cuh

### DIFF
--- a/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketDevice.cuh
+++ b/include/flamegpu/runtime/messaging/MessageBucket/MessageBucketDevice.cuh
@@ -305,7 +305,7 @@ __device__ void MessageBucket::Out::setKey(const IntT &key) const {
 
 #if !defined(FLAMEGPU_SEATBELTS) || FLAMEGPU_SEATBELTS
     if (key < metadata->min || key >= metadata->max) {
-        DTHROW("MessageArray key %u is out of range [%d, %d).\n", key, metadata->min, metadata->max);
+        DTHROW("Bucket message key %u is out of range [%d, %d).\n", key, metadata->min, metadata->max);
         return;
     }
 #endif


### PR DESCRIPTION
Fix: fix device exception message string in MessageBucketDevice.cuh

The message matches other DTHROWs in MessageBucketDevice.cuh

Closes #1269