### PR TITLE
CI: Downgrade windows-2025 to windows-2022 for Visual Studio 17 2022

### DIFF
--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -33,7 +33,7 @@ jobs:
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
         python:
           - "3.10"
         config:

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -193,12 +193,12 @@ jobs:
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, and although we have a workaround in place 12.4+ is required for pyflamegpu in c++20.
           - cuda: "12.9.1"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           - cuda: "12.4.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
@@ -497,7 +497,7 @@ jobs:
           - cuda: "13.0.0"
             cuda_arch: "75-real;80-real;90-real;100-real;110-real;120-real;120-virtual"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           # Oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, and is required for pyflamegpu as c++20 due to compiler/stdlib errors
           - cuda: "12.4.0"
             cuda_arch: "50-real;60-real;70-real;80-real;90-real;90-virtual"

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -27,12 +27,12 @@ jobs:
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, and although we have a workaround in place 12.4+ is required for pyflamegpu in c++20.
           - cuda: "12.9.1"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           - cuda: "12.4.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -34,12 +34,12 @@ jobs:
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           # Newest and oldest CUDA 12.x we support. 12.4 is the oldest officially supported by MSVC >= 1940, and although we have a workaround in place 12.4+ is required for pyflamegpu in c++20.
           - cuda: "12.9.1"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"
-            os: windows-2025
+            os: windows-2022
           - cuda: "12.4.0"
             cuda_arch: "50"
             hostcxx: "Visual Studio 17 2022"


### PR DESCRIPTION
CI: Downgrade windows-2025 to windows-2022 for Visual Studio 17 2022 workflows in advance of 2025-05-04

See #1365