### PR TITLE
Serialization of Models

### DIFF
--- a/include/flamegpu/io/JSONSerializerReader.h
+++ b/include/flamegpu/io/JSONSerializerReader.h
@@ -1,0 +1,29 @@
+#ifndef INCLUDE_FLAMEGPU_IO_JSONSERIALIZERREADER_H_
+#define INCLUDE_FLAMEGPU_IO_JSONSERIALIZERREADER_H_
+
+#include <memory>
+#include <string>
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+
+#include "flamegpu/model/ModelDescription.h"
+
+
+namespace flamegpu {
+namespace io {
+/**
+ * JSON format SerializerReader
+ */
+class JSONSerializerReader {
+ public:
+	/**
+	 * Write the model file to serialized json
+	 @param filePath The file path to a serialized FLAME GPU model (must end in '.json')
+	 */
+    static ModelDescription parse(const std::string &filePath);
+};
+}  // namespace io
+}  // namespace flamegpu
+
+#endif  // INCLUDE_FLAMEGPU_IO_JSONSERIALIZERREADER_H_

--- a/include/flamegpu/io/JSONSerializerWriter.h
+++ b/include/flamegpu/io/JSONSerializerWriter.h
@@ -1,0 +1,40 @@
+#ifndef INCLUDE_FLAMEGPU_IO_JSONSERIALIZERWRITER_H_
+#define INCLUDE_FLAMEGPU_IO_JSONSERIALIZERWRITER_H_
+
+#include <memory>
+#include <string>
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+
+#include "flamegpu/model/ModelDescription.h"
+
+
+namespace flamegpu {
+namespace io {
+/**
+ * JSON format SerializerWriter
+ */
+class JSONSerializerWriter {
+ public:
+    /**
+     * Constructs a writer capable of writing (serializing) model object to an JSON file
+	 * @param outPath The file path to serialize the model to (must end in '.json')
+     */
+    JSONSerializerWriter(const std::string &outPath);
+
+	/**
+	 * Write the model file to serialized json
+	 @param model A model description object which will be serialized
+	 */
+    void writeModel(ModelDescription model);
+
+ private:
+    std::string out_path;
+    bool prettyPrint;
+    bool truncateFile;
+};
+}  // namespace io
+}  // namespace flamegpu
+
+#endif  // INCLUDE_FLAMEGPU_IO_JSONSERIALIZERWRITER_H_

--- a/include/flamegpu/model/ModelDescription.h
+++ b/include/flamegpu/model/ModelDescription.h
@@ -393,6 +393,12 @@ class ModelDescription {
      */
     flamegpu::size_type getLayersCount() const;
 
+    /**
+     * Serialize the model to file in the JSON format
+     * @param path The file path to serialize the model to (must end in '.json')
+     */
+    void serialize(const std::string& path);
+
  private:
     /**
      * The class which stores all of the model hierarchies data.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,8 @@ SET(SRC_INCLUDE
     ${FLAMEGPU_ROOT}/include/flamegpu/io/StateWriter.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/JSONStateReader.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/JSONStateWriter.h
+	${FLAMEGPU_ROOT}/include/flamegpu/io/JSONSerializerReader.h
+	${FLAMEGPU_ROOT}/include/flamegpu/io/JSONSerializerWriter.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/XMLStateReader.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/XMLStateWriter.h
     ${FLAMEGPU_ROOT}/include/flamegpu/io/StateReaderFactory.h
@@ -372,6 +374,8 @@ SET(SRC_FLAMEGPU
     ${FLAMEGPU_ROOT}/src/flamegpu/runtime/random/HostRandom.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONStateWriter.cu
+	${FLAMEGPU_ROOT}/src/flamegpu/io/JSONSerializerReader.cpp
+    ${FLAMEGPU_ROOT}/src/flamegpu/io/JSONSerializerWriter.cpp
     ${FLAMEGPU_ROOT}/src/flamegpu/io/StateReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateReader.cu
     ${FLAMEGPU_ROOT}/src/flamegpu/io/XMLStateWriter.cu

--- a/src/flamegpu/io/JSONSerializerReader.cpp
+++ b/src/flamegpu/io/JSONSerializerReader.cpp
@@ -1,0 +1,28 @@
+#include "flamegpu/io/JSONSerializerReader.h"
+
+#include <stack>
+#include <fstream>
+#include <string>
+#include <map>
+#include <set>
+#include <cstdio>
+#include <memory>
+
+#include <nlohmann/json.hpp>
+
+#include "flamegpu/exception/FLAMEGPUException.h"
+
+
+namespace flamegpu {
+namespace io {
+
+namespace {
+
+}  // namespace
+
+ModelDescription JSONSerializerReader::parse(const std::string& filepath) {
+	THROW exception::JSONError("Not implemented\n");
+}
+
+}  // namespace io
+}  // namespace flamegpu

--- a/src/flamegpu/io/JSONSerializerWriter.cpp
+++ b/src/flamegpu/io/JSONSerializerWriter.cpp
@@ -1,0 +1,211 @@
+#include "flamegpu/io/JSONGraphWriter.h"
+
+#include <fstream>
+#include <cstdio>
+#include <utility>
+#include <string>
+#include <memory>
+
+#include <nlohmann/json.hpp>
+
+#include "flamegpu/exception/FLAMEGPUException.h"
+#include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"
+
+namespace flamegpu {
+namespace io {
+
+namespace {
+void writeAnyVertex(nlohmann::ordered_json& j, const std::pair<std::string, Variable> &var, const unsigned int index, const std::shared_ptr<const detail::CUDAEnvironmentDirectedGraphBuffers>& directed_graph, cudaStream_t stream) {
+    size_type foo = 0;
+    // Output value
+    if (var.second.elements == 1) {
+        if (var.second.type == std::type_index(typeid(float))) {
+            j = directed_graph->getVertexPropertyBuffer<float>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(double))) {
+            j = directed_graph->getVertexPropertyBuffer<double>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int64_t))) {
+            j = directed_graph->getVertexPropertyBuffer<int64_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(uint64_t))) {
+            j = directed_graph->getVertexPropertyBuffer<uint64_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int32_t))) {
+            j = directed_graph->getVertexPropertyBuffer<int32_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(uint32_t))) {
+            j = directed_graph->getVertexPropertyBuffer<uint32_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int16_t))) {
+            j = directed_graph->getVertexPropertyBuffer<int16_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(uint16_t))) {
+            j = directed_graph->getVertexPropertyBuffer<uint16_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int8_t))) {
+            j = static_cast<int32_t>(directed_graph->getVertexPropertyBuffer<int8_t>(var.first, foo, stream)[var.second.elements * index]);  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(uint8_t))) {
+            j = static_cast<uint32_t>(directed_graph->getVertexPropertyBuffer<uint8_t>(var.first, foo, stream)[var.second.elements * index]);  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(char))) {
+            j = static_cast<int32_t>(directed_graph->getVertexPropertyBuffer<char>(var.first, foo, stream)[var.second.elements * index]);  // Char outputs weird if being used as an integer
+        } else {
+            THROW exception::JSONError("Attempting to export value of unsupported type '%s', "
+                "in JsonGraphWriter::writeAny()\n", var.second.type.name());
+        }
+        return;
+    }
+    // Loop through elements, to construct array
+    j = {};
+    for (unsigned int el = 0; el < var.second.elements; ++el) {
+        if (var.second.type == std::type_index(typeid(float))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<float>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(double))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<double>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int64_t))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<int64_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(uint64_t))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<uint64_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int32_t))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<int32_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(uint32_t))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<uint32_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int16_t))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<int16_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(uint16_t))) {
+            j.push_back(directed_graph->getVertexPropertyBuffer<uint16_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int8_t))) {
+            j.push_back(static_cast<int32_t>(directed_graph->getVertexPropertyBuffer<int8_t>(var.first, foo, stream)[var.second.elements * index + el]));  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(uint8_t))) {
+            j.push_back(static_cast<uint32_t>(directed_graph->getVertexPropertyBuffer<uint8_t>(var.first, foo, stream)[var.second.elements * index + el]));  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(char))) {
+            j.push_back(static_cast<int32_t>(directed_graph->getVertexPropertyBuffer<char>(var.first, foo, stream)[var.second.elements * index + el]));  // Char outputs weird if being used as an integer
+        } else {
+            THROW exception::JSONError("Attempting to export value of unsupported type '%s', "
+                "in JsonGraphWriter::writeAny()\n", var.second.type.name());
+        }
+    }
+}
+void writeAnyEdge(nlohmann::ordered_json& j, const std::pair<std::string, Variable> &var, const unsigned int index, const std::shared_ptr<const detail::CUDAEnvironmentDirectedGraphBuffers>& directed_graph, cudaStream_t stream) {
+    size_type foo = 0;
+    // Output value
+    if (var.second.elements == 1) {
+        if (var.second.type == std::type_index(typeid(float))) {
+            j = directed_graph->getEdgePropertyBuffer<float>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(double))) {
+            j = directed_graph->getEdgePropertyBuffer<double>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int64_t))) {
+            j = directed_graph->getEdgePropertyBuffer<int64_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(uint64_t))) {
+            j = directed_graph->getEdgePropertyBuffer<uint64_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int32_t))) {
+            j = directed_graph->getEdgePropertyBuffer<int32_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(uint32_t))) {
+            j = directed_graph->getEdgePropertyBuffer<uint32_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int16_t))) {
+            j = directed_graph->getEdgePropertyBuffer<int16_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(uint16_t))) {
+            j = directed_graph->getEdgePropertyBuffer<uint16_t>(var.first, foo, stream)[var.second.elements * index];
+        } else if (var.second.type == std::type_index(typeid(int8_t))) {
+            j = static_cast<int32_t>(directed_graph->getEdgePropertyBuffer<int8_t>(var.first, foo, stream)[var.second.elements * index]);  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(uint8_t))) {
+            j = static_cast<uint32_t>(directed_graph->getEdgePropertyBuffer<uint8_t>(var.first, foo, stream)[var.second.elements * index]);  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(char))) {
+            j = static_cast<int32_t>(directed_graph->getEdgePropertyBuffer<char>(var.first, foo, stream)[var.second.elements * index]);  // Char outputs weird if being used as an integer
+        } else {
+            THROW exception::JSONError("Attempting to export value of unsupported type '%s', "
+                "in JsonGraphWriter::writeAny()\n", var.second.type.name());
+        }
+        return;
+    }
+    // Loop through elements, to construct array
+    j = {};
+    for (unsigned int el = 0; el < var.second.elements; ++el) {
+        if (var.second.type == std::type_index(typeid(float))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<float>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(double))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<double>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int64_t))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<int64_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(uint64_t))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<uint64_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int32_t))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<int32_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(uint32_t))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<uint32_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int16_t))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<int16_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(uint16_t))) {
+            j.push_back(directed_graph->getEdgePropertyBuffer<uint16_t>(var.first, foo, stream)[var.second.elements * index + el]);
+        } else if (var.second.type == std::type_index(typeid(int8_t))) {
+            j.push_back(static_cast<int32_t>(directed_graph->getEdgePropertyBuffer<int8_t>(var.first, foo, stream)[var.second.elements * index + el]));  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(uint8_t))) {
+            j.push_back(static_cast<uint32_t>(directed_graph->getEdgePropertyBuffer<uint8_t>(var.first, foo, stream)[var.second.elements * index + el]));  // Char outputs weird if being used as an integer
+        } else if (var.second.type == std::type_index(typeid(char))) {
+            j.push_back(static_cast<int32_t>(directed_graph->getEdgePropertyBuffer<char>(var.first, foo, stream)[var.second.elements * index + el]));  // Char outputs weird if being used as an integer
+        } else {
+            THROW exception::JSONError("Attempting to export value of unsupported type '%s', "
+                "in JsonGraphWriter::writeAny()\n", var.second.type.name());
+        }
+    }
+}
+void toAdjancencyLike(nlohmann::ordered_json &j, const std::shared_ptr<const detail::CUDAEnvironmentDirectedGraphBuffers>& directed_graph, cudaStream_t stream) {
+    const EnvironmentDirectedGraphData &data = directed_graph->getDescription();
+    // Vertices
+    if (directed_graph->getVertexCount()) {
+        j["nodes"] = {};
+        for (unsigned int i = 0; i < directed_graph->getVertexCount(); ++i) {
+            nlohmann::ordered_json j_v;
+            // Reserved members first
+            size_type foo = 0;
+            j_v["id"] = std::to_string(directed_graph->getVertexPropertyBuffer<id_t>(ID_VARIABLE_NAME, foo, stream)[i]);
+            // Custom members after
+            for (const auto &v : data.vertexProperties) {
+                if (v.first[0] != '_') {
+                    writeAnyVertex(j_v[v.first], v, i, directed_graph, stream);
+                    if (i == 0 && v.first == "id" && v.first != ID_VARIABLE_NAME) {
+                        fprintf(stderr, "Warning: Graph vertices contain both 'id' and '%s' properties, export may be invalid.\n", ID_VARIABLE_NAME);
+                    }
+                }
+            }
+            j["nodes"].push_back(j_v);
+        }
+    }
+    // Edges
+    if (directed_graph->getEdgeCount()) {
+    j["links"] = {};
+        for (unsigned int i = 0; i < directed_graph->getEdgeCount(); ++i) {
+            nlohmann::ordered_json j_e;
+            // Reserved members first
+            size_type foo = 0;
+            const id_t *src_dest_buffer = directed_graph->getEdgePropertyBuffer<id_t>(GRAPH_SOURCE_DEST_VARIABLE_NAME, foo, stream);
+            j_e["source"] = std::to_string(src_dest_buffer[i * 2 + 1]);
+            j_e["target"] = std::to_string(src_dest_buffer[i * 2 + 0]);
+            // Custom members after
+            for (const auto& e : data.edgeProperties) {
+                if (e.first[0] != '_') {
+                    writeAnyEdge(j_e[e.first], e, i, directed_graph, stream);
+                    if (i == 0 && e.first == "source") {
+                        fprintf(stderr, "Warning: Graph edges contain both 'source' and '%s' properties, export may be invalid.\n", GRAPH_SOURCE_DEST_VARIABLE_NAME);
+                    } else if (i == 0 && e.first == "target") {
+                        fprintf(stderr, "Warning: Graph edges contain both 'target' and '%s' properties, export may be invalid.\n", GRAPH_SOURCE_DEST_VARIABLE_NAME);
+                    }
+                }
+            }
+            j["links"].push_back(j_e);
+        }
+    }
+}
+}  // namespace
+
+void JSONGraphWriter::saveAdjacencyLike(const std::string& filepath,
+    const std::shared_ptr<const detail::CUDAEnvironmentDirectedGraphBuffers>& directed_graph, cudaStream_t stream, bool pretty_print) {
+    // Init writer
+    nlohmann::ordered_json j;
+    toAdjancencyLike(j, directed_graph, stream);
+    // Perform output
+    std::ofstream out(filepath, std::ios::trunc | std::ios::binary);
+    if (!out.is_open()) {
+        THROW exception::InvalidFilePath("Unable to open file '%s' for writing, in JSONGraphWriter::saveAdjacencyLike()\n", filepath.c_str());
+    }
+    if (pretty_print) {
+        out << std::setw(4);
+    }
+    out << j;
+    out.close();
+}
+
+}  // namespace io
+}  // namespace flamegpu

--- a/src/flamegpu/model/ModelDescription.cpp
+++ b/src/flamegpu/model/ModelDescription.cpp
@@ -275,4 +275,9 @@ flamegpu::size_type ModelDescription::getLayersCount() const {
     return static_cast<flamegpu::size_type>(model->layers.size());
 }
 
+void ModelDescription::serialize(const std::string& path)
+{
+    //TODO
+}
+
 }  // namespace flamegpu


### PR DESCRIPTION
Closes #1353.

PR to add serialization of model objects. 

Initial limitations

 - No serialization of compile time functions. I.e. RTC functions only.
 - No idea what to do with host functions...

TODO List:

- [x] Create initial serialization classes
- [ ] Method of serializing 
- [ ] Serialization writer of model objects
- [ ] Serialization reader of model objects
- [ ] Serialization of Python function strings (as Python).
- [ ] Tests (scope to be defined)