### PR TITLE
Changes to module annotations for py3.14

### DIFF
--- a/swig/python/codegen/__init__.py
+++ b/swig/python/codegen/__init__.py
@@ -42,12 +42,8 @@ def translate(function: Union[str, Callable]) -> str:
         tree = ast.parse(function_source)
         # Filter constants
         module_members = inspect.getmembers(module);
-        # Emulate inspect.get_annotations() (requires python 3.10+)
-        module_annontations = {}
-        for mem in module_members:
-            if mem[0] == "__annotations__":
-                module_annontations = mem[1]
-                break
+        # Requires python 3.10+
+        module_annontations = inspect.get_annotations(module)
         prepend_c_source = ""
         # Find all annotated variables
         for key, val in module_annontations.items():


### PR DESCRIPTION
Python 3.14 changes to lazy evaulation of annotations breaking module variables prepaended to pyflamegpu functions. E.g.

```
TEN: pyflamegpu.constant = 10
TWO: typing.Final = return_two()
```

This has been recfited by using inspect.get_annotations which was previously avoided due to support of Python <3.10.