### PR TITLE
Circles examples: Enable truncate_log_files 

### DIFF
--- a/examples/cpp/circles_bruteforce/src/main.cu
+++ b/examples/cpp/circles_bruteforce/src/main.cu
@@ -125,6 +125,9 @@ int main(int argc, const char ** argv) {
     flamegpu::CUDASimulation  cudaSimulation(model, argc, argv);
     flamegpu::util::nvtx::pop();
 
+    // Configure the simulation to overwrite log and xml files
+    cudaSimulation.SimulationConfig().truncate_log_files = true;
+
     /**
      * Create visualisation
      */

--- a/examples/cpp/circles_spatial3D/src/main.cu
+++ b/examples/cpp/circles_spatial3D/src/main.cu
@@ -119,6 +119,9 @@ int main(int argc, const char ** argv) {
      */
     flamegpu::CUDASimulation cudaSimulation(model, argc, argv);
 
+    // Configure the simulation to overwrite log and xml files
+    cudaSimulation.SimulationConfig().truncate_log_files = true;
+
     /**
      * Create visualisation
      */


### PR DESCRIPTION
Enable `truncate_log_files` for the circles examples

The `truncate_log_files` Simulation config option also controls truncation of files written by `exportData`

Closes #1042