### PR TITLE
CI: Add CUDA 13.2 to relevant workflows

### DIFF
--- a/.github/scripts/install_cuda_windows.ps1
+++ b/.github/scripts/install_cuda_windows.ps1
@@ -63,6 +63,10 @@ $CUDA_KNOWN_URLS = @{
     "12.9.1" = "https://developer.download.nvidia.com/compute/cuda/12.9.1/network_installers/cuda_12.9.1_windows_network.exe";
     "13.0.0" = "https://developer.download.nvidia.com/compute/cuda/13.0.0/network_installers/cuda_13.0.0_windows_network.exe";
     "13.0.1" = "https://developer.download.nvidia.com/compute/cuda/13.0.1/network_installers/cuda_13.0.1_windows_network.exe";
+    "13.0.2" = "https://developer.download.nvidia.com/compute/cuda/13.0.2/network_installers/cuda_13.0.2_windows_network.exe";
+    "13.1.0" = "https://developer.download.nvidia.com/compute/cuda/13.1.0/network_installers/cuda_13.1.0_windows_network.exe";
+    "13.1.1" = "https://developer.download.nvidia.com/compute/cuda/13.1.1/network_installers/cuda_13.1.1_windows_network.exe";
+    "13.2.0" = "https://developer.download.nvidia.com/compute/cuda/13.2.0/network_installers/cuda_13.2.0_windows_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -42,6 +42,10 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           # CUDA 13
+          - cuda: "13.2"
+            cuda_arch: "75-real;120-real;120-virtual;"
+            hostcxx: gcc-14
+            os: ubuntu-24.04
           - cuda: "13.0"
             cuda_arch: "75-real;120-real;120-virtual;"
             hostcxx: gcc-13
@@ -190,6 +194,10 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           # Newest and oldest CUDA 13.x we support
+          - cuda: "13.2.0"
+            cuda_arch: "75"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -30,6 +30,10 @@ jobs:
       matrix:
         cudacxx:
           # CUDA 13
+          - cuda: "13.2"
+            cuda_arch: "75"
+            hostcxx: gcc-14
+            os: ubuntu-24.04
           - cuda: "13.0"
             cuda_arch: "75"
             hostcxx: gcc-13

--- a/.github/workflows/Windows-Tests.yml
+++ b/.github/workflows/Windows-Tests.yml
@@ -24,6 +24,10 @@ jobs:
         # CUDA_ARCH values are reduced compared to wheels due to CI memory issues while compiling the test suite.
         cudacxx:
           # CUDA 13
+          - cuda: "13.2.0"
+            cuda_arch: "75"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -31,6 +31,10 @@ jobs:
       matrix:
         cudacxx:
           # CUDA 13
+          - cuda: "13.2.0"
+            cuda_arch: "75"
+            hostcxx: "Visual Studio 17 2022"
+            os: windows-2022
           - cuda: "13.0.0"
             cuda_arch: "75"
             hostcxx: "Visual Studio 17 2022"

--- a/include/flamegpu/runtime/agent/HostAgentAPI.cuh
+++ b/include/flamegpu/runtime/agent/HostAgentAPI.cuh
@@ -992,10 +992,10 @@ void HostAgentAPI::sort_async(const std::string & variable1, Order order1, const
         // pair sort values
         if (order2 == Asc) {
             thrust::stable_sort_by_key(thrust::cuda::par.on(stream), thrust::device_ptr<Var2T>(keys2), thrust::device_ptr<Var2T>(keys2 + agentCount),
-            thrust::device_ptr<unsigned int>(vals), thrust::less<Var2T>());
+            thrust::device_ptr<unsigned int>(vals), std::less<>());
         } else {
             thrust::stable_sort_by_key(thrust::cuda::par.on(stream), thrust::device_ptr<Var2T>(keys2), thrust::device_ptr<Var2T>(keys2 + agentCount),
-            thrust::device_ptr<unsigned int>(vals), thrust::greater<Var2T>());
+            thrust::device_ptr<unsigned int>(vals), std::greater<>());
         }
         gpuErrchkLaunch();
         // sort keys1 based on this order
@@ -1006,10 +1006,10 @@ void HostAgentAPI::sort_async(const std::string & variable1, Order order1, const
         // pair sort
         if (order1 == Asc) {
             thrust::stable_sort_by_key(thrust::cuda::par.on(stream), thrust::device_ptr<Var1T>(keys1), thrust::device_ptr<Var1T>(keys1 + agentCount),
-            thrust::device_ptr<unsigned int>(vals), thrust::less<Var1T>());
+            thrust::device_ptr<unsigned int>(vals), std::less<>());
         } else {
             thrust::stable_sort_by_key(thrust::cuda::par.on(stream), thrust::device_ptr<Var1T>(keys1), thrust::device_ptr<Var1T>(keys1 + agentCount),
-            thrust::device_ptr<unsigned int>(vals), thrust::greater<Var1T>());
+            thrust::device_ptr<unsigned int>(vals), std::greater<>());
         }
         gpuErrchkLaunch();
     }


### PR DESCRIPTION
Adds CUDA 13.2 to relevant CI workflows

Includes changes to avoid thrust functions which were deprecated in Thrust 3.1, as CUDA 13.2 ships with a newer Thrust (13.1 may also hit this issue). 

Closes #1364