### PR TITLE
Set `FLAMEGPU_BUILD_PYTHON_PATCHELF` default to `OFF`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ cmake --build . --target all
 | `FLAMEGPU_SEATBELTS`                 | `ON`/`OFF`                  | Enable / Disable additional runtime checks which harm performance but increase usability. Default `ON`     |
 | `FLAMEGPU_BUILD_PYTHON`              | `ON`/`OFF`                  | Enable Python target `pyflamegpu` via Swig. Default `OFF`. Python packages `setuptools`, `build` & `wheel` required |
 | `FLAMEGPU_BUILD_PYTHON_VENV`         | `ON`/`OFF`                  | Use a python `venv` when building the python Swig target. Default `ON`. Python package `venv` required     |
+| `FLAMEGPU_BUILD_PYTHON_PATCHELF`     | `ON`/`OFF`                  | Under linux, Use `patchelf` to remove explicit runtime dependency on versioned `libnvrtc-builtins.so` for `pyflamegpu`. Default `OFF`. `patchelf` required |
 | `FLAMEGPU_BUILD_TESTS`               | `ON`/`OFF`                  | Build the C++/CUDA test suite. Default `OFF`.                                                              |
 | `FLAMEGPU_BUILD_TESTS_DEV`           | `ON`/`OFF`                  | Build the reduced-scope development test suite. Default `OFF`                                              |
 | `FLAMEGPU_ENABLE_GTEST_DISCOVER`     | `ON`/`OFF`                  | Run individual CUDA C++ tests as independent `ctest` tests. This dramatically increases test suite runtime. Default `OFF`. |

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -15,7 +15,7 @@ option(FLAMEGPU_BUILD_PYTHON_LOCALVERSION "Embed CUDA version for the build in t
 mark_as_advanced(FLAMEGPU_BUILD_PYTHON_LOCALVERSION)
 
 # Add option use patchelf to remove explicit runtime dynamic dependency on libnvrtc-builtins.so
-option(FLAMEGPU_BUILD_PYTHON_PATCHELF "Use PATCHELF to remove a runtime dependency on libnvrtc-builtins.so" ON)
+option(FLAMEGPU_BUILD_PYTHON_PATCHELF "Use PATCHELF to remove a runtime dependency on libnvrtc-builtins.so" OFF)
 mark_as_advanced(FLAMEGPU_BUILD_PYTHON_PATCHELF)
 
 # Get the root of the repository to find other CMake files etc.


### PR DESCRIPTION
- CMake: Set default FLAMEGPU_BUILD_PYTHON_PATCHELF value to OFF as originally intended
  - Closes #1261
- Readme: Add Cmake option FLAMEGPU_BUILD_PYTHON_PATCHELF to the readme