### PR TITLE
WIP: Visualisation metadata sharing with simulation.

### DIFF
--- a/include/flamegpu/runtime/environment/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/environment/HostEnvironment.cuh
@@ -18,6 +18,8 @@
 #include "flamegpu/runtime/environment/HostMacroProperty.cuh"
 #include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"
 #include "flamegpu/runtime/environment/HostEnvironmentDirectedGraph.cuh"
+#include "flamegpu/simulation/CUDASimulation.h"
+#include "flamegpu/visualiser/FLAMEGPU_Visualisation.h"
 
 namespace flamegpu {
 
@@ -244,15 +246,86 @@ std::vector<T> HostEnvironment::setPropertyArray(const std::string &name, const 
  */
 template<typename T>
 T HostEnvironment::getProperty(const std::string &name) const  {
-    return env_mgr->getProperty<T>(name);
+    if (name.length() && name[0] == '_') {
+        // Internal
+#ifdef FLAMEGPU_VISUALISATION
+        if (simulation.visInfo) {
+            if (name == "_ortho_zoom") {
+                return static_cast<T>(simulation.visInfo->orthoZoom);
+            } else if(name == "_ortho_enabled") {
+                return static_cast<T>(simulation.visInfo->isOrtho);
+            }
+            // @todo support vectors with GLM
+        } else {
+            THROW flamegpu::exception::UnknownInternalError("Visualisation info not ready.\n");
+        }
+        THROW flamegpu::exception::InvalidArgument("%s is not a valid internal environment property.", name.c_str());
+#else
+        THROW flamegpu::exception::InvalidArgument("_ prefixed environment properties are currently restricted to visualisation enabled runs.", name.c_str());
+#endif
+    } else {
+        return env_mgr->getProperty<T>(name);
+    }
 }
 template<typename T, flamegpu::size_type N>
 std::array<T, N> HostEnvironment::getProperty(const std::string &name) const  {
-    return env_mgr->getProperty<T, N>(name);
+    if (name.length() && name[0] == '_') {
+        // Internal
+#ifdef FLAMEGPU_VISUALISATION
+        if (simulation.visInfo) {
+            if (N == 3) {
+                if (name == "_view_pos") {
+                    return std::array<T, N>({
+                        static_cast<T>(simulation.visInfo->viewPos[0]),
+                        static_cast<T>(simulation.visInfo->viewPos[1]),
+                        static_cast<T>(simulation.visInfo->viewPos[2])
+                    });
+                } else if (name == "_view_dir") {
+                    return std::array<T, N>({
+                        static_cast<T>(simulation.visInfo->viewDir[0]),
+                        static_cast<T>(simulation.visInfo->viewDir[1]),
+                        static_cast<T>(simulation.visInfo->viewDir[2])
+                    });
+                }
+            } else {
+                THROW flamegpu::exception::InvalidArgument("Visualisation info arrays require length 3, %u != 3.", N);
+            }
+        } else {
+            THROW flamegpu::exception::UnknownInternalError("Visualisation info not ready.\n");
+        }
+        THROW flamegpu::exception::InvalidArgument("%s is not a valid internal environment property array.", name.c_str());
+#else
+        THROW flamegpu::exception::InvalidArgument("_ prefixed environment properties are currently restricted to visualisation enabled runs.", name.c_str());
+#endif
+    } else {
+        return env_mgr->getProperty<T, N>(name);
+    }
 }
 template<typename T, flamegpu::size_type N>
 T HostEnvironment::getProperty(const std::string &name, const flamegpu::size_type index) const  {
-    return env_mgr->getProperty<T, N>(name, index);
+    if (name.length() && name[0] == '_') {
+        // Internal
+#ifdef FLAMEGPU_VISUALISATION
+        if (simulation.visInfo) {
+            if (N == 3) {
+                if (name == "_view_pos") {
+                    return static_cast<T>(simulation.visInfo->viewPos[index]);
+                } else if (name == "_view_dir") {
+                    return static_cast<T>(simulation.visInfo->viewDir[index]);
+                }
+            } else {
+                THROW flamegpu::exception::InvalidArgument("Visualisation info arrays require length 3, %u != 3.", N);
+            }
+        } else {
+            THROW flamegpu::exception::UnknownInternalError("Visualisation info not ready.\n");
+        }
+        THROW flamegpu::exception::InvalidArgument("%s is not a valid internal environment property array.", name.c_str());
+#else
+        THROW flamegpu::exception::InvalidArgument("_ prefixed environment properties are currently restricted to visualisation enabled runs.", name.c_str());
+#endif     
+    } else {
+        return env_mgr->getProperty<T, N>(name, index);
+    }
 }
 #ifdef SWIG
 template<typename T>

--- a/include/flamegpu/runtime/environment/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/environment/HostEnvironment.cuh
@@ -19,7 +19,9 @@
 #include "flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cuh"
 #include "flamegpu/runtime/environment/HostEnvironmentDirectedGraph.cuh"
 #include "flamegpu/simulation/CUDASimulation.h"
+#ifdef FLAMEGPU_VISUALISATION
 #include "flamegpu/visualiser/FLAMEGPU_Visualisation.h"
+#endif
 
 namespace flamegpu {
 

--- a/include/flamegpu/runtime/environment/HostEnvironment.cuh
+++ b/include/flamegpu/runtime/environment/HostEnvironment.cuh
@@ -254,7 +254,7 @@ T HostEnvironment::getProperty(const std::string &name) const  {
         if (simulation.visInfo) {
             if (name == "_ortho_zoom") {
                 return static_cast<T>(simulation.visInfo->orthoZoom);
-            } else if(name == "_ortho_enabled") {
+            } else if (name == "_ortho_enabled") {
                 return static_cast<T>(simulation.visInfo->isOrtho);
             }
             // @todo support vectors with GLM
@@ -324,7 +324,7 @@ T HostEnvironment::getProperty(const std::string &name, const flamegpu::size_typ
         THROW flamegpu::exception::InvalidArgument("%s is not a valid internal environment property array.", name.c_str());
 #else
         THROW flamegpu::exception::InvalidArgument("_ prefixed environment properties are currently restricted to visualisation enabled runs.", name.c_str());
-#endif     
+#endif
     } else {
         return env_mgr->getProperty<T, N>(name, index);
     }

--- a/include/flamegpu/simulation/CUDASimulation.h
+++ b/include/flamegpu/simulation/CUDASimulation.h
@@ -36,7 +36,11 @@
 #endif
 
 namespace flamegpu {
-namespace detail {
+    namespace visualiser {
+        struct VisInfo;
+    }
+
+    namespace detail {
 class AbstractSimRunner;
 class CUDAAgent;
 class CUDAMessage;
@@ -59,6 +63,7 @@ class CUDASimulation : public Simulation {
      */
     friend class HostAgentAPI;
     friend class HostAPI;
+    friend class HostEnvironment;
     /**
      * Requires internal access to getCUDAAgent()
      */
@@ -432,7 +437,7 @@ class CUDASimulation : public Simulation {
      * Duration of the last call to exitFunctions() in seconds
      */
     double elapsedSecondsExitFunctions;
-   /**
+    /**
      * Duration of the last call to initialiseRTC() in seconds
      */
     double elapsedSecondsRTCInitialisation;
@@ -663,6 +668,10 @@ class CUDASimulation : public Simulation {
      * Empty if getVisualisation() hasn't been called
      */
     std::shared_ptr<visualiser::ModelVisData> visualisation;
+    /**
+     * Struct for data passed back from visualisation
+     */
+    std::shared_ptr<visualiser::VisInfo> visInfo;
 #endif
     /**
      * Returns false if any agent functions or agent function conditions are not RTC

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -24,9 +24,9 @@ class CUDASimulation;
 class FLAMEGPU_Visualisation;
 
 namespace visualiser {
-    struct VisInfo;
+struct VisInfo;
 
-    struct ModelVisData {
+struct ModelVisData {
     /**
      * This class is constructed by/with a CUDASimulation
      * Constructor will be clarified later, once requirements are clearer

--- a/include/flamegpu/visualiser/ModelVis.h
+++ b/include/flamegpu/visualiser/ModelVis.h
@@ -24,8 +24,9 @@ class CUDASimulation;
 class FLAMEGPU_Visualisation;
 
 namespace visualiser {
+    struct VisInfo;
 
-struct ModelVisData {
+    struct ModelVisData {
     /**
      * This class is constructed by/with a CUDASimulation
      * Constructor will be clarified later, once requirements are clearer
@@ -101,7 +102,7 @@ struct ModelVisData {
  */
 class ModelVis {
  public:
-    explicit ModelVis(std::shared_ptr<ModelVisData> data, bool _isSWIG);
+    explicit ModelVis(std::shared_ptr<ModelVisData> data, bool _isSWIG, std::shared_ptr<VisInfo> visInfo);
     /**
      * Default destructor behaviour
      * Defined explicitly, so that header include does not require including FLAMEGPU_Visualisation for std::unique_ptr destruction.
@@ -307,6 +308,7 @@ class ModelVis {
  private:
     const bool isSWIG;
     std::shared_ptr<ModelVisData> data;
+    std::shared_ptr<VisInfo> visInfo;
 };
 
 }  // namespace visualiser

--- a/src/flamegpu/io/JSONGraphReader.cpp
+++ b/src/flamegpu/io/JSONGraphReader.cpp
@@ -85,7 +85,7 @@ class JSONAdjacencyGraphSizeReader : public nlohmann::json_sax<nlohmann::json> {
  * It stores it's current position within the hierarchy with mode, lastKey and current_variable_array_index
  */
 class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
-    enum Mode{ Nop, Root, Nodes, Links, Node, Link, VariableArray };
+    enum Mode{ Nop, Root, Nodes, Links, Node, Link, VariableArray, Skip };
     std::stack<Mode> mode;
     std::string lastKey;
     std::string filename;
@@ -128,6 +128,8 @@ class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
     unsigned int last_source = ID_NOT_SET, last_target = ID_NOT_SET;
 
  public:
+     bool skip_nodes = false;
+     bool skip_links = false;
      JSONAdjacencyGraphReader(const std::string &_filename,
         const std::shared_ptr<detail::CUDAEnvironmentDirectedGraphBuffers>& _graph, cudaStream_t _stream)
         : filename(_filename)
@@ -136,6 +138,8 @@ class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
         , metagraph(_graph->getDescription()) { }
     template<typename T>
     bool processValue(const T val) {
+        if (mode.top() == Skip)
+            return true;
         Mode isArray = Nop;
         if (mode.top() == VariableArray) {
             isArray = mode.top();
@@ -312,8 +316,9 @@ class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
                 }
                 return true;
             }
+        } else if (mode.top() != Skip) {
+            THROW exception::JSONError("Unexpected string whilst parsing input file '%s', string properties are not supported.\n", filename.c_str());
         }
-        THROW exception::JSONError("Unexpected string whilst parsing input file '%s', string properties are not supported.\n", filename.c_str());
     }
     bool binary(binary_t&) {
         THROW exception::JSONError("Unexpected binary value whilst parsing input file '%s'.\n", filename.c_str());
@@ -322,9 +327,17 @@ class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
         if (mode.empty()) {
             mode.push(Root);
         } else if (mode.top() == Nodes) {
-            mode.push(Node);
+            if (skip_nodes) {
+                mode.push(Skip);
+            } else {
+                mode.push(Node);
+            }
         } else if (mode.top() == Links) {
-            mode.push(Link);
+            if (skip_links) {
+                mode.push(Skip);
+            } else {
+                mode.push(Link);
+            }
         } else {
             THROW exception::JSONError("Unexpected object start whilst parsing input file '%s'.\n", filename.c_str());
         }
@@ -360,7 +373,7 @@ class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
         if (mode.top() == VariableArray) {
             mode.pop();
             current_variable_array_index = 0;
-        } else {
+        } else if (mode.top() != Skip) {
             mode.pop();
             current_index = 0;
         }
@@ -389,8 +402,19 @@ void JSONGraphReader::loadAdjacencyLike(const std::string& filepath, const std::
     // Third reset the stream
     in.clear();
     in.seekg(0);
-    // Fourth parse the graph (and map string vertex IDs to integers)
+    // Fourth parse the graph nodes (and map string vertex IDs to integers)
     JSONAdjacencyGraphReader graphReader(filepath, directed_graph, stream);
+    graphReader.skip_nodes = false;
+    graphReader.skip_links = true;
+    if (!nlohmann::json::sax_parse(in, &graphReader)) {
+        THROW exception::JSONError("Reading graph from input file '%s' failed, in JSONGraphReader::loadAdjacencyLike()\n", filepath.c_str());
+    }
+    // Fifth reset the stream
+    in.clear();
+    in.seekg(0);
+    // sixth parse the graph links;
+    graphReader.skip_nodes = true;
+    graphReader.skip_links = false;
     if (!nlohmann::json::sax_parse(in, &graphReader)) {
         THROW exception::JSONError("Reading graph from input file '%s' failed, in JSONGraphReader::loadAdjacencyLike()\n", filepath.c_str());
     }

--- a/src/flamegpu/io/JSONGraphReader.cpp
+++ b/src/flamegpu/io/JSONGraphReader.cpp
@@ -319,6 +319,7 @@ class JSONAdjacencyGraphReader : public nlohmann::json_sax<nlohmann::json> {
         } else if (mode.top() != Skip) {
             THROW exception::JSONError("Unexpected string whilst parsing input file '%s', string properties are not supported.\n", filename.c_str());
         }
+        return true;
     }
     bool binary(binary_t&) {
         THROW exception::JSONError("Unexpected binary value whilst parsing input file '%s'.\n", filename.c_str());

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -1267,7 +1267,8 @@ void CUDASimulation::simulate() {
     if (visualisation) {
         visualisation->updateBuffers();
     }
-    visualiser::ModelVis mv(visualisation, isSWIG);
+    visInfo = visInfo ? visInfo : std::make_shared<visualiser::VisInfo>();
+    visualiser::ModelVis mv(visualisation, isSWIG, visInfo);
     #endif
 
     // Run the required number of simulation steps.
@@ -1514,7 +1515,8 @@ void CUDASimulation::applyConfig_derived() {
     // Handle console_mode
 #ifdef FLAMEGPU_VISUALISATION
     if (visualisation) {
-        visualiser::ModelVis mv(visualisation, isSWIG);
+        visInfo = visInfo ? visInfo : std::make_shared<visualiser::VisInfo>();
+        visualiser::ModelVis mv(visualisation, isSWIG, visInfo);
         if (getSimulationConfig().console_mode) {
             mv.deactivate();
         } else {
@@ -1758,7 +1760,8 @@ visualiser::ModelVis CUDASimulation::getVisualisation() {
             visualisation->hookVis(visualisation, directed_graph_map);
         }
     }
-    return visualiser::ModelVis(visualisation, isSWIG);
+    visInfo = visInfo ? visInfo : std::make_shared<visualiser::VisInfo>();
+    return visualiser::ModelVis(visualisation, isSWIG, visInfo);
 }
 #endif
 

--- a/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
+++ b/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
@@ -459,7 +459,6 @@ void CUDAEnvironmentDirectedGraphBuffers::syncDevice_async(detail::CUDAScatter& 
                 } else if (err_collision_range[1] > 0) {
                     THROW flamegpu::exception::UnknownInternalError("Graph contains invalid vertex IDs, %u vertices reported an ID that does not satisfy %u < ID < %u, in CUDAEnvironmentDirectedGraphBuffers::syncDevice_async()", err_collision_range[1], vertex_id_min, vertex_id_max);
                 }
-                printf("Built device vertex index map at: %p\n", d_vertex_index_map);
             }
             {  // Validate that edge source/dest pairs correspond to valid IDs
                 const auto& e_srcdest_b = edge_buffers.at(GRAPH_SOURCE_DEST_VARIABLE_NAME);

--- a/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
+++ b/src/flamegpu/simulation/detail/CUDAEnvironmentDirectedGraphBuffers.cu
@@ -459,6 +459,7 @@ void CUDAEnvironmentDirectedGraphBuffers::syncDevice_async(detail::CUDAScatter& 
                 } else if (err_collision_range[1] > 0) {
                     THROW flamegpu::exception::UnknownInternalError("Graph contains invalid vertex IDs, %u vertices reported an ID that does not satisfy %u < ID < %u, in CUDAEnvironmentDirectedGraphBuffers::syncDevice_async()", err_collision_range[1], vertex_id_min, vertex_id_max);
                 }
+                printf("Built device vertex index map at: %p\n", d_vertex_index_map);
             }
             {  // Validate that edge source/dest pairs correspond to valid IDs
                 const auto& e_srcdest_b = edge_buffers.at(GRAPH_SOURCE_DEST_VARIABLE_NAME);

--- a/src/flamegpu/visualiser/ModelVis.cpp
+++ b/src/flamegpu/visualiser/ModelVis.cpp
@@ -97,9 +97,19 @@ void ModelVisData::rebuildEnvGraph(const std::string &graph_name) {
     graphs.at(graph_name)->constructGraph(model.directed_graph_map.at(graph_name));
 }
 
-ModelVis::ModelVis(std::shared_ptr<ModelVisData> _data, bool _isSWIG)
+ModelVis::ModelVis(const std::shared_ptr<ModelVisData> _data, const bool _isSWIG, const std::shared_ptr<VisInfo> visInfo)
     : isSWIG(_isSWIG)
-    , data(std::move(_data)) { }
+    , data(std::move(_data))
+    , visInfo(std::move(visInfo)) {
+    // Init VisInfo from model config
+    // Somewhat redundant as this class may be created late
+    if (visInfo) {
+        visInfo->isOrtho = data->modelCfg.isOrtho;
+        visInfo->orthoZoom = data->modelCfg.orthoZoom;
+        memcpy(visInfo->viewPos, data->modelCfg.cameraLocation, sizeof(float) * 3);
+        memcpy(visInfo->viewDir, data->modelCfg.cameraTarget, sizeof(float) * 3);
+    }
+}
 
 void ModelVis::setAutoPalette(const Palette& palette) {
     data->autoPalette = std::make_shared<AutoPalette>(palette);
@@ -199,6 +209,7 @@ void ModelVis::activate() {
         }
         data->env_registered = false;
         data->registerEnvProperties();
+        data->visualiser->registerVisInfo(visInfo);
         data->visualiser->start();
     }
 }


### PR DESCRIPTION
*In development as part of CrisisTrack, interface needs review.*

In order for simulations to appropriately scale models, this feature passes back limited visualisation metadata (e.g. orthographic projection zoom value, and view position/direction). It would be possible to do this in shader, but allowing it to be handled at a model level enables more complex scaling behaviours to be represented.

Current implementation works, and will suffice for CrisisTrack however I'm regretting the decision to hide it inside the host environment interface, as it won't be consistent with device environment.

- [ ] Protect against race conditions (they seem unimportant in this context, worst case a single simulation step sees a junk value)
- [ ] Finalise/refactor interface
- [ ] Fix CI (the current error seems spurious at first glance)
 

Matching visualiser PR: https://github.com/FLAMEGPU/FLAMEGPU2-visualiser/pull/152