### PR TITLE
CI: always install setuptools on manylinux

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -414,16 +414,11 @@ jobs:
         make install
 
     - name: Install setuptools and wheel
-      if: ${{ env.PYTHON >= 3.12 }}
       run: |
         python${{env.PYTHON}} -m pip install setuptools wheel
+
     - name: Add custom problem matchers for annotations
       run: echo "::add-matcher::.github/problem-matchers.json"
-
-    - name: Install setuptools and wheel
-      if: ${{ env.PYTHON >= 3.12 }}
-      run: |
-        python${{env.PYTHON}} -m pip install setuptools wheel
 
     # This patches a bug where ManyLinux doesn't generate buildnumber as git dir is owned by diff user
     - name: Enable git safe-directory

--- a/.github/workflows/Manylinux_2_28.yml
+++ b/.github/workflows/Manylinux_2_28.yml
@@ -134,7 +134,6 @@ jobs:
         make install
 
     - name: Install setuptools and wheel
-      if: ${{ env.PYTHON >= 3.12 }}
       run: |
         python${{env.PYTHON}} -m pip install setuptools wheel
 


### PR DESCRIPTION
Setuptoolls and wheels were removed from the base image for all pythons (not just < 3.12) on 2025-06-22.