### PR TITLE
Fix cudaErrorInvalidConfiguration on empty population sort in HostAgentAPI

### DIFF
--- a/include/flamegpu/runtime/agent/HostAgentAPI.cuh
+++ b/include/flamegpu/runtime/agent/HostAgentAPI.cuh
@@ -587,6 +587,7 @@ void HostAgentAPI::meanStandardDeviation_async(const std::string& variable, std:
     const auto agentCount = agent.getStateSize(stateName);
     if (agentCount == 0) {
         result = std::make_pair(0.0, 0.0);
+        return;
     }
     // Calculate mean (We could make this more efficient by leaving sum in device mem?)
     typename sum_input_t<InT>::result_t sum_result;
@@ -879,6 +880,9 @@ void HostAgentAPI::sort_async(const std::string & variable, Order order, int beg
     }
     // We will use scan_flag agent_death/message_output here so resize
     const unsigned int agentCount = agent.getStateSize(stateName);
+    if (agentCount == 0) {
+        return;
+    }
     void *var_ptr = agent.getStateVariablePtr(stateName, variable);
     const size_t total_variable_buffer_size = sizeof(VarT) * agentCount;
     const unsigned int fake_num_agent = static_cast<unsigned int>(total_variable_buffer_size/sizeof(unsigned int)) +1;
@@ -958,6 +962,9 @@ void HostAgentAPI::sort_async(const std::string & variable1, Order order1, const
         }
     }
     const unsigned int agentCount = agent.getStateSize(stateName);
+    if (agentCount == 0) {
+        return;
+    }
     // Fill array with var1 keys
     {
         // Resize

--- a/src/flamegpu/runtime/agent/HostAgentAPI.cu
+++ b/src/flamegpu/runtime/agent/HostAgentAPI.cu
@@ -30,6 +30,9 @@ __global__ void initToThreadIndex(unsigned int *output, unsigned int threadCount
 }
 
 void HostAgentAPI::fillTIDArray_async(unsigned int *buffer, unsigned int threadCount, cudaStream_t stream) {
+    if (threadCount == 0) {
+        return;
+    }
     initToThreadIndex<<<(threadCount/512)+1, 512, 0, stream>>>(buffer, threadCount);
     gpuErrchkLaunch();
 }
@@ -42,6 +45,9 @@ __global__ void sortBuffer_kernel(char *dest, char*src, unsigned int *position, 
 }
 
 void HostAgentAPI::sortBuffer_async(void *dest, void*src, unsigned int *position, size_t typeLen, unsigned int threadCount, cudaStream_t stream) {
+    if (threadCount == 0) {
+        return;
+    }
     sortBuffer_kernel<<<(threadCount/512)+1, 512, 0, stream >>>(static_cast<char*>(dest), static_cast<char*>(src), position, typeLen, threadCount);
     gpuErrchkLaunch();
 }

--- a/src/flamegpu/simulation/detail/CUDAScatter.cu
+++ b/src/flamegpu/simulation/detail/CUDAScatter.cu
@@ -144,6 +144,9 @@ unsigned int CUDAScatter::scatter(
     const unsigned int out_index_offset,
     const bool invert_scan_flag,
     const unsigned int scatter_all_count) {
+    if (itemCount == 0) {
+        return scatter_all_count;
+    }
     int blockSize = 0;  // The launch configurator returned block size
     int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
     int gridSize = 0;  // The actual grid size needed, based on input size
@@ -200,6 +203,9 @@ void CUDAScatter::scatterPosition_async(
     unsigned int *position,
     const std::vector<ScatterData> &sd,
     unsigned int itemCount) {
+    if (itemCount == 0) {
+        return;
+    }
     int blockSize = 0;  // The launch configurator returned block size
     int minGridSize = 0;  // The minimum grid size needed to achieve the // maximum occupancy for a full device // launch
     int gridSize = 0;  // The actual grid size needed, based on input size
@@ -372,6 +378,9 @@ void CUDAScatter::scatterNewAgents(
     const size_t totalAgentSize,
     const unsigned int inCount,
     const unsigned int outIndexOffset) {
+    if (inCount == 0 || sd.empty()) {
+        return;
+    }
     // 1 thread per agent variable
     const unsigned int threadCount = static_cast<unsigned int>(sd.size()) * inCount;
     int blockSize = 0;  // The launch configurator returned block size
@@ -436,7 +445,7 @@ void CUDAScatter::broadcastInit_async(
     unsigned int inCount,
     unsigned int outIndexOffset) {
     // No variables means no work to do
-    if (vars.size() == 0) return;
+    if (vars.empty() || inCount == 0) return;
     // 1 thread per agent variable
     const unsigned int threadCount = static_cast<unsigned int>(vars.size()) * inCount;
     int blockSize = 0;  // The launch configurator returned block size
@@ -494,6 +503,7 @@ void CUDAScatter::broadcastInit_async(
     void * const d_newBuff,
     unsigned int inCount,
     unsigned int outIndexOffset) {
+    if (vars.empty() || inCount == 0) return;
     // 1 thread per agent variable
     const unsigned int threadCount = static_cast<unsigned int>(vars.size()) * inCount;
     int blockSize = 0;  // The launch configurator returned block size

--- a/tests/python/runtime/agent/test_host_agent_sort.py
+++ b/tests/python/runtime/agent/test_host_agent_sort.py
@@ -188,4 +188,48 @@ class HostAgentSort(TestCase):
             # Store prev
             prev = f
 
+    def test_empty_sort_float(self):
+        # Define model
+        model = pyflamegpu.ModelDescription("model")
+        agent = model.newAgent("agent")
+        agent.newVariableFloat("float")
+        agent.newVariableFloat("spare")
+        func_asc = sort_ascending_float()
+        func_desc = sort_descending_float()
+        model.newLayer().addHostFunction(func_asc)
+        model.newLayer().addHostFunction(func_desc)
 
+        # Init empty pop
+        pop = pyflamegpu.AgentVector(agent, 0)
+
+        # Setup Model
+        cudaSimulation = pyflamegpu.CUDASimulation(model)
+        cudaSimulation.setPopulationData(pop)
+        # Execute step fn - should be no-op with no exception
+        cudaSimulation.step()
+        # Check results
+        cudaSimulation.getPopulationData(pop)
+        assert pop.size() == 0
+
+    def test_empty_sort_int(self):
+        # Define model
+        model = pyflamegpu.ModelDescription("model")
+        agent = model.newAgent("agent")
+        agent.newVariableInt("int")
+        agent.newVariableInt("spare")
+        func_asc = sort_ascending_int()
+        func_desc = sort_descending_int()
+        model.newLayer().addHostFunction(func_asc)
+        model.newLayer().addHostFunction(func_desc)
+
+        # Init empty pop
+        pop = pyflamegpu.AgentVector(agent, 0)
+
+        # Setup Model
+        cudaSimulation = pyflamegpu.CUDASimulation(model)
+        cudaSimulation.setPopulationData(pop)
+        # Execute step fn - should be no-op with no exception
+        cudaSimulation.step()
+        # Check results
+        cudaSimulation.getPopulationData(pop)
+        assert pop.size() == 0

--- a/tests/test_cases/runtime/agent/host_reduction/test_mean_standarddeviation.cu
+++ b/tests/test_cases/runtime/agent/host_reduction/test_mean_standarddeviation.cu
@@ -51,6 +51,13 @@ TEST_F(HostReductionTest, MeanStandardDeviation_uint32_t) {
     EXPECT_DOUBLE_EQ(sum / 101.0, mean_sd_out.first);
     EXPECT_FLOAT_EQ(29.15476f, static_cast<float>(mean_sd_out.second));  // Test value calculated with excel
 }
+TEST_F(HostReductionTest, MeanStandardDeviation_empty) {
+    ms->model.addStepFunction(step_sum_float);
+    ms->population->resize(0);
+    ms->run();
+    EXPECT_DOUBLE_EQ(0.0, mean_sd_out.first);
+    EXPECT_DOUBLE_EQ(0.0, mean_sd_out.second);
+}
 
 }  // namespace test_host_reductions
 }  // namespace flamegpu

--- a/tests/test_cases/runtime/agent/test_host_agent_sort.cu
+++ b/tests/test_cases/runtime/agent/test_host_agent_sort.cu
@@ -450,5 +450,70 @@ TEST(HostAgentSort, 2x_DescAsc_int) {
         prev = f1 + (999-f2);
     }
 }
+
+FLAMEGPU_STEP_FUNCTION(sort_exceptions_empty) {
+    EXPECT_THROW(FLAMEGPU->agent("agent").sort<float>("invalid_var", HostAgentAPI::Asc), exception::InvalidAgentVar);
+    EXPECT_THROW(FLAMEGPU->agent("agent").sort<int>("float", HostAgentAPI::Asc), exception::InvalidVarType);
+    EXPECT_THROW(FLAMEGPU->agent("agent").sort<float, float>("float1", HostAgentAPI::Asc, "invalid_var", HostAgentAPI::Asc), exception::InvalidAgentVar);
+    EXPECT_THROW(FLAMEGPU->agent("agent").sort<float, int>("float1", HostAgentAPI::Asc, "float2", HostAgentAPI::Asc), exception::InvalidVarType);
+    EXPECT_THROW(FLAMEGPU->agent("agent").sort<int>("array_var", HostAgentAPI::Asc), exception::UnsupportedVarType);
+}
+
+TEST(HostAgentSort, EmptyPopulation_1D) {
+    ModelDescription model("model");
+    AgentDescription agent = model.newAgent("agent");
+    agent.newVariable<float>("float");
+    agent.newVariable<int>("int");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort_ascending_float);
+    model.newLayer().addHostFunction(sort_descending_float);
+    model.newLayer().addHostFunction(sort_ascending_int);
+    model.newLayer().addHostFunction(sort_descending_int);
+
+    AgentVector pop(agent, 0);
+    CUDASimulation cudaSimulation(model);
+    cudaSimulation.setPopulationData(pop);
+    EXPECT_NO_THROW(cudaSimulation.step());
+    cudaSimulation.getPopulationData(pop);
+    EXPECT_EQ(0u, pop.size());
+}
+
+TEST(HostAgentSort, EmptyPopulation_2D) {
+    ModelDescription model("model");
+    AgentDescription agent = model.newAgent("agent");
+    agent.newVariable<float>("float1");
+    agent.newVariable<float>("float2");
+    agent.newVariable<int>("int1");
+    agent.newVariable<int>("int2");
+    agent.newVariable<int>("spare");
+    model.newLayer().addHostFunction(sort2x_ascending_float);
+    model.newLayer().addHostFunction(sort2x_descending_float);
+    model.newLayer().addHostFunction(sort2x_ascending_int);
+    model.newLayer().addHostFunction(sort2x_descending_int);
+    model.newLayer().addHostFunction(sort2x_ascdesc_int);
+    model.newLayer().addHostFunction(sort2x_descasc_int);
+
+    AgentVector pop(agent, 0);
+    CUDASimulation cudaSimulation(model);
+    cudaSimulation.setPopulationData(pop);
+    EXPECT_NO_THROW(cudaSimulation.step());
+    cudaSimulation.getPopulationData(pop);
+    EXPECT_EQ(0u, pop.size());
+}
+
+TEST(HostAgentSort, EmptyPopulation_Exceptions) {
+    ModelDescription model("model");
+    AgentDescription agent = model.newAgent("agent");
+    agent.newVariable<float>("float");
+    agent.newVariable<float>("float1");
+    agent.newVariable<float>("float2");
+    agent.newVariable<int, 4>("array_var");
+    model.newLayer().addHostFunction(sort_exceptions_empty);
+
+    AgentVector pop(agent, 0);
+    CUDASimulation cudaSimulation(model);
+    cudaSimulation.setPopulationData(pop);
+    EXPECT_NO_THROW(cudaSimulation.step());
+}
 }  // namespace test_host_agent_sort
 }  // namespace flamegpu


### PR DESCRIPTION
## Summary
Fixes `cudaErrorInvalidConfiguration` CUDA exception when calling `HostAgentAPI::sort()` (or Python `HostAgentAPI.sortInt()` / `sortFloat()`) on an empty agent population (0 agents in state), and hardens `CUDAScatter` kernel launch routines against zero-item configurations.

## Problem
When `HostAgentAPI::sort()` is called on an agent population with 0 agents in the current state, FLAME GPU 2 attempts to perform CUB radix sorting and launches `CUDAScatter::scatterPosition_async()`. In `scatterPosition_async()`, calculating `gridSize = (itemCount + blockSize - 1) / blockSize` evaluates to 0 when `itemCount == 0`. Launching `scatter_position_generic <<<0, blockSize, 0, stream>>>` triggers `cudaErrorInvalidConfiguration` (CUDA error 9), raising a `FLAMEGPURuntimeException (CUDAError)`.

In addition:
- In `HostAgentAPI::meanStandardDeviation_async()`, when `agentCount == 0`, `result` was initialized to `(0.0, 0.0)` but the function failed to return, proceeding to divide by `agentCount == 0` (`NaN`).
- In `CUDAScatter.cu`, several scatter and broadcast routines lacked zero-item guards, unlike `scatterAll` and `pbm_reorder`.

## Root Cause
1. `HostAgentAPI::sort_async()` (both 1D and 2D overloads) did not check if `agentCount == 0` before executing scan buffer allocations, device memory copies, CUB radix sorting, and scatter operations.
2. `CUDAScatter::scatterPosition_async()` did not guard against `itemCount == 0`, leading to a zero-grid-dimension kernel launch configuration.
3. `HostAgentAPI::meanStandardDeviation_async()` omitted a `return;` statement within the `if (agentCount == 0)` block.

## Solution
1. In `include/flamegpu/runtime/agent/HostAgentAPI.cuh`:
   - Added an early return in both 1D and 2D `HostAgentAPI::sort_async()` overloads after validating variable existence and types when `agentCount == 0`.
   - Added the missing `return;` statement in `HostAgentAPI::meanStandardDeviation_async()` when `agentCount == 0`.
2. In `src/flamegpu/runtime/agent/HostAgentAPI.cu`:
   - Guarded `fillTIDArray_async()` and `sortBuffer_async()` against `threadCount == 0`.
3. In `src/flamegpu/simulation/detail/CUDAScatter.cu`:
   - Added early-return guards for `itemCount == 0` / `inCount == 0` across `scatter()`, `scatterPosition_async()`, `scatterNewAgents()`, and `broadcastInit_async()`.
4. In `tests/`:
   - Added C++ unit tests in `test_host_agent_sort.cu` (`EmptyPopulation_1D`, `EmptyPopulation_2D`, `EmptyPopulation_Exceptions`).
   - Added C++ unit test in `test_mean_standarddeviation.cu` (`MeanStandardDeviation_empty`).
   - Added Python unit tests in `test_host_agent_sort.py` (`test_empty_sort_float`, `test_empty_sort_int`).

## Testing
- `cpplint` executed across all modified C++/CUDA files with `CPPLINT.cfg` — 0 errors reported.
- Python test syntax checked with `py_compile` — passed cleanly.
- Added comprehensive unit tests covering:
  - 1D host agent sort with 0 agents (Ascending and Descending, float and int).
  - 2D host agent sort with 0 agents (all ordering combinations).
  - Invalid variable / unsupported type error checking on empty populations.
  - Empty population mean and standard deviation reductions.
  - Python bindings for empty host agent sorting.

## Validation
- Linting: `cpplint` passed on all modified files (`HostAgentAPI.cuh`, `HostAgentAPI.cu`, `CUDAScatter.cu`, `test_host_agent_sort.cu`, `test_mean_standarddeviation.cu`).
- Style: Conforms to Google C++ Style with project line length limit (240 chars).

## Impact
- Correctness: Calling `sort` on an empty agent population now gracefully completes as a safe no-op without CUDA invalid configuration errors, as requested in #1362.
- Robustness: Kernel launch helpers in `CUDAScatter` are safeguarded against zero-grid dimensions.
- API Compatibility: Fully preserved.

## Related Issue
Fixes #1362