### PR TITLE
Python 3.9 to 3.13

### DIFF
--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -26,9 +26,9 @@ defaults:
 # + Thorough Windows builds
 #   + Oldest and newest cuda, lots of arch, vis off, tests on
 # + Wheel producing manylinux builds
-#   + CUDA 12.0 and 13.0, py 3.8-3.12, vis on/off, py only.
+#   + CUDA 12.0 and 13.0, py 3.9-3.13, vis on/off, py only.
 # + Wheel producing Windows builds
-#   + CUDA 12.4 and 13.0, py 3.8-3.12, vis on/off, py only.
+#   + CUDA 12.4 and 13.0, py 3.9-3.13, vis on/off, py only.
 # + Draft github release workflow.
 
 jobs:
@@ -56,7 +56,7 @@ jobs:
             hostcxx: gcc-10
             os: ubuntu-22.04
         python:
-          - "3.8"
+          - "3.9"
         config:
           - name: "Release"
             config: "Release"
@@ -204,7 +204,7 @@ jobs:
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
         python:
-          - "3.8"
+          - "3.9"
         config:
           - name: "Release"
             config: "Release"
@@ -325,11 +325,11 @@ jobs:
             hostcxx: gcc-toolset-12
             os: ubuntu-24.04
         python:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
         config:
           - name: "Release"
             config: "Release"
@@ -504,11 +504,11 @@ jobs:
             hostcxx: "Visual Studio 17 2022"
             os: windows-2022
         python:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
         config:
           - name: "Release"
             config: "Release"

--- a/.github/workflows/MPI.yml
+++ b/.github/workflows/MPI.yml
@@ -37,7 +37,7 @@ jobs:
             hostcxx: gcc-11
             os: ubuntu-22.04
         python:
-          - "3.8"
+          - "3.9"
         mpi:
           - lib: "openmpi"
             version: "apt" # MPI 3.1

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Optionally:
 
 + [cpplint](https://github.com/cpplint/cpplint) for linting code
 + [Doxygen](http://www.doxygen.nl/) to build the documentation
-+ [Python](https://www.python.org/) `>= 3.8` for python integration
++ [Python](https://www.python.org/) `>= 3.9` for python integration
   + With `setuptools`, `wheel`, `build` and optionally `venv` python packages installed
   + On Windows, CUDA >= 12.4 is required for python integration
 + [swig](http://www.swig.org/) `>= 4.1.0` for python integration (with c++20 support)


### PR DESCRIPTION
Update python versions supported and wheels produced to the currrent 3.9-3.13

- [x] Update readme
- [x] Remove 3.8 from CI
- [x] Add 3.13 to CI
- [x] Test 3.13 wheel(s) on linux
    - `676 passed, 12 skipped in 292.62s`
- [x] Test 3.13 wheel(s) on windows
    - `676 passed, 12 skipped in 352.98s`


Closes #1235 
Closes #1236