### PR TITLE
Bugfix: Refactor constructGraph() parameter to const shared ptr

### DIFF
--- a/src/flamegpu/visualiser/EnvironmentGraphVis.cpp
+++ b/src/flamegpu/visualiser/EnvironmentGraphVis.cpp
@@ -34,7 +34,8 @@ EnvironmentGraphVisData::EnvironmentGraphVisData(std::shared_ptr <EnvironmentDir
         z_varName = "z";
     }
 }
-void EnvironmentGraphVisData::constructGraph(const std::shared_ptr<detail::CUDAEnvironmentDirectedGraphBuffers> &graph) {
+void EnvironmentGraphVisData::constructGraph(const std::shared_ptr<detail::CUDAEnvironmentDirectedGraphBuffers> &_graph) {
+    const std::shared_ptr<const detail::CUDAEnvironmentDirectedGraphBuffers> graph = _graph;
     // Can't construct prior to initialisation
     if (!graph->getVertexCount() && !graph->getEdgeCount())
         return;


### PR DESCRIPTION
Accessing the mutable graph here flags the graph as requiring a rebuild each step, greatly increasing the expense of visualising large graphs.

*Still chasing a different issue, this rebuild was changing what's stored in the src_dest map. It would appear if src_dest is flagged as updated after initial graph construction, src_dest map fails to be re-translated to index or similar.*