### PR TITLE
docs(DependencyNode): fix 'HostFunctionDescriotion' -> 'HostFunctionDescription'

### DIFF
--- a/include/flamegpu/model/DependencyNode.h
+++ b/include/flamegpu/model/DependencyNode.h
@@ -16,7 +16,7 @@ class DependencyNode {
     /**
      * Specifies that this agent function depends on the completion of all of the provided functions
      * @param dep The host functions, agent functions and submodels which this depends on
-     * @tparam A function description object (e.g. AgentFunctionDescription, HostFunctionDescriotion)
+     * @tparam A function description object (e.g. AgentFunctionDescription, HostFunctionDescription)
      */
     template<typename A>
     void dependsOn(A& dep) {
@@ -27,8 +27,8 @@ class DependencyNode {
      * Specifies that this agent function depends on the completion of all of the provided functions
      * @param dep The host functions, agent functions and submodels which this depends on
      * @param dependencyList More arguments suitable for dep
-     * @tparam A function description object (e.g. AgentFunctionDescription, HostFunctionDescriotion)
-     * @tparam Args function description object (e.g. AgentFunctionDescription, HostFunctionDescriotion)
+     * @tparam A function description object (e.g. AgentFunctionDescription, HostFunctionDescription)
+     * @tparam Args function description object (e.g. AgentFunctionDescription, HostFunctionDescription)
      */
     template<typename A, typename...Args>
     void dependsOn(A& dep, Args&...dependencyList) {


### PR DESCRIPTION
## Summary

Three \`@tparam\` doxygen comments in \`include/flamegpu/model/DependencyNode.h\` referenced \`HostFunctionDescriotion\` (extra 'io'). The real class is \`HostFunctionDescription\`.

Refs #1208

## Testing

Doxygen-only change; no code paths touched.