### PR TITLE
BugFix: Resolve race condition during graph visualisation init.

### DIFF
--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -25,11 +25,16 @@ void ModelVisData::hookVis(std::shared_ptr<visualiser::ModelVisData>& vis, std::
     for (auto [key, buf] : map) {
         buf->setVisualisation(vis);
     }
+    // Can only lock the mutex after vis is retrieved
+    if (vis->visualiser)
+        vis->visualiser->lockDynamicLinesMutex();
     for (auto [name, graph] : graphs) {
         auto &graph_buffs = map.at(name);
         graph->constructGraph(graph_buffs);
         vis->rebuildEnvGraph(name);
     }
+    if (vis->visualiser)
+        vis->visualiser->releaseDynamicLinesMutex();
 }
 void ModelVisData::registerEnvProperties() {
     if (model.singletons && !env_registered) {


### PR DESCRIPTION
Missing mutex lock when a graph is first linked to visualisation.

Reported by @DavidFletcherShef in https://github.com/FLAMEGPU/FLAMEGPU2-docs/pull/189#issuecomment-3543650107

*CI failures appear to be due to GitHub outage, 500 internal server error during repo fetches.*