### PR TITLE
CMake 4 support

### DIFF
--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -26,21 +26,27 @@ jobs:
       # Multiplicative build matrix
       matrix:
         cudacxx:
-          - cuda: "12.0"
-            cuda_arch: "50"
-            hostcxx: gcc-10
-            os: ubuntu-22.04
+          - cuda: "13.0"
+            cuda_arch: "75"
+            hostcxx: gcc-12
+            os: ubuntu-24.04
+          - cuda: "13.0.0"
+            cuda_arch: "75"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2025
         python:
-          - "3.8"
+          - "3.10"
         config:
           - name: "Release"
             config: "Release"
             SEATBELTS: "ON"
         VISUALISATION:
-          - "OFF"
+          - "ON"
         # 'default' or '' will not install cmake, otherwise provide a full semver version.
         cmake:
           - "default"
+          - "4.0.0"
+          - "3.31.8"
           - "3.25.2"
 
     # Name the job based on matrix/env options
@@ -65,13 +71,16 @@ jobs:
       FLAMEGPU_SEATBELTS: ${{ matrix.config.SEATBELTS }}
       PYTHON: ${{ matrix.python}}
       VISUALISATION: ${{ matrix.VISUALISATION }}
+      # Ensure MSVC >= 1940 works with CUDA <= 12.3
+      NVCC_PREPEND_FLAGS: "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH --allow-unsupported-compiler"
       CMAKE: ${{ matrix.cmake }}
+      
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install cmake from GitHub Releases
-      if: ${{ env.CMAKE != '' && env.CMAKE != 'default' }}
+    - name: Install cmake from GitHub Releases (Linux)
+      if: ${{ startswith(env.OS, 'ubuntu') && env.CMAKE != '' && env.CMAKE != 'default' }}
       working-directory: ${{ runner.temp }}
       run: |
         wget -q https://github.com/Kitware/CMake/releases/download/v${{ env.CMAKE }}/cmake-${{ env.CMAKE }}-linux-x86_64.tar.gz
@@ -79,13 +88,39 @@ jobs:
         # Inner directory case changes in some releases, use find to get the right path
         echo "$(dirname $(find $(pwd) -wholename "*/bin/cmake" -exec echo {} \; -quit))" >> $GITHUB_PATH
 
-    - name: Install CUDA
+    - name: Install cmake from GitHub Releases (Windows)
+      if: ${{ runner.os == 'Windows' && env.CMAKE != '' && env.CMAKE != 'default' }}
+      working-directory: ${{ runner.temp }}
+      run: |
+        curl -s -L -O  https://github.com/Kitware/CMake/releases/download/v${{ env.CMAKE }}/cmake-${{ env.CMAKE }}-windows-x86_64.zip
+        ls
+        7z.exe x "cmake-${{ env.CMAKE }}-windows-x86_64.zip" -o"cmake-${{ env.CMAKE }}-windows-x86_64"
+        echo "$(dirname $(find $(pwd) -wholename "*/bin/cmake.exe" -exec echo {} \; -quit))" >> $GITHUB_PATH
+
+    - name: Check CMake Version
+      run: cmake --version
+
+    - name: Install CUDA (Ubuntu)
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
       env:
         cuda: ${{ env.CUDA }}
       run: .github/scripts/install_cuda_ubuntu.sh
 
-    - name: Install/Select gcc and g++
+    - name: Install CUDA (Windows)
+      if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
+      shell: powershell
+      timeout-minutes: 35
+      env:
+        cuda: ${{ env.CUDA }}
+        visual_studio: ${{ env.HOSTCXX }}
+      run: |
+        if ([version]$env:cuda -ge [version]"12.0") {
+          .github\scripts\install_cuda_windows_redist.ps1
+        } else {
+          .github\scripts\install_cuda_windows.ps1
+        }
+
+    - name: Install/Select gcc and g++ (Ubuntu)
       if: ${{ startsWith(env.HOSTCXX, 'gcc-') }}
       run: |
         gcc_version=${HOSTCXX//gcc-/}
@@ -100,14 +135,18 @@ jobs:
       with:
         python-version: ${{ env.PYTHON }}
 
-    # @todo - is some/all of this still required when using select Python?
-    - name: Install python dependencies
-      if: ${{ env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
+    - name: Install python dependencies (Ubuntu)
+      if: ${{ startswith(env.OS, 'ubuntu') && env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
       run: |
         sudo apt-get install python3-venv
         python3 -m pip install --upgrade wheel build setuptools
 
-    - name: Install Visualisation Dependencies
+    - name: Install python dependencies (Windows)
+      if: ${{ runner.os == 'Windows' && env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
+      run: |
+        python3 -m pip install --upgrade wheel build setuptools
+
+    - name: Install Visualisation Dependencies (Ubuntu)
       if: ${{ startswith(env.OS, 'ubuntu') && env.VISUALISATION == 'ON' }}
       run: |
         # Install ubuntu-24.04 packages
@@ -119,7 +158,8 @@ jobs:
           sudo apt-get install -y libglew-dev libfontconfig1-dev libsdl2-dev libdevil-dev libfreetype-dev
         fi
 
-    - name: Install Swig >= 4.1.0
+    - name: Install Swig >= 4.1.0 (Ubuntu)
+      if: ${{ startswith(env.OS, 'ubuntu') && env.PYTHON != '' && env.FLAMEGPU_BUILD_PYTHON == 'ON' }}
       run: |
         # Install additional apt-based dependencies required to build swig 4.1.0.
         # swig >= 4.1 requires pcre2-config from libpcre2-dev
@@ -135,7 +175,6 @@ jobs:
         make
         sudo make install
 
-    # This pre-emptively patches a bug from ManyLinux where git dir is owned by diff user, blocking buildnumber generation
     - name: Enable git safe-directory
       run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
@@ -144,9 +183,10 @@ jobs:
         cmake . -B "${{ env.BUILD_DIR }}"
         -DCMAKE_BUILD_TYPE="${{ env.CONFIG }}"
         -Werror=dev
-        -DCMAKE_WARN_DEPRECATED="OFF"
+        -DCMAKE_WARN_DEPRECATED="ON"
         -DFLAMEGPU_WARNINGS_AS_ERRORS="ON"
         -DCMAKE_CUDA_ARCHITECTURES="${{ env.CUDA_ARCH }}"
+        -DFLAMEGPU_SEATBELTS="${{ env.FLAMEGPU_SEATBELTS }}"
         -DFLAMEGPU_BUILD_TESTS="${{ env.FLAMEGPU_BUILD_TESTS }}"
         -DFLAMEGPU_BUILD_PYTHON="${{ env.FLAMEGPU_BUILD_PYTHON }}"
         -DPYTHON3_EXACT_VERSION="${{ env.PYTHON }}"
@@ -160,7 +200,9 @@ jobs:
         cmake . -B "${{ env.BUILD_DIR }}"
         -DCMAKE_BUILD_TYPE="${{ env.CONFIG }}"
         -Werror=dev
-        -DCMAKE_WARN_DEPRECATED="OFF"
+        -DCMAKE_WARN_DEPRECATED="ON"
         -DFLAMEGPU_WARNINGS_AS_ERRORS="ON"
         -DCMAKE_CUDA_ARCHITECTURES="${{ env.CUDA_ARCH }}"
+        -DFLAMEGPU_SEATBELTS="${{ env.FLAMEGPU_SEATBELTS }}"
+        -DFLAMEGPU_VISUALISATION="${{ env.VISUALISATION }}"
         -DFLAMEGPU_ENABLE_NVTX="ON"

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -28,12 +28,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install doxygen >= 1.9.0 + other dependencies
       run: |
         # Install graphviz + dependencies to build doxygen from source

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -87,12 +87,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
       env:
@@ -242,12 +236,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
 
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
@@ -400,14 +388,13 @@ jobs:
         cuda: ${{ env.CUDA }}
       run: .github/scripts/install_cuda_el8.sh
 
-    # Downgrade CMake for DeVIL. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0, overwriting the pipx installed version from manylinux
-      run: |
-        pipx install --global --force 'cmake<4.0'
-
     - name: Install Visualisation Dependencies (EL 8)
       if: ${{ env.VISUALISATION == 'ON' }}
       run: |
+        # Install CMake 3 just to build DevIL
+        python3 -m venv devil-venv
+        source devil-venv/bin/activate
+        python3 -m pip install 'cmake<4.0'
         yum install -y glew-devel fontconfig-devel SDL2-devel freetype-devel
         # Build/Install DevIL from source.
         yum install -y freeglut-devel
@@ -557,12 +544,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
 
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -43,12 +43,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
       env:

--- a/.github/workflows/MPI.yml
+++ b/.github/workflows/MPI.yml
@@ -93,12 +93,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
       env:

--- a/.github/workflows/Manylinux_2_28.yml
+++ b/.github/workflows/Manylinux_2_28.yml
@@ -103,14 +103,13 @@ jobs:
         cuda: ${{ env.CUDA }}
       run: .github/scripts/install_cuda_el8.sh
 
-    # Downgrade CMake for DeVIL. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0, overwriting the pipx installed version from manylinux
-      run: |
-        pipx install --global --force 'cmake<4.0'
-
     - name: Install Visualisation Dependencies (EL 8)
       if: ${{ env.VISUALISATION == 'ON' }}
       run: |
+        # Install CMake 3 just to build DevIL
+        python3 -m venv devil-venv
+        source devil-venv/bin/activate
+        python3 -m pip install 'cmake<4.0'
         yum install -y glew-devel fontconfig-devel SDL2-devel freetype-devel
         # Build/Install DevIL from source.
         yum install -y freeglut-devel

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -100,12 +100,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install CUDA
       if: ${{ startswith(env.OS, 'ubuntu') && env.CUDA != '' }}
       env:

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -67,12 +67,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
       shell: powershell

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -107,12 +107,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Downgrade CMake while some dependencies are not CMake 4 compatible. See https://github.com/FLAMEGPU/FLAMEGPU2/issues/1276
-    - name: Install CMake < 4.0
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
-      with:
-        cmake-version: '3.x'
-
     - name: Install CUDA (Windows)
       if: ${{ runner.os == 'Windows' && env.CUDA != '' }}
       shell: powershell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Include and call some CMake to record initial state of CMAKE_CUDA_ARCHITECTURES for later use
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/CUDAArchitectures.cmake)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -1,9 +1,6 @@
 message(STATUS "-----Configuring Project: ${PROJECT_NAME}-----")
 include_guard(DIRECTORY)
 
-# Policy to enable use of separate device link options, introduced in CMake 3.18
-cmake_policy(SET CMP0105 NEW)
-
 # Add custom modules directory
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 

--- a/cmake/dependencies/CCCL.cmake
+++ b/cmake/dependencies/CCCL.cmake
@@ -5,7 +5,6 @@
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 
 include(FetchContent)
-cmake_policy(SET CMP0079 NEW)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/Jitify.cmake
+++ b/cmake/dependencies/Jitify.cmake
@@ -4,7 +4,6 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-cmake_policy(SET CMP0079 NEW)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/Jitify.cmake
+++ b/cmake/dependencies/Jitify.cmake
@@ -4,12 +4,9 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
-endif()
 
 # Change the source-dir to allow inclusion via jitify/jitify.hpp rather than jitify.hpp
+# Specify an invalid SOURCE_SUBDIR to prevent FetchContent_MakeAvailable from adding the CMakeLists.txt
 FetchContent_Declare(
     jitify
     GIT_REPOSITORY https://github.com/NVIDIA/jitify.git
@@ -17,45 +14,47 @@ FetchContent_Declare(
     SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/jitify-src/jitify
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON
+    SOURCE_SUBDIR "do_not_use_add_subirectory"
 )
 FetchContent_GetProperties(jitify)
-if(NOT jitify_POPULATED)
-    FetchContent_Populate(jitify)
-    # Apply patches to jitify2 for msvc support prior to https://github.com/NVIDIA/jitify/pull/146 being merged
-    # patch generated from jitify fork/branch, via `git format-patch jitify2 --stdout > jitify2-pr-146.patch`
-    # Does not use fetch content PATCH_COMMAND as it was unreliable / problematic on windows for prior rapidjson patching
-    # This will silently not apply the patch if it is not applicable, which supports repeated fetching but may lead to silent failures
-    # Check if the patch is applicable
+# Download content but do not use add_subdirectory
+FetchContent_MakeAvailable(jitify)
+
+# Apply patches to jitify2 for msvc support prior to https://github.com/NVIDIA/jitify/pull/146 being merged
+# patch generated from jitify fork/branch, via `git format-patch jitify2 --stdout > jitify2-pr-146.patch`
+# Does not use fetch content PATCH_COMMAND as it was unreliable / problematic on windows for prior rapidjson patching
+# This will silently not apply the patch if it is not applicable, which supports repeated fetching but may lead to silent failures
+# Check if the patch is applicable
+execute_process(
+    COMMAND git apply --check ${CMAKE_CURRENT_LIST_DIR}/patches/jitify2-pr-146.patch
+    WORKING_DIRECTORY "${jitify_SOURCE_DIR}"
+    RESULT_VARIABLE jitify_patch_check_result
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+# If applicable, apply the patch
+if (jitify_patch_check_result EQUAL 0)
+    message(CHECK_START  "Patching jitify #146")
     execute_process(
-        COMMAND git apply --check ${CMAKE_CURRENT_LIST_DIR}/patches/jitify2-pr-146.patch
+        COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patches/jitify2-pr-146.patch
         WORKING_DIRECTORY "${jitify_SOURCE_DIR}"
-        RESULT_VARIABLE jitify_patch_check_result
+        RESULT_VARIABLE jifity_patch_apply_result
         OUTPUT_QUIET
         ERROR_QUIET
     )
-    # If applicable, apply the patch
-    if (jitify_patch_check_result EQUAL 0)
-        message(CHECK_START  "Patching jitify #146")
-        execute_process(
-            COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patches/jitify2-pr-146.patch
-            WORKING_DIRECTORY "${jitify_SOURCE_DIR}"
-            RESULT_VARIABLE jifity_patch_apply_result
-            OUTPUT_QUIET
-            ERROR_QUIET
-        )
-        # If the patch failed emit a warning but allow cmake to progress. This should not occur given the previous check.
-        if (jifity_patch_apply_result EQUAL 0)
-            message(CHECK_PASS "done")
-        else()
-            message(CHECK_FAIL "patching failed")
-        endif()
-        unset(jifity_patch_apply_result)
+    # If the patch failed emit a warning but allow cmake to progress. This should not occur given the previous check.
+    if (jifity_patch_apply_result EQUAL 0)
+        message(CHECK_PASS "done")
+    else()
+        message(CHECK_FAIL "patching failed")
     endif()
-    unset(jitify_patch_check_result)
+    unset(jifity_patch_apply_result)
 endif()
+unset(jitify_patch_check_result)
 
 # Jitify is not a cmake project, so cannot use add_subdirectory, use custom find_package.
 set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${jitify_SOURCE_DIR}/..")
+
 # Always find the package, even if jitify is already populated.
 find_package(Jitify REQUIRED)
 

--- a/cmake/dependencies/Tinyxml2.cmake
+++ b/cmake/dependencies/Tinyxml2.cmake
@@ -5,12 +5,8 @@
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
 
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
-endif()
-
 # Change the source_dir to allow inclusion via tinyxml2/tinyxml2.h rather than tinyxml2.h
+# Specify an invalid SOURCE_SUBDIR to prevent FetchContent_MakeAvailable from adding the CMakeLists.txt
 FetchContent_Declare(
     tinyxml2
     GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
@@ -19,64 +15,62 @@ FetchContent_Declare(
     SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/tinyxml2-src/tinyxml2
     GIT_PROGRESS   ON
     # UPDATE_DISCONNECTED   ON
+    SOURCE_SUBDIR "do_not_use_add_subirectory"
 )
 
 # @todo - try finding the pacakge first, assuming it sets system correctly when used.
 FetchContent_GetProperties(tinyxml2)
-if(NOT tinyxml2_POPULATED)
-    FetchContent_Populate(tinyxml2)
+FetchContent_MakeAvailable(tinyxml2)
     
-    # The Tinxyxml2 repository does not include tinyxml2.h in a subdirectory, so include "tinyxml2.h" would be used not "tinyxml2/tinyxml2.h"
-    # To avoid this, do not use add_subdirectory, instead create our own cmake target for tinyxml2.
-    # @todo - a possible alternative (from tinyxml2 9.0.0?) might be to run the install target of tinyxml2, and then use find package in config mode. Would require investigation. 
-    # Disabled:
-    # get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_LIST_DIR}/../ REALPATH)
-    # add_subdirectory(${tinyxml2_SOURCE_DIR} ${tinyxml2_BINARY_DIR})
+# The Tinxyxml2 repository does not include tinyxml2.h in a subdirectory, so include "tinyxml2.h" would be used not "tinyxml2/tinyxml2.h"
+# To avoid this, do not use add_subdirectory, instead create our own cmake target for tinyxml2.
+# @todo - a possible alternative (from tinyxml2 9.0.0?) might be to run the install target of tinyxml2, and then use find package in config mode. Would require investigation. 
+# Disabled:
+# get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_LIST_DIR}/../ REALPATH)
+# add_subdirectory(${tinyxml2_SOURCE_DIR} ${tinyxml2_BINARY_DIR})
 
-    # If the target does not already exist, add it.
-    # @todo - make this far more robust.
-    if(NOT TARGET tinyxml2)
-        # @todo - make a dynamically generated CMakeLists.txt which can be add_subdirectory'd instead, so that the .vcxproj goes in a folder. Just adding a project doesn't work.
-        # project(tinyxml2 LANGUAGES CXX)
+# If the target does not already exist, add it.
+# @todo - make this far more robust.
+if(NOT TARGET tinyxml2)
+    # @todo - make a dynamically generated CMakeLists.txt which can be add_subdirectory'd instead, so that the .vcxproj goes in a folder. Just adding a project doesn't work.
+    # project(tinyxml2 LANGUAGES CXX)
 
-        # Set location of static library files
-        # Define output location of static library
-        if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-            # If top level project
-            SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE}/)
-        else()
-            # If called via add_subdirectory()
-            SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../lib/${CMAKE_BUILD_TYPE}/)
-        endif()
-
-        # Depends on the cpp and header files in case of changes
-        add_library(tinyxml2 STATIC ${tinyxml2_SOURCE_DIR}/tinyxml2.cpp ${tinyxml2_SOURCE_DIR}/tinyxml2.h)
-        # Pic is sensible for any library
-        set_property(TARGET tinyxml2 PROPERTY POSITION_INDEPENDENT_CODE ON)
-    
-        # Specify the include directory, to be forwared to targets which link against the tinyxml2 target.
-        # Mark this as SYSTEM INTERFACE, so that it does not result in compiler warnings being generated for dependent projects.
-        # For our use  case, this is up a folder so we can use tinyxml2/tinyxml2.h as the include, by resolving the relative path to get an abs path
-        get_filename_component(tinyxml2_inc_dir ${tinyxml2_SOURCE_DIR}/../ REALPATH)
-        target_include_directories(tinyxml2 SYSTEM INTERFACE ${tinyxml2_inc_dir})
-        
-        # Add some compile time definitions
-        target_compile_definitions(tinyxml2 INTERFACE $<$<CONFIG:Debug>:TINYXML2_DEBUG>)
-        set_target_properties(tinyxml2 PROPERTIES
-            COMPILE_DEFINITIONS "TINYXML2_EXPORT"
-        )
-        if(MSVC)
-            target_compile_definitions(tinyxml2 PUBLIC -D_CRT_SECURE_NO_WARNINGS)
-        endif(MSVC)
-
-        # Suppress warnigns from this target.
-        include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
-        flamegpu_disable_compiler_warnings(TARGET tinyxml2)
-
-        # Create an alias target for tinyxml2 to namespace it / make it more like other modern cmake 
-        add_library(Tinyxml2::tinyxml2 ALIAS tinyxml2)
-
+    # Set location of static library files
+    # Define output location of static library
+    if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+        # If top level project
+        SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE}/)
+    else()
+        # If called via add_subdirectory()
+        SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../lib/${CMAKE_BUILD_TYPE}/)
     endif()
+
+    # Depends on the cpp and header files in case of changes
+    add_library(tinyxml2 STATIC ${tinyxml2_SOURCE_DIR}/tinyxml2.cpp ${tinyxml2_SOURCE_DIR}/tinyxml2.h)
+    # Pic is sensible for any library
+    set_property(TARGET tinyxml2 PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    # Specify the include directory, to be forwared to targets which link against the tinyxml2 target.
+    # Mark this as SYSTEM INTERFACE, so that it does not result in compiler warnings being generated for dependent projects.
+    # For our use  case, this is up a folder so we can use tinyxml2/tinyxml2.h as the include, by resolving the relative path to get an abs path
+    get_filename_component(tinyxml2_inc_dir ${tinyxml2_SOURCE_DIR}/../ REALPATH)
+    target_include_directories(tinyxml2 SYSTEM INTERFACE ${tinyxml2_inc_dir})
+    
+    # Add some compile time definitions
+    target_compile_definitions(tinyxml2 INTERFACE $<$<CONFIG:Debug>:TINYXML2_DEBUG>)
+    set_target_properties(tinyxml2 PROPERTIES
+        COMPILE_DEFINITIONS "TINYXML2_EXPORT"
+    )
+    if(MSVC)
+        target_compile_definitions(tinyxml2 PUBLIC -D_CRT_SECURE_NO_WARNINGS)
+    endif(MSVC)
+
+    # Suppress warnigns from this target.
+    include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
+    flamegpu_disable_compiler_warnings(TARGET tinyxml2)
+
+    # Create an alias target for tinyxml2 to namespace it / make it more like other modern cmake 
+    add_library(Tinyxml2::tinyxml2 ALIAS tinyxml2)
 endif()
 
 # Mark some CACHE vars advanced for a cleaner GUI

--- a/cmake/dependencies/Tinyxml2.cmake
+++ b/cmake/dependencies/Tinyxml2.cmake
@@ -5,7 +5,6 @@
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
 
-cmake_policy(SET CMP0079 NEW)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -4,7 +4,6 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-cmake_policy(SET CMP0079 NEW)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -4,10 +4,6 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
-endif()
 
 # Set the visualiser repo and tag to use unless overridden by the user.
 set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "f46aa474e2703d5589d2fd7e8a7fe89fe35004b4")
@@ -69,13 +65,9 @@ else()
         GIT_TAG        ${FLAMEGPU_VISUALISATION_GIT_VERSION}
         GIT_PROGRESS   ON
     )
+    FetchContent_MakeAvailable(flamegpu_visualiser)
     FetchContent_GetProperties(flamegpu_visualiser)
-    if(NOT flamegpu_visualiser_POPULATED)
-        message(STATUS "using flamegpu_visualiser ${FLAMEGPU_VISUALISATION_GIT_VERSION} from ${FLAMEGPU_VISUALISATION_REPOSITORY}")
-        FetchContent_Populate(flamegpu_visualiser)
-        # Add the project as a subdirectory
-        add_subdirectory(${flamegpu_visualiser_SOURCE_DIR} ${flamegpu_visualiser_BINARY_DIR} EXCLUDE_FROM_ALL)
-    endif()
+    message(STATUS "using flamegpu_visualiser ${FLAMEGPU_VISUALISATION_GIT_VERSION} from ${FLAMEGPU_VISUALISATION_REPOSITORY}")
 endif()
 # Mark some CACHE vars advanced for a cleaner GUI
 mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FLAMEGPU_VISUALISER)

--- a/cmake/dependencies/flamegpu2-visualiser.cmake
+++ b/cmake/dependencies/flamegpu2-visualiser.cmake
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
 
 # Set the visualiser repo and tag to use unless overridden by the user.
-set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "f46aa474e2703d5589d2fd7e8a7fe89fe35004b4")
+set(DEFAULT_FLAMEGPU_VISUALISATION_GIT_VERSION "9282bf46560976e932160e5ede6ce3b730111f20")
 set(DEFAULT_FLAMEGPU_VISUALISATION_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2-visualiser.git")
 
 # Set a VISUSLAITION_ROOT cache entry so it is available in the GUI to override the location if required

--- a/cmake/dependencies/glm.cmake
+++ b/cmake/dependencies/glm.cmake
@@ -2,10 +2,6 @@
 # glm #
 #######
 
-# As the URL method is used for download, set the policy if available
-if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
-endif()
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/glm.cmake
+++ b/cmake/dependencies/glm.cmake
@@ -1,43 +1,38 @@
 #######
 # glm #
 #######
-
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
-endif()
-
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
 
 # Head of master at point BugFix for NVRTC support was merged
+# Specify an invalid SOURCE_SUBDIR to prevent FetchContent_MakeAvailable from adding the CMakeLists.txt
 FetchContent_Declare(
     glm
     URL            "https://github.com/g-truc/glm/archive/66062497b104ca7c297321bd0e970869b1e6ece5.zip"
+    SOURCE_SUBDIR "do_not_use_add_subirectory"
 )
 FetchContent_GetProperties(glm)
-if(NOT glm_POPULATED)
-    FetchContent_Populate(glm)
-    if (NOT TARGET glm::glm)
-        # glm CMake wants to generate the find file in a system location, so handle it manually
-        # Find the path, just incase
-        find_path(glm_INCLUDE_DIRS
-        NAMES
-            glm/glm.hpp
-        PATHS
-            ${glm_SOURCE_DIR}
-        NO_CACHE
-        )
-        if(glm_INCLUDE_DIRS)
-            # Define an imported interface target
-            add_library(glm::glm INTERFACE IMPORTED)
-            # Specify the location of the headers (but actually the parent dir, so include <glm/glm.hpp> can be used.)
-            target_include_directories(glm::glm INTERFACE "${glm_INCLUDE_DIRS}")
-        else()
-            message(FATAL_ERROR "Error during creation og `glm::glm` target. Could not find glm/glm.hpp")
-        endif()
-        unset(glm_INCLUDE_DIRS)
+FetchContent_MakeAvailable(glm)
+
+if (NOT TARGET glm::glm)
+    # glm CMake wants to generate the find file in a system location, so handle it manually
+    # Find the path, just incase
+    find_path(glm_INCLUDE_DIRS
+    NAMES
+        glm/glm.hpp
+    PATHS
+        ${glm_SOURCE_DIR}
+    NO_CACHE
+    )
+    if(glm_INCLUDE_DIRS)
+        # Define an imported interface target
+        add_library(glm::glm INTERFACE IMPORTED)
+        # Specify the location of the headers (but actually the parent dir, so include <glm/glm.hpp> can be used.)
+        target_include_directories(glm::glm INTERFACE "${glm_INCLUDE_DIRS}")
+    else()
+        message(FATAL_ERROR "Error during creation og `glm::glm` target. Could not find glm/glm.hpp")
     endif()
+    unset(glm_INCLUDE_DIRS)
 endif()
 
 # Mark some CACHE vars advanced for a cleaner GUI

--- a/cmake/dependencies/googletest.cmake
+++ b/cmake/dependencies/googletest.cmake
@@ -4,7 +4,6 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-cmake_policy(SET CMP0079 NEW)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/googletest.cmake
+++ b/cmake/dependencies/googletest.cmake
@@ -4,35 +4,34 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules/ ${CMAKE_MODULE_PATH})
 include(FetchContent)
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+    list(APPEND DEPENDENCY_ARGS EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG        v1.14.0
+  ${DEPENDENCY_ARGS}
 )
 
 FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    # Suppress installation target, as this makes a warning
-    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-    mark_as_advanced(FORCE INSTALL_GTEST)
-    set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject" FORCE)
-    mark_as_advanced(FORCE BUILD_GMOCK)
-    # Prevent overriding the parent project's compiler/linker
-    # settings on Windows
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-    flamegpu_set_target_folder("gtest" "Tests/Dependencies")
-    # Suppress warnigns from this target.
-    include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
-    if(TARGET gtest)
-        flamegpu_disable_compiler_warnings(TARGET gtest)
-    endif()
+# Suppress installation target, as this makes a warning
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+mark_as_advanced(FORCE INSTALL_GTEST)
+set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject" FORCE)
+mark_as_advanced(FORCE BUILD_GMOCK)
+# Prevent overriding the parent project's compiler/linker settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Download and add_subdirectory
+FetchContent_MakeAvailable(googletest)
+# Setup the visual studiop project filter
+flamegpu_set_target_folder("gtest" "Tests/Dependencies")
+# Suppress warnigns from this target.
+include(${CMAKE_CURRENT_LIST_DIR}/../warnings.cmake)
+if(TARGET gtest)
+    flamegpu_disable_compiler_warnings(TARGET gtest)
 endif()
 
 # Mark some CACHE vars advanced for a cleaner GUI

--- a/cmake/dependencies/nlohmann_json.cmake
+++ b/cmake/dependencies/nlohmann_json.cmake
@@ -3,7 +3,6 @@
 #################
 
 include(FetchContent)
-cmake_policy(SET CMP0079 NEW)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)

--- a/cmake/dependencies/nlohmann_json.cmake
+++ b/cmake/dependencies/nlohmann_json.cmake
@@ -3,25 +3,22 @@
 #################
 
 include(FetchContent)
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+    list(APPEND DEPENDENCY_ARGS EXCLUDE_FROM_ALL)
 endif()
+
 FetchContent_Declare(
     nlohmann_json
     URL            "https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz"
+    ${DEPENDENCY_ARGS}
 )
 FetchContent_GetProperties(nlohmann_json)
-if(NOT nlohmann_json_POPULATED)
-    FetchContent_Populate(nlohmann_json)
-    # Add the project as a subdirectory
-    add_subdirectory(${nlohmann_json_SOURCE_DIR} ${nlohmann_json_BINARY_DIR} EXCLUDE_FROM_ALL)
-
-    # If we are using CUDA 12.0 or 12.1 on linux or windows, add an interface definition of JSON_HAS_RANGES to 0 to the nlohmann target to workaround an nvcc bug. See https://github.com/nlohmann/json/issues/3907.
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0 AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.2)
-        target_compile_definitions(nlohmann_json INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:JSON_HAS_RANGES=0>)
-    endif()
-
+# Download and add_subdirectory
+FetchContent_MakeAvailable(nlohmann_json)
+# If we are using CUDA 12.0 or 12.1 on linux or windows, add an interface definition of JSON_HAS_RANGES to 0 to the nlohmann target to workaround an nvcc bug. See https://github.com/nlohmann/json/issues/3907.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0 AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.2 AND TARGET nlohmann_json)
+    target_compile_definitions(nlohmann_json INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:JSON_HAS_RANGES=0>)
 endif()
 
 # Mark some CACHE vars advanced for a cleaner GUI

--- a/examples/cpp/boids_bruteforce/CMakeLists.txt
+++ b/examples/cpp/boids_bruteforce/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/boids_spatial3D/CMakeLists.txt
+++ b/examples/cpp/boids_spatial3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/circles_bruteforce/CMakeLists.txt
+++ b/examples/cpp/circles_bruteforce/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/circles_spatial3D/CMakeLists.txt
+++ b/examples/cpp/circles_spatial3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/diffusion/CMakeLists.txt
+++ b/examples/cpp/diffusion/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/ensemble/CMakeLists.txt
+++ b/examples/cpp/ensemble/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/game_of_life/CMakeLists.txt
+++ b/examples/cpp/game_of_life/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/host_functions/CMakeLists.txt
+++ b/examples/cpp/host_functions/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp/sugarscape/CMakeLists.txt
+++ b/examples/cpp/sugarscape/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp_rtc/boids_bruteforce/CMakeLists.txt
+++ b/examples/cpp_rtc/boids_bruteforce/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/examples/cpp_rtc/boids_spatial3D/CMakeLists.txt
+++ b/examples/cpp_rtc/boids_spatial3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Set the location of the ROOT flame gpu project relative to this CMakeList.txt
 get_filename_component(FLAMEGPU_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -8,11 +8,6 @@ endif()
 
 # Set some policy behaviours for SWIG
 
-# SWIG: use standard target name.
-if(POLICY CMP0078)
-  cmake_policy(SET CMP0078 NEW)
-endif()
-
 # SWIG: use SWIG_MODULE_NAME property.
 if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -8,11 +8,6 @@ endif()
 
 # Set some policy behaviours for SWIG
 
-# SWIG: use SWIG_MODULE_NAME property.
-if(POLICY CMP0086)
-  cmake_policy(SET CMP0086 NEW)
-endif()
-
 # As the URL method is used for download, set the policy if available
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -6,13 +6,6 @@ if(POLICY CMP0169)
     cmake_policy(SET CMP0169 OLD)
 endif()
 
-# Set some policy behaviours for SWIG
-
-# As the URL method is used for download, set the policy if available
-if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
-endif()
-
 # Ensure custom Find* modules are avialable
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake/modules/ ${CMAKE_MODULE_PATH})
 

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
 cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 include(FetchContent)
-# Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD)
-endif()
 
 # Ensure custom Find* modules are avialable
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake/modules/ ${CMAKE_MODULE_PATH})
@@ -70,87 +66,85 @@ if(NOT SWIG_FOUND)
 
     if(WIN32)
         # Download pre-compiled swig on windows.
+        # Specify an invalid SOURCE_SUBDIR to prevent FetchContent_MakeAvailable from adding the CMakeLists.txt
         FetchContent_Declare(
             swig
             URL      http://prdownloads.sourceforge.net/swig/swigwin-${FLAMEGPU_SWIG_DOWNLOAD}.zip
             # URL_HASH #@todo - make sure the hash of the download is good?
+            SOURCE_SUBDIR "do_not_use_add_subirectory"
         )
-        FetchContent_GetProperties(swig)
-        if(NOT swig_POPULATED)
-            message(STATUS "[swig] Downloading swigwin-${FLAMEGPU_SWIG_DOWNLOAD}.zip")
-            # Download
-            FetchContent_Populate(swig)
-            
-            # Set variables used by find_swig to find swig.
-            # Set locally and in the cache for subsequent invocations of CMake
-            set(SWIG_EXECUTABLE "${swig_SOURCE_DIR}/swig.exe")
-            set(SWIG_EXECUTABLE "${swig_SOURCE_DIR}/swig.exe" CACHE FILEPATH "Path to SWIG executable")
-        endif()
+        # Download
+        FetchContent_MakeAvailable(swig)            
+        # Set variables used by find_swig to find swig.
+        # Set locally and in the cache for subsequent invocations of CMake
+        set(SWIG_EXECUTABLE "${swig_SOURCE_DIR}/swig.exe")
+        set(SWIG_EXECUTABLE "${swig_SOURCE_DIR}/swig.exe" CACHE FILEPATH "Path to SWIG executable")
     else()
         # Under linux, download the .tar.gz, extract, build and install.
         # This must be done at configure time, as FindSwig requires the swig executable.
         # FetchContent allows download at configure time, but must use execute_process to run commands at configure time.
 
         # Download from sourceforge not github, github releases require several extra tools to build (bison, yacc, autoconfigure, automake), and we want to keep dependencies light. 
+        # Specify an invalid SOURCE_SUBDIR to prevent FetchContent_MakeAvailable from adding the CMakeLists.txt
         FetchContent_Declare(
             swig
             URL      https://downloads.sourceforge.net/project/swig/swig/swig-${FLAMEGPU_SWIG_DOWNLOAD}/swig-${FLAMEGPU_SWIG_DOWNLOAD}.tar.gz
             # URL_HASH #@todo - make sure the hash of the download is good?
+            SOURCE_SUBDIR "do_not_use_add_subirectory"
         )
-        FetchContent_GetProperties(swig)
-        if(NOT swig_POPULATED)
-            # Quitely Find PCRE (Swig < 4.1) or PCRE2 >= swig 4.1. If not found, emit a warning, but do not error (incase cmake/modules/FindPCRE.cmake is not perfect)
-            if (FLAMEGPU_SWIG_DOWNLOAD VERSION_LESS "4.1")
-                find_package(PCRE QUIET)
-                message("a")
-                if(NOT PCRE_FOUND)
-                    message(
-                        WARNING "  Swig ${FLAMEGPU_SWIG_DOWNLOAD} requires 'pcre-config', but PCRE could not be found.\n"
-                        "  Swig compilation from source may fail.\n"
-                        "  If so, please insall PCRE with development dependencies, e.g.:\n"
-                        "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install libpcre3-dev\n"
-                        "  - On RPM-based distributions (Fedora, RHEL, etc): dnf install libpcre-devel"
-                    )
-                endif()
-            else()
-                find_package(PCRE2 QUIET)
-                if(NOT PCRE2_FOUND)
-                    message(
-                        WARNING "  Swig ${FLAMEGPU_SWIG_DOWNLOAD} requires 'pcre2-config', but PCRE could not be found.\n"
-                        "  Swig compilation from source may fail.\n"
-                        "  If so, please insall PCRE with development dependencies, e.g.:\n"
-                        "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install libpcre2-dev\n"
-                        "  - On DNF-based distributions (Fedora, RHEL, etc): dnf install libpcre2-devel"
-                    )
-                endif()
-            endif()
-
-            # Ensure that autotools/automake is available, as required to build swig from source.
-            find_program(AUTOMAKE_EXECUTABLE NAMES automake)
-            find_program(ACLOCAL_EXECUTABLE NAMES aclocal)
-            if(NOT AUTOMAKE_EXECUTABLE OR NOT ACLOCAL_EXECUTABLE)
+        # Quitely Find PCRE (Swig < 4.1) or PCRE2 >= swig 4.1. If not found, emit a warning, but do not error (incase cmake/modules/FindPCRE.cmake is not perfect)
+        if (FLAMEGPU_SWIG_DOWNLOAD VERSION_LESS "4.1")
+            find_package(PCRE QUIET)
+            message("a")
+            if(NOT PCRE_FOUND)
                 message(
-                    FATAL_ERROR "  Building Swig ${FLAMEGPU_SWIG_DOWNLOAD} from source requires automake, but it could not be found\n"
-                    "  Please insall automake, e.g.:\n"
-                    "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install automake\n"
-                    "  - On DNF-based distributions (Fedora, RHEL, etc): dnf install automake"
+                    WARNING "  Swig ${FLAMEGPU_SWIG_DOWNLOAD} requires 'pcre-config', but PCRE could not be found.\n"
+                    "  Swig compilation from source may fail.\n"
+                    "  If so, please insall PCRE with development dependencies, e.g.:\n"
+                    "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install libpcre3-dev\n"
+                    "  - On RPM-based distributions (Fedora, RHEL, etc): dnf install libpcre-devel"
                 )
             endif()
-
-            find_package(BISON)
-            if(NOT BISON_FOUND)
+        else()
+            find_package(PCRE2 QUIET)
+            if(NOT PCRE2_FOUND)
                 message(
-                    FATAL_ERROR "  Buidling Swig ${FLAMEGPU_SWIG_DOWNLOAD} from source requires 'bison', but it could not be found\n"
-                    "  Please insall bison, e.g.:\n"
-                    "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install bison\n"
-                    "  - On DNF-based distributions (Fedora, RHEL, etc): dnf install bison"
+                    WARNING "  Swig ${FLAMEGPU_SWIG_DOWNLOAD} requires 'pcre2-config', but PCRE could not be found.\n"
+                    "  Swig compilation from source may fail.\n"
+                    "  If so, please insall PCRE with development dependencies, e.g.:\n"
+                    "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install libpcre2-dev\n"
+                    "  - On DNF-based distributions (Fedora, RHEL, etc): dnf install libpcre2-devel"
                 )
             endif()
+        endif()
 
-            message(STATUS "[swig] Downloading swig-${FLAMEGPU_SWIG_DOWNLOAD}.tar.gz")
-            # Download the content
-            FetchContent_Populate(swig)
+        # Ensure that autotools/automake is available, as required to build swig from source.
+        find_program(AUTOMAKE_EXECUTABLE NAMES automake)
+        find_program(ACLOCAL_EXECUTABLE NAMES aclocal)
+        if(NOT AUTOMAKE_EXECUTABLE OR NOT ACLOCAL_EXECUTABLE)
+            message(
+                FATAL_ERROR "  Building Swig ${FLAMEGPU_SWIG_DOWNLOAD} from source requires automake, but it could not be found\n"
+                "  Please insall automake, e.g.:\n"
+                "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install automake\n"
+                "  - On DNF-based distributions (Fedora, RHEL, etc): dnf install automake"
+            )
+        endif()
 
+        find_package(BISON)
+        if(NOT BISON_FOUND)
+            message(
+                FATAL_ERROR "  Buidling Swig ${FLAMEGPU_SWIG_DOWNLOAD} from source requires 'bison', but it could not be found\n"
+                "  Please insall bison, e.g.:\n"
+                "  - On DEB-based distributions (Debian, Ubuntu, etc): apt-get install bison\n"
+                "  - On DNF-based distributions (Fedora, RHEL, etc): dnf install bison"
+            )
+        endif()
+
+        message(STATUS "[swig] Downloading swig-${FLAMEGPU_SWIG_DOWNLOAD}.tar.gz")
+        # Download the content
+        FetchContent_MakeAvailable(swig)
+
+        if(NOT EXISTS "${swig_BINARY_DIR}/bin/swig")
             # Set some paths for error files in case things go wrong.
             set(swig_configure_ERROR_FILE "${swig_BINARY_DIR}/swig-error-configue.log")
             set(swig_make_ERROR_FILE "${swig_BINARY_DIR}/swig-error-make.log")

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 include(FetchContent)
 # Temporary CMake >= 3.30 fix https://github.com/FLAMEGPU/FLAMEGPU2/issues/1223
 if(POLICY CMP0169)

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Defines multiple CMake targets and custom commands to build swig bindings, create a python wheel and (optionally) install it into a venv.
 # defines `pyflamegpu` - the user-facing target which creates the wheel.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake version 3.25.2 for CUDA --std=c++20
-cmake_minimum_required(VERSION 3.25.2...3.29 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2...4.1.1 FATAL_ERROR)
 
 # Option to enable GTEST_DISCOVER if tests or tests_dev are enabled. Defaults to off due to runtime increase
 cmake_dependent_option(FLAMEGPU_ENABLE_GTEST_DISCOVER "Enable GTEST_DISCOVER for more detailed ctest output without -VV. This dramatically increases test suite runtime to CUDA context initialisation." OFF "FLAMEGPU_BUILD_TESTS OR FLAMEGPU_BUILD_TESTS_DEV" OFF)


### PR DESCRIPTION
- [x] Update CMake CI to include 3.25.2, 3.31 & 4.x, including Windows
- [x] Fix Cmake 3.30 deprecations (#1223)
- [x] Fix CMake 3.31 warning (#1275)
- [x] Fix CMake 4.x compatibililty (#1276)
- [x] Update maximum CMake version to 4.x in `cmake_minimum_required`
- [x] Update Visualistion repo to be CMake 4.x compatible
  - See https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/144


Depends on (and merges into) #1314, #1150, #1302, #1277

Closes #1223 
Closes #1275
Closes #1276