### PR TITLE
Fix docstrings, remove dead typedef, and fix getElapsedTimeStep off-by-one

### DIFF
--- a/include/flamegpu/simulation/CUDASimulation.h
+++ b/include/flamegpu/simulation/CUDASimulation.h
@@ -332,26 +332,26 @@ class CUDASimulation : public Simulation {
     visualiser::ModelVis getVisualisation();
 #endif
    /**
-     * Get the duration of the last time RTC was iniitliased 
-     * @return elapsed time of last simulation call in seconds.
+     * Get the duration of the last RTC initialisation in seconds.
+     * @return elapsed time of last RTC initialisation in seconds.
      */
     double getElapsedTimeRTCInitialisation() const;
 
     /**
-     * Get the duration of the last call to simulate() in seconds. 
-     * @return elapsed time of last simulation call in seconds.
+     * Get the duration of the last call to simulate() in seconds.
+     * @return elapsed time of last simulate() call in seconds.
      */
     double getElapsedTimeSimulation() const;
 
     /**
-     * Get the duration of the last call to initFunctions() in seconds. 
-     * @return elapsed time of last simulation call in seconds.
+     * Get the duration of the last call to initFunctions() in seconds.
+     * @return elapsed time of last initFunctions() call in seconds.
      */
     double getElapsedTimeInitFunctions() const;
 
     /**
-     * Get the duration of the last call to stepFunctions() in seconds. 
-     * @return elapsed time of last simulation call in seconds.
+     * Get the duration of the last call to exitFunctions() in seconds.
+     * @return elapsed time of last exitFunctions() call in seconds.
      */
     double getElapsedTimeExitFunctions() const;
 

--- a/include/flamegpu/simulation/detail/CUDAAgent.h
+++ b/include/flamegpu/simulation/detail/CUDAAgent.h
@@ -45,10 +45,6 @@ class CUDAAgent : public AgentInterface {
      typedef std::map<const std::string, std::unique_ptr<jitify2::KernelData>> CUDARTCFuncMap;
      typedef std::map<const std::string, std::shared_ptr<detail::curve::CurveRTCHost>> CUDARTCHeaderMap;
     /**
-     * Element type of CUDARTCFuncMap
-     */
-    typedef std::pair<const std::string, std::unique_ptr<jitify2::KernelData>> CUDARTCFuncMapPair;
-    /**
      * Normal constructor
      * @param description Agent description of the agent
      * @param _cudaSimulation Parent CUDASimulation of the agent

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -1862,7 +1862,7 @@ std::vector<double> CUDASimulation::getElapsedTimeSteps() const {
 }
 
 double CUDASimulation::getElapsedTimeStep(unsigned int step) const {
-    if (step > this->elapsedSecondsPerStep.size()) {
+    if (step >= this->elapsedSecondsPerStep.size()) {
         THROW exception::OutOfBoundsException("getElapsedTimeStep out of bounds.\n");
     }
     return this->elapsedSecondsPerStep.at(step);

--- a/src/flamegpu/simulation/CUDASimulation.cu
+++ b/src/flamegpu/simulation/CUDASimulation.cu
@@ -1856,7 +1856,7 @@ double CUDASimulation::getElapsedTimeRTCInitialisation() const {
 }
 
 std::vector<double> CUDASimulation::getElapsedTimeSteps() const {
-    // returns a copy of the timing vector, to avoid mutabililty issues. This should not be called in a performacne intensive part of the application.
+    // returns a copy of the timing vector, to avoid mutability issues. This should not be called in a performance intensive part of the application.
     std::vector<double> rtn = this->elapsedSecondsPerStep;
     return rtn;
 }

--- a/tests/test_cases/simulation/test_cuda_simulation.cu
+++ b/tests/test_cases/simulation/test_cuda_simulation.cu
@@ -530,8 +530,9 @@ TEST(TestCUDASimulation, stepElapsedTime) {
 
     // Try getting the timer before running simulate, which should be empty.
     EXPECT_EQ(c.getElapsedTimeSteps().size(), 0.);
-    // Or gettng an individual element which is out of boudns should have some kind of error.
-    // EXPECT_GT(c.getElapsedTimeStep(1), 0.); // @todo
+    // Getting an individual element which is out of bounds should throw.
+    EXPECT_THROW(c.getElapsedTimeStep(0), exception::OutOfBoundsException);
+    EXPECT_THROW(c.getElapsedTimeStep(1), exception::OutOfBoundsException);
 
     // Call simulate to run 10 steps, which should take some length of time
     const unsigned int STEPS = 10u;
@@ -544,6 +545,8 @@ TEST(TestCUDASimulation, stepElapsedTime) {
         EXPECT_GT(stepTimes.at(step), 0.);
         EXPECT_GT(c.getElapsedTimeStep(step), 0.);
     }
+    // Accessing step == STEPS should throw (off-by-one boundary).
+    EXPECT_THROW(c.getElapsedTimeStep(STEPS), exception::OutOfBoundsException);
 }
 
 /* const char* rtc_empty_agent_func = R"###(


### PR DESCRIPTION
## Summary

Code quality PR addressing 3 open issues: incorrect/copy-pasted docstrings, an unused typedef, and a newly discovered off-by-one bounds check bug in `getElapsedTimeStep()`.

Each fix is in a distinct commit for ease of review.

## Changes

### Commit 1: Fix `getElapsedTime*` docstrings (Fixes #1392)

The docstring for `CUDASimulation::getElapsedTimeExitFunctions` incorrectly referred to `stepFunctions()` instead of `exitFunctions()`. As suggested in the issue, a wider pass was done over all `getElapsedTime*` docstrings, revealing:

- **`getElapsedTimeRTCInitialisation`**: Typo "iniitliased" corrected to "initialised".
- **All four methods**: Copy-pasted `@return elapsed time of last simulation call in seconds.` corrected to method-specific descriptions.
- **`getElapsedTimeSteps` comment**: Typos "mutabililty" and "performacne" corrected.

### Commit 2: Remove unused `CUDARTCFuncMapPair` typedef (Fixes #1378)

`CUDAAgent::CUDARTCFuncMapPair` was defined as a typedef but never referenced anywhere in the codebase. The docstring described it as "Element type of CUDARTCFuncMap" but `CUDARTCFuncMap` is a `std::map`, not using this pair type. Removed the typedef and its docstring.

### Commit 3: Fix `getElapsedTimeStep` off-by-one bounds check (Fixes #1411)

`CUDASimulation::getElapsedTimeStep(unsigned int step)` used `step > size()` instead of `step >= size()`. When `step == size()` (e.g., requesting step 10 after a 10-step simulation where valid indices are 0–9):
- The guard condition `10 > 10` evaluated to `false`, passing the check
- `.at(10)` then threw `std::out_of_range` instead of `exception::OutOfBoundsException`

Also enables the previously commented-out `// @todo` out-of-bounds test and adds a boundary regression test.

## Files Changed

| File | Change |
|------|--------|
| `include/flamegpu/simulation/CUDASimulation.h` | Fix docstrings for all `getElapsedTime*` methods |
| `include/flamegpu/simulation/detail/CUDAAgent.h` | Remove unused `CUDARTCFuncMapPair` typedef |
| `src/flamegpu/simulation/CUDASimulation.cu` | Fix off-by-one bounds check and comment typos |
| `tests/test_cases/simulation/test_cuda_simulation.cu` | Enable + extend out-of-bounds regression tests |

## Validation

- `cpplint` passed on all 4 modified files with 0 errors.
- All changes are backwards-compatible; no API changes.

Fixes #1392, #1378, #1411