### PR TITLE
Fix telemetry curl timeouts with recent Curl

### DIFF
--- a/src/flamegpu/io/Telemetry.cpp
+++ b/src/flamegpu/io/Telemetry.cpp
@@ -272,8 +272,8 @@ bool Telemetry::sendData(std::string telemetry_data) {
     curl_command << " --connect-timeout 0.5";
     // Maximum total duration for the curl call, including connection and payload
     curl_command << " --max-time 1.0";
-    curl_command << " -X POST '" << std::string(TELEMETRY_ENDPOINT) << "'";
-    curl_command << " -H 'Content-Type: application/json; charset=utf-8'";
+    curl_command << " -X POST \"" << std::string(TELEMETRY_ENDPOINT) << "\"";
+    curl_command << " -H \"Content-Type: application/json; charset=utf-8\"";
     curl_command << " --data-raw \"" << telemetry_data << "\"";
     curl_command << " > " << null << " 2>&1";
     // capture the return value


### PR DESCRIPTION
Due to `std::to_string` converting `0.5` to `0.500000`, more recent curl versions under linux were timing out on submitting telemetry.

This fixes telemetry submission on ubuntu 25.10 which includes curl `8.14.1`.
The old behaviour was OK on ubuntu 24.04 with CURL `8.5.0`. 


Also fixes windows curl which disliked the use of `'` (by @mondus)